### PR TITLE
chore: bump version to 1.0.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.0.0a2"
+version = "1.0.0b1"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
First beta release for v1.0.

After merge, CI will automatically:
- Build changelog with towncrier (keeps fragments)
- Create git tag `v1.0.0b1`
- Create GitHub pre-release with beta warning

This tests our new release workflow!