### PR TITLE
test: increase coverage to 74.48% (Phase 2 complete)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 50
+fail_under = 70
 show_missing = true
 skip_covered = false
 precision = 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,14 @@ def app():
             mock_job.get_id.return_value = "test-job-id"
             mock_job.meta = {}
             mock_queue.return_value.enqueue.return_value = mock_job
-            mock_queue.return_value.fetch_job.return_value = mock_job
+
+            # Make fetch_job return None for new job IDs (not duplicates)
+            def fetch_job_side_effect(job_id):
+                if job_id == "test-job-id":
+                    return mock_job
+                return None
+
+            mock_queue.return_value.fetch_job.side_effect = fetch_job_side_effect
 
             from naas.app import app as flask_app
 

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -1,0 +1,234 @@
+"""Unit tests for send_command and send_config resources."""
+
+from base64 import b64encode
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naas.library.auth import Credentials
+
+
+class TestSendCommand:
+    """Test send_command resource."""
+
+    def test_send_command_get(self, client):
+        """Test GET returns base response."""
+        response = client.get("/send_command")
+        assert response.status_code == 200
+        assert "app" in response.json
+        assert response.json["app"] == "naas"
+
+    def test_send_command_post_success(self, app, client):
+        """Test POST enqueues job successfully."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        # Mock tacacs_auth_lockout to avoid Redis connection in validation
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/send_command",
+                json={
+                    "ip": "192.168.1.1",
+                    "port": 22,
+                    "device_type": "cisco_ios",
+                    "commands": ["show version"],
+                    "delay_factor": 1,
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        if response.status_code != 202:
+            print(f"Response: {response.get_json()}")
+        assert response.status_code == 202
+
+    def test_send_command_post_no_auth(self, client):
+        """Test POST without auth returns 401."""
+        response = client.post(
+            "/send_command",
+            json={
+                "ip": "192.168.1.1",
+                "commands": ["show version"],
+            },
+        )
+
+        assert response.status_code == 401
+
+
+class TestSendConfig:
+    """Test send_config resource."""
+
+    def test_send_config_get(self, client):
+        """Test GET returns base response."""
+        response = client.get("/send_config")
+        assert response.status_code == 200
+        assert "app" in response.json
+        assert response.json["app"] == "naas"
+
+    def test_send_config_post_success(self, app, client):
+        """Test POST enqueues job successfully."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        # Mock tacacs_auth_lockout to avoid Redis connection in validation
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/send_config",
+                json={
+                    "ip": "192.168.1.1",
+                    "port": 22,
+                    "device_type": "cisco_ios",
+                    "commands": ["interface gi0/1", "description test"],
+                    "delay_factor": 1,
+                    "save_config": False,
+                    "commit": False,
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+        assert "job_id" in response.json
+        assert response.headers["X-Request-ID"] == response.json["job_id"]
+
+    def test_send_config_post_no_auth(self, client):
+        """Test POST without auth returns 401."""
+        response = client.post(
+            "/send_config",
+            json={
+                "ip": "192.168.1.1",
+                "commands": ["interface gi0/1"],
+            },
+        )
+
+        assert response.status_code == 401
+
+
+class TestGetResults:
+    """Test get_results resource."""
+
+    @pytest.mark.xfail(reason="Need to fix app context for salted_hash in tests")
+    def test_get_results_not_found(self, app, client):
+        """Test GET with non-existent job returns 404."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        response = client.get(
+            "/send_command/00000000-0000-0000-0000-000000000000",
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 404
+        assert response.json["status"] == "not_found"
+
+    @pytest.mark.xfail(reason="Need to fix app context for salted_hash in tests")
+    def test_get_results_queued(self, app, client):
+        """Test GET with queued job returns status."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        job_id = "11111111-1111-1111-1111-111111111111"
+
+        # Setup job with hash
+        job = MagicMock()
+        job.meta = {}
+        job.get_status = lambda: "queued"
+
+        # Generate hash within app context
+        with app.app_context():
+            creds = Credentials("testuser", "testpass")
+            job.meta["hash"] = creds.salted_hash()
+
+        # Update fetch_job to return this job for our UUID
+        original_fetch = app.config["q"].fetch_job.side_effect
+
+        def new_fetch(job_id_param):
+            if job_id_param == job_id:
+                return job
+            return original_fetch(job_id_param) if original_fetch else None
+
+        app.config["q"].fetch_job.side_effect = new_fetch
+
+        response = client.get(
+            f"/send_command/{job_id}",
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json["status"] == "queued"
+        assert response.json["results"] is None
+
+    @pytest.mark.xfail(reason="Need to fix app context for salted_hash in tests")
+    def test_get_results_finished(self, app, client):
+        """Test GET with finished job returns results."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        job_id = "22222222-2222-2222-2222-222222222222"
+
+        # Setup job with hash and results
+        job = MagicMock()
+        job.meta = {}
+        job.get_status = lambda: "finished"
+        job.result = ("command output", None)
+
+        # Generate hash within app context
+        with app.app_context():
+            creds = Credentials("testuser", "testpass")
+            job.meta["hash"] = creds.salted_hash()
+
+        # Update fetch_job to return this job for our UUID
+        original_fetch = app.config["q"].fetch_job.side_effect
+
+        def new_fetch(job_id_param):
+            if job_id_param == job_id:
+                return job
+            return original_fetch(job_id_param) if original_fetch else None
+
+        app.config["q"].fetch_job.side_effect = new_fetch
+
+        response = client.get(
+            f"/send_command/{job_id}",
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 200
+        assert response.json["status"] == "finished"
+        assert response.json["results"] == "command output"
+        assert response.json["error"] is None
+
+    def test_get_results_no_auth(self, client):
+        """Test GET without auth returns 401."""
+        response = client.get("/send_command/00000000-0000-0000-0000-000000000000")
+        assert response.status_code == 401
+
+    def test_get_results_wrong_user(self, app, client):
+        """Test GET with wrong user returns 403."""
+        auth = b64encode(b"wronguser:wrongpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        job_id = "33333333-3333-3333-3333-333333333333"
+
+        # Setup job with different user's hash
+        job = MagicMock()
+        job.meta = {}
+
+        # Generate hash within app context for different user
+        with app.app_context():
+            creds = Credentials("testuser", "testpass")
+            job.meta["hash"] = creds.salted_hash()
+
+        # Update fetch_job to return this job for our UUID
+        original_fetch = app.config["q"].fetch_job.side_effect
+
+        def new_fetch(job_id_param):
+            if job_id_param == job_id:
+                return job
+            return original_fetch(job_id_param) if original_fetch else None
+
+        app.config["q"].fetch_job.side_effect = new_fetch
+
+        response = client.get(
+            f"/send_command/{job_id}",
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 403


### PR DESCRIPTION
## Overview
Phase 2 of test coverage improvements - exceeded 70% target, reaching **74.48% coverage** (+17.01% from 57.47%).

## Changes

### Auth Tests (97% coverage)
- Add tests for  (success, wrong hash, no hash, exceptions)
- Add tests for  (with salt, from Redis)
- Merge duplicate TestCredentials classes

### Resource Tests (100% coverage for send_command/send_config)
- Add tests for send_command GET and POST endpoints
- Add tests for send_config GET and POST endpoints
- Add tests for authentication and authorization
- Add placeholder tests for get_results (marked xfail for future work)

### Infrastructure Improvements
- Fix conftest fetch_job to return None for new job IDs (prevents duplicate job errors)
- Mock tacacs_auth_lockout to avoid Redis connection issues in tests
- Update coverage threshold from 50% to 70%

## Coverage Progress
**Overall**: 57.47% → 74.48% (+17.01%)
**Tests Added**: 17 new tests (14 passing, 3 xfailed)

### Module Coverage Improvements
- `naas/library/auth.py`: 68% → **97%** ✨
- `naas/library/decorators.py`: 31% → **93%** ✨
- `naas/library/validation.py`: 91% → **96%** ✨
- `naas/resources/send_command.py`: 52% → **100%** 🎯
- `naas/resources/send_config.py`: 52% → **100%** 🎯
- `naas/resources/get_results.py`: 28% → 53%

## Testing
```bash
pytest tests/unit --cov=naas --cov-report=term-missing
# 56 passed, 3 xfailed, 74.48% coverage
```

## Related
- Part of #47 (Achieve 100% test coverage)
- Part of v1.0 milestone
- Follows PR #48 (Phase 1 coverage)