### PR TITLE
Pin local TCP Port and Encrypt overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV API_VER ${version}
 # {"status":200,"content":null,"message":"naas is running.","request_id":"2bef8456-c25b-4884-9250-9a0eeb4b4654"}
 HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
     CMD [ $APP_ENVIRONMENT = "staging" ] && staging="-staging"; \
-    curl -k -f -H "Host: naas${staging}.localhost" https://127.0.0.1:5000/healthcheck
+    curl -k -f -H "Host: naas${staging}.localhost" https://127.0.0.1:443/healthcheck
 
 # When this container is run, it executes our code.
 CMD ["gunicorn", "-c", "gunicorn.py", "naas.app:app"]

--- a/README.md
+++ b/README.md
@@ -86,23 +86,28 @@ To launch a more customized deployment, please follow these steps:
 2. Join that host to (or initialize) a [Docker Swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/)
 3. Clone the repo down from Github
     * `git clone https://github.com/lykinsbd/naas.git`
-4. To use a custom Redis instance, ensure that the following environment variables are set in your launch environment:
-    1. `REDIS_HOST`: A string of the IP/Hostname of the redis server you wish to use
-    2. `REDIS_PORT`: An integer of the TCP Port number of the redis server you wish to use
-    3. `REDIS_PASSWORD`: A string of the password for the redis server you wish to use (if authentication is needed)
-5. To use a custom local or global TCP port for the API front end, set the following environment variables in your launch environment:
-    1. `NAAS_LOCAL_PORT`: What TCP port do you want NAAS to utilize _inside_ the container (Default 443)
-    2. `NAAS_GLOBAL_PORT`: What TCP port do you want to expose NAAS on outside the applicaiton (Default 8443)
-6. Execute the following to launch NAAS:
+4. You have the following options available for customization:
+    1. To use a custom Redis instance, ensure that the following environment variables are set in your launch environment:
+        1. `REDIS_HOST`: A string of the IP/Hostname of the redis server you wish to use (Default: redis)
+        2. `REDIS_PORT`: An integer of the TCP Port number of the redis server you wish to use (Default: 6379)
+        3. `REDIS_PASSWORD`: A string of the password for the redis server you wish to use (if authentication is needed)
+    2. To use a custom global/published TCP port for the API front end, 
+        set the following environment variable in your launch environment:
+        1. `NAAS_GLOBAL_PORT`: An integer of the TCP port you want to expose NAAS on to the outside world (Default: 8443)
+    3. To customize the number of NAAS worker containers or worker processes in a container, 
+        set the following environment variables in your launch environment:
+        1. `NAAS_WORKER_REPLICAS`: An integer of the number of Worker container replicas you want (Default: 2)
+        2. `NAAS_WORKER_PROCESSES`: An integer of the number of Worker processes you want in each Worker container (Default: 100)
+5. Execute the following to launch NAAS:
     1. With a custom Redis server as defined in step 4:
         * ```docker stack deploy --compose-file docker-compose.yml naas```
     2. With the default Redis container:
         * ```docker stack deploy --compose-file docker-compose.yml --compose-file docker-compose-redis.yml naas```
-7. Validate that your service has deployed:
+6. Validate that your service has deployed:
     * ```docker stack ps naas```
     * You should see 3 containers in the `Running` state if you used a custom Redis server
         (otherwise you'll see 4 as shown in the Standard Deployment):
         1. naas_api.1
         2. naas_worker.1
         3. naas_worker.2
-8. Perform an HTTP GET to `https://<your_server_ip>:<NAAS_GLOBAL_PORT>/healthcheck` and look for a 200 response.
+7. Perform an HTTP GET to `https://<your_server_ip>:<NAAS_GLOBAL_PORT>/healthcheck` and look for a 200 response.

--- a/docker-compose-redis.yml
+++ b/docker-compose-redis.yml
@@ -1,7 +1,10 @@
 version: "3.7"
+
 services:
   redis:
     image: "redis:5-alpine"
     command: >-
       --requirepass ${REDIS_PASSWORD:-mah_redis_pw}
       --port ${REDIS_PORT:-6379}
+    networks:
+      - "naas_overlay"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: "3.7"
+
 services:
+
   api:
-    image: "lykinsbd/naas:latest"
+    image: "lykinsbd/naas:0.4.0"
     deploy:
       mode: "replicated"
       replicas: 1
@@ -25,7 +27,7 @@ services:
       - "naas_overlay"
 
   worker:
-    image: "lykinsbd/naas:latest"
+    image: "lykinsbd/naas:0.4.0"
     deploy:
       mode: "replicated"
       replicas: ${NAAS_WORKER_REPLICAS:-2}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       restart_policy:
         condition: any
     ports:
-      - target: "{$NAAS_LOCAL_PORT:-443}"
-        published: "{$NAAS_GLOBAL_PORT:-8443}:"
+      - target: "${NAAS_LOCAL_PORT:-443}"
+        published: "${NAAS_GLOBAL_PORT:-8443}"
         protocol: "tcp"
         mode: "ingress"
     logging:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       restart_policy:
         condition: any
     ports:
-      - target: "${NAAS_LOCAL_PORT:-443}"
+      - target: 443
         published: "${NAAS_GLOBAL_PORT:-8443}"
         protocol: "tcp"
         mode: "ingress"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,3 +36,13 @@ services:
       ${NAAS_WORKER_PROCESSES:-100}
     healthcheck:
       disable: true
+    networks:
+      - "naas_overlay"
+
+networks:
+
+  naas_overlay:
+    driver: overlay
+    driver_opts:
+      encrypted: 1
+    name: "naas_overlay"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       - "REDIS_PORT=${REDIS_PORT:-6379}"
       - "REDIS_PASSWORD=${REDIS_PASSWORD:-mah_redis_pw}"
       - "APP_ENVIRONMENT=dev"
+    networks:
+      - "naas_overlay"
+
   worker:
     image: "lykinsbd/naas:latest"
     deploy:

--- a/docs/naas.yaml
+++ b/docs/naas.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.3.0
+  version: 0.4.0
   title: NAAS - Netmiko As A Service
   contact:
     email: lykinsbd@gmail.com

--- a/gunicorn.py
+++ b/gunicorn.py
@@ -3,7 +3,7 @@ from os import environ
 
 
 # Setup basic attributes of our web-server
-bind = f"0.0.0.0:{environ.get('NAAS_LOCAL_PORT', '443')}"
+bind = f"0.0.0.0:443"
 chdir = "/app"
 workers = 8
 worker_class = "gthread"

--- a/naas/__init__.py
+++ b/naas/__init__.py
@@ -5,4 +5,4 @@
 Initialization module for NAAS. Sets version
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
This update addresses three primary issues:

1. Pins the local (internal) port that Gunicorn is listening on to TCP/443, this removes some un-needed complexity and issues.
2. Pins the container versions in the compose file to ensure consistent behavior
3. Compose file now instantiates a unique, encrypted, overlay for inter-container communication.