### PR TITLE
fixes #11 where 500 error was returned if no auth provided

### DIFF
--- a/naas/library/decorators.py
+++ b/naas/library/decorators.py
@@ -17,6 +17,7 @@ def valid_post(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
         v = validation.Validate()
+        v.has_auth()
         v.is_json()
         v.is_ip_addr(request.json["ip"], "ip")
         v.is_command_set()

--- a/naas/library/validation.py
+++ b/naas/library/validation.py
@@ -6,7 +6,7 @@ import ipaddress
 
 from flask import current_app, request
 from uuid import UUID
-from werkzeug.exceptions import UnprocessableEntity, BadRequest
+from werkzeug.exceptions import BadRequest, Unauthorized, UnprocessableEntity
 
 
 class Validate(object):
@@ -72,6 +72,14 @@ class Validate(object):
         if not isinstance(request.json["device_type"], str):
             self._error("device_type must be a string", code=422)
 
+    def has_auth(self):
+        if (
+            not request.authorization
+            or request.authorization.username is None
+            or request.authorization.password is None
+        ):
+            self._error("you must authenticate with HTTP Basic authentication to use this resource", code=401)
+
     @staticmethod
     def _error(message, code=400):
         current_app.logger.error(message)
@@ -79,6 +87,8 @@ class Validate(object):
             raise BadRequest
         elif code == 422:
             raise UnprocessableEntity
+        elif code == 401:
+            raise Unauthorized
 
 
 class ValidateHTTP(object):

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -5,7 +5,7 @@ from flask import current_app, request
 from naas import __version__
 from naas.library.auth import Credentials, job_unlocker
 from naas.library.validation import Validate
-from werkzeug.exceptions import Unauthorized, Forbidden
+from werkzeug.exceptions import Forbidden
 
 
 class GetResults(Resource):
@@ -20,11 +20,10 @@ class GetResults(Resource):
         # Validate our job_id
         v = Validate()
         v.is_uuid(uuid=job_id)
+        v.has_auth()
 
         # Ensure this user can access the job...
         auth = request.authorization
-        if auth.username is None:
-            raise Unauthorized
 
         # Create a credentials object
         creds = Credentials(username=auth.username, password=auth.password)

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -7,7 +7,7 @@ from naas.library.auth import Credentials, job_locker, tacacs_auth_lockout
 from naas.library.errorhandlers import DuplicateRequestID
 from naas.library.decorators import valid_post
 from naas.library.netmiko_lib import netmiko_send_command
-from werkzeug.exceptions import Forbidden, Unauthorized
+from werkzeug.exceptions import Forbidden
 
 
 class SendCommand(Resource):
@@ -34,8 +34,6 @@ class SendCommand(Resource):
 
         # Grab creds off the basic_auth header
         auth = request.authorization
-        if auth.username is None:
-            raise Unauthorized
 
         # Check if this user is locked out or not
         if tacacs_auth_lockout(username=auth.username):

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -7,7 +7,7 @@ from naas.library.auth import Credentials, job_locker, tacacs_auth_lockout
 from naas.library.errorhandlers import DuplicateRequestID
 from naas.library.decorators import valid_post
 from naas.library.netmiko_lib import netmiko_send_config
-from werkzeug.exceptions import Forbidden, Unauthorized
+from werkzeug.exceptions import Forbidden
 
 
 class SendConfig(Resource):
@@ -36,8 +36,6 @@ class SendConfig(Resource):
 
         # Grab creds off the basic_auth header
         auth = request.authorization
-        if auth.username is None:
-            raise Unauthorized
 
         # Check if this user is locked out or not
         if tacacs_auth_lockout(username=auth.username):


### PR DESCRIPTION
I was attempting to log the username prior to validating authentication
 existed.  Now all validation of authentication existence is in the proper
 decorator/validator.