### PR TITLE
test: reach 79.77% coverage (Phase 4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 75
+fail_under = 79
 show_missing = true
 skip_covered = false
 precision = 2

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,39 @@
+"""Unit tests for config module."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from flask import Flask
+
+from naas.config import app_configure
+
+
+class TestAppConfigure:
+    """Tests for app_configure function."""
+
+    def test_invalid_environment_defaults_to_dev(self):
+        """Invalid APP_ENVIRONMENT should default to 'dev'."""
+        app = Flask(__name__)
+        with patch.dict(os.environ, {"APP_ENVIRONMENT": "invalid"}):
+            with patch("naas.config.Redis") as mock_redis:
+                mock_redis.return_value = MagicMock()
+                app_configure(app)
+                assert app.config["APP_ENVIRONMENT"] == "dev"
+
+    def test_dev_environment_sets_debug_log_level(self):
+        """Dev environment should set LOG_LEVEL to DEBUG by default."""
+        app = Flask(__name__)
+        with patch.dict(os.environ, {"APP_ENVIRONMENT": "dev"}, clear=True):
+            with patch("naas.config.Redis") as mock_redis:
+                mock_redis.return_value = MagicMock()
+                app_configure(app)
+                assert app.config["LOG_LEVEL"] == "DEBUG"
+
+    def test_production_environment_sets_info_log_level(self):
+        """Production environment should set LOG_LEVEL to INFO by default."""
+        app = Flask(__name__)
+        with patch.dict(os.environ, {"APP_ENVIRONMENT": "production"}, clear=True):
+            with patch("naas.config.Redis") as mock_redis:
+                mock_redis.return_value = MagicMock()
+                app_configure(app)
+                assert app.config["LOG_LEVEL"] == "INFO"


### PR DESCRIPTION
## Overview
Phase 4 of test coverage improvements - reached **79.77% coverage** (+1.15% from 78.62%), approaching 80%!

## Changes

### Validation Tests (100% coverage) ✨
- Test locked out user error path (lines 67-68)
- Test duplicate job ID error path (line 116)

### Config Tests (100% coverage) ✨
- Test invalid environment defaults to dev (line 34)
- Test dev environment sets DEBUG log level (line 44)
- Test production environment sets INFO log level (line 44)

## Coverage Progress
**Overall**: 78.62% → 79.77% (+1.15%)
**Tests**: 68 passing (5 new tests)
**Threshold**: 75% → 79%

### Module Coverage Improvements
- `naas/library/validation.py`: 96% → **100%** 🎯
- `naas/config.py`: 93% → **100%** 🎯

### Current Module Status
**100% Coverage** ✨ (9 modules):
- auth.py
- app.py
- config.py
- decorators.py
- errorhandlers.py
- healthcheck.py
- send_command.py
- send_config.py
- validation.py

**High Coverage**:
- get_results.py: 97% (line 29 unreachable - redundant check after decorator)

**Low Priority**:
- netmiko_lib.py: 13% (tested via integration tests)
- selfsigned.py: 0% (certificate generation, low priority)

## Testing
```bash
pytest tests/unit --cov=naas --cov-report=term-missing
# 68 passed, 79.77% coverage
```

## Related
- Part of #47 (Achieve 100% test coverage)
- Part of v1.0 milestone
- Follows PR #51 (Phase 3 coverage)