### PR TITLE
test: increase coverage to 78.62% (Phase 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 75
 show_missing = true
 skip_covered = false
 precision = 2


### PR DESCRIPTION
## Overview
Phase 3 of test coverage improvements - reached **78.62% coverage** (+3.68% from 74.94%), approaching 80%!

## Changes

### Fixed xfailed Tests
- Resolved all 3 xfailed get_results tests from Phase 2
- Simplified approach by mocking  instead of managing app context
- All tests now passing with no xfails

### Get_results Tests (97% coverage)
- Test job not found (404 response)
- Test queued job status
- Test finished job with results
- Test missing authentication (401)
- Test wrong user access (403)

### Edge Case Tests
- Add test for custom X-Request-ID header handling
- Test decorator path when request ID is provided vs generated

## Coverage Progress
**Overall**: 74.94% → 78.62% (+3.68%)
**Tests**: 63 → 63 passing (fixed 3 xfailed)
**Threshold**: 70% → 75%

### Module Coverage Improvements
- `naas/resources/get_results.py`: 53% → **97%** 🎯
- `naas/library/decorators.py`: 93% → **100%** 🎯

### Current Module Status
**100% Coverage** ✨:
- auth.py
- app.py  
- decorators.py
- errorhandlers.py
- healthcheck.py
- send_command.py
- send_config.py

**High Coverage** (>90%):
- get_results.py: 97%
- validation.py: 96%
- config.py: 93%

## Testing
```bash
pytest tests/unit --cov=naas --cov-report=term-missing
# 63 passed, 0 xfailed, 78.62% coverage
```

## Related
- Part of #47 (Achieve 100% test coverage)
- Part of v1.0 milestone
- Follows PR #50 (Phase 2 coverage)