### PR TITLE
feat(api): add pagination for job history with GET /v1/jobs endpoint

### DIFF
--- a/changes/87.feature.md
+++ b/changes/87.feature.md
@@ -1,0 +1,1 @@
+Add pagination for job history with GET /v1/jobs endpoint

--- a/naas/app.py
+++ b/naas/app.py
@@ -16,6 +16,7 @@ from naas.config import app_configure
 from naas.library.errorhandlers import api_error_generator
 from naas.resources.get_results import GetResults
 from naas.resources.healthcheck import HealthCheck
+from naas.resources.list_jobs import ListJobs
 from naas.resources.send_command import SendCommand
 from naas.resources.send_config import SendConfig
 
@@ -39,3 +40,4 @@ api.add_resource(HealthCheck, "/", "/healthcheck")
 api.add_resource(SendCommand, "/send_command")
 api.add_resource(SendConfig, "/send_config")
 api.add_resource(GetResults, "/send_command/<string:job_id>", "/send_config/<string:job_id>")
+api.add_resource(ListJobs, "/v1/jobs")

--- a/naas/resources/list_jobs.py
+++ b/naas/resources/list_jobs.py
@@ -1,0 +1,112 @@
+# API Resources
+
+from flask import current_app, request
+from flask_restful import Resource
+from rq.job import Job
+from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
+
+from naas import __base_response__
+from naas.library.validation import Validate
+
+
+class ListJobs(Resource):
+    @staticmethod
+    def get():
+        """
+        List jobs with pagination and filtering.
+        Query parameters:
+        - page: Page number (default: 1)
+        - per_page: Results per page (default: 20, max: 100)
+        - status: Filter by status (finished, failed, started, queued)
+        :return: Dict with jobs list and pagination info
+        """
+        # Validate auth
+        v = Validate()
+        v.has_auth()
+
+        # Parse query parameters
+        page = request.args.get("page", 1, type=int)
+        per_page = request.args.get("per_page", 20, type=int)
+        status_filter = request.args.get("status", type=str)
+
+        # Validate parameters
+        if page < 1:
+            page = 1
+        if per_page < 1 or per_page > 100:
+            per_page = 20
+
+        # Get queue and registries
+        q = current_app.config["q"]
+        redis_conn = current_app.config["redis"]
+
+        # Collect job IDs based on status filter
+        job_ids = []
+        total_count = 0
+
+        if status_filter == "finished":
+            registry = FinishedJobRegistry(queue=q)
+            total_count = registry.count
+            start = (page - 1) * per_page
+            end = start + per_page - 1
+            job_ids = registry.get_job_ids(start=start, end=end)
+        elif status_filter == "failed":
+            registry = FailedJobRegistry(queue=q)
+            total_count = registry.count
+            start = (page - 1) * per_page
+            end = start + per_page - 1
+            job_ids = registry.get_job_ids(start=start, end=end)
+        elif status_filter == "started":
+            registry = StartedJobRegistry(queue=q)
+            total_count = registry.count
+            start = (page - 1) * per_page
+            end = start + per_page - 1
+            job_ids = registry.get_job_ids(start=start, end=end)
+        elif status_filter == "queued":
+            total_count = len(q)
+            start = (page - 1) * per_page
+            end = start + per_page
+            job_ids = q.get_job_ids(offset=start, length=per_page)
+        else:
+            # No filter - get all jobs from all registries
+            finished_reg = FinishedJobRegistry(queue=q)
+            failed_reg = FailedJobRegistry(queue=q)
+            started_reg = StartedJobRegistry(queue=q)
+
+            all_job_ids = (
+                finished_reg.get_job_ids() + failed_reg.get_job_ids() + started_reg.get_job_ids() + q.get_job_ids()
+            )
+            total_count = len(all_job_ids)
+            start = (page - 1) * per_page
+            end = start + per_page
+            job_ids = all_job_ids[start:end]
+
+        # Fetch job details
+        jobs = []
+        for job_id in job_ids:
+            job = Job.fetch(job_id, connection=redis_conn)
+            if job:
+                jobs.append(
+                    {
+                        "job_id": job.id,
+                        "status": job.get_status(),
+                        "created_at": job.created_at.isoformat() if job.created_at else None,
+                        "ended_at": job.ended_at.isoformat() if job.ended_at else None,
+                    }
+                )
+
+        # Calculate pagination
+        total_pages = (total_count + per_page - 1) // per_page if total_count > 0 else 0
+
+        # Build response
+        r_dict = {
+            "jobs": jobs,
+            "pagination": {
+                "page": page,
+                "per_page": per_page,
+                "total": total_count,
+                "pages": total_pages,
+            },
+        }
+        r_dict.update(__base_response__)
+
+        return r_dict

--- a/tests/unit/test_list_jobs.py
+++ b/tests/unit/test_list_jobs.py
@@ -1,0 +1,237 @@
+"""Unit tests for list_jobs resource."""
+
+from base64 import b64encode
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from rq.job import Job
+
+
+class TestListJobs:
+    """Test list_jobs resource."""
+
+    def test_list_jobs_no_auth(self, client):
+        """Test GET without auth returns 401."""
+        response = client.get("/v1/jobs")
+        assert response.status_code == 401
+
+    def test_list_jobs_default_pagination(self, app, client):
+        """Test GET with default pagination parameters."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        # Mock registries
+        with (
+            patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_finished,
+            patch("naas.resources.list_jobs.FailedJobRegistry") as mock_failed,
+            patch("naas.resources.list_jobs.StartedJobRegistry") as mock_started,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            # Setup mock registries
+            mock_finished_inst = MagicMock()
+            mock_finished_inst.get_job_ids.return_value = ["job1", "job2"]
+            mock_finished.return_value = mock_finished_inst
+
+            mock_failed_inst = MagicMock()
+            mock_failed_inst.get_job_ids.return_value = []
+            mock_failed.return_value = mock_failed_inst
+
+            mock_started_inst = MagicMock()
+            mock_started_inst.get_job_ids.return_value = []
+            mock_started.return_value = mock_started_inst
+
+            # Mock queue
+            app.config["q"].get_job_ids = MagicMock(return_value=[])
+
+            # Mock job fetch
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job1"
+            mock_job.get_status.return_value = "finished"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = datetime(2026, 2, 23, 12, 0, 5)
+            mock_job_fetch.return_value = mock_job
+
+            response = client.get("/v1/jobs", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert "jobs" in data
+        assert "pagination" in data
+        assert data["pagination"]["page"] == 1
+        assert data["pagination"]["per_page"] == 20
+
+    def test_list_jobs_with_status_filter(self, app, client):
+        """Test GET with status filter."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_finished,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            # Setup mock registry
+            mock_finished_inst = MagicMock()
+            mock_finished_inst.count = 5
+            mock_finished_inst.get_job_ids.return_value = ["job1"]
+            mock_finished.return_value = mock_finished_inst
+
+            # Mock job fetch
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job1"
+            mock_job.get_status.return_value = "finished"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = datetime(2026, 2, 23, 12, 0, 5)
+            mock_job_fetch.return_value = mock_job
+
+            response = client.get("/v1/jobs?status=finished", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["total"] == 5
+
+    def test_list_jobs_custom_pagination(self, app, client):
+        """Test GET with custom page and per_page."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_finished,
+            patch("naas.resources.list_jobs.FailedJobRegistry") as mock_failed,
+            patch("naas.resources.list_jobs.StartedJobRegistry") as mock_started,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            # Setup mock registries
+            mock_finished_inst = MagicMock()
+            mock_finished_inst.get_job_ids.return_value = []
+            mock_finished.return_value = mock_finished_inst
+
+            mock_failed_inst = MagicMock()
+            mock_failed_inst.get_job_ids.return_value = []
+            mock_failed.return_value = mock_failed_inst
+
+            mock_started_inst = MagicMock()
+            mock_started_inst.get_job_ids.return_value = []
+            mock_started.return_value = mock_started_inst
+
+            # Mock queue
+            app.config["q"].get_job_ids = MagicMock(return_value=[])
+
+            mock_job_fetch.return_value = None
+
+            response = client.get("/v1/jobs?page=2&per_page=10", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["page"] == 2
+        assert data["pagination"]["per_page"] == 10
+
+    def test_list_jobs_invalid_pagination(self, app, client):
+        """Test GET with invalid pagination parameters defaults correctly."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_finished,
+            patch("naas.resources.list_jobs.FailedJobRegistry") as mock_failed,
+            patch("naas.resources.list_jobs.StartedJobRegistry") as mock_started,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            # Setup mock registries
+            mock_finished_inst = MagicMock()
+            mock_finished_inst.get_job_ids.return_value = []
+            mock_finished.return_value = mock_finished_inst
+
+            mock_failed_inst = MagicMock()
+            mock_failed_inst.get_job_ids.return_value = []
+            mock_failed.return_value = mock_failed_inst
+
+            mock_started_inst = MagicMock()
+            mock_started_inst.get_job_ids.return_value = []
+            mock_started.return_value = mock_started_inst
+
+            # Mock queue
+            app.config["q"].get_job_ids = MagicMock(return_value=[])
+
+            mock_job_fetch.return_value = None
+
+            response = client.get("/v1/jobs?page=0&per_page=200", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["page"] == 1  # Invalid page 0 defaults to 1
+        assert data["pagination"]["per_page"] == 20  # Invalid per_page 200 defaults to 20
+
+    def test_list_jobs_failed_status(self, app, client):
+        """Test GET with failed status filter."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.FailedJobRegistry") as mock_failed,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            # Setup mock registry
+            mock_failed_inst = MagicMock()
+            mock_failed_inst.count = 3
+            mock_failed_inst.get_job_ids.return_value = ["job1"]
+            mock_failed.return_value = mock_failed_inst
+
+            # Mock job fetch
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job1"
+            mock_job.get_status.return_value = "failed"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = datetime(2026, 2, 23, 12, 0, 5)
+            mock_job_fetch.return_value = mock_job
+
+            response = client.get("/v1/jobs?status=failed", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["total"] == 3
+
+    def test_list_jobs_started_status(self, app, client):
+        """Test GET with started status filter."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.StartedJobRegistry") as mock_started,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            # Setup mock registry
+            mock_started_inst = MagicMock()
+            mock_started_inst.count = 2
+            mock_started_inst.get_job_ids.return_value = ["job1"]
+            mock_started.return_value = mock_started_inst
+
+            # Mock job fetch
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job1"
+            mock_job.get_status.return_value = "started"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = None
+            mock_job_fetch.return_value = mock_job
+
+            response = client.get("/v1/jobs?status=started", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["total"] == 2
+
+    def test_list_jobs_queued_status(self, app, client):
+        """Test GET with queued status filter."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch:
+            # Mock queue
+            app.config["q"].__len__ = MagicMock(return_value=4)
+            app.config["q"].get_job_ids = MagicMock(return_value=["job1"])
+
+            # Mock job fetch
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job1"
+            mock_job.get_status.return_value = "queued"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = None
+            mock_job_fetch.return_value = mock_job
+
+            response = client.get("/v1/jobs?status=queued", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["total"] == 4


### PR DESCRIPTION
## Summary

Implements pagination for job history as described in #87.

## Implementation

**New Endpoint:** `GET /v1/jobs`

**Query Parameters:**
- `page` - Page number (default: 1)
- `per_page` - Results per page (default: 20, max: 100)
- `status` - Filter by status: `finished`, `failed`, `started`, `queued` (optional)

**Features:**
- Uses RQ registries for efficient job retrieval
- Supports filtering by job status
- Returns pagination metadata (page, per_page, total, pages)
- Validates and sanitizes pagination parameters

## Response Format

```json
{
  "jobs": [
    {
      "job_id": "abc123",
      "status": "finished",
      "created_at": "2026-02-23T12:00:00",
      "ended_at": "2026-02-23T12:00:05"
    }
  ],
  "pagination": {
    "page": 1,
    "per_page": 20,
    "total": 150,
    "pages": 8
  },
  "app": "naas",
  "version": "1.1.0a1"
}
```

## Testing

- ✅ 8 comprehensive unit tests with 100% coverage
- ✅ Tests for all status filters (finished, failed, started, queued)
- ✅ Tests for pagination edge cases (invalid page/per_page)
- ✅ Tests for authentication
- ✅ All existing tests still pass

## Code Quality

- ✅ All pre-commit hooks pass (ruff, mypy, etc.)
- ✅ 100% test coverage maintained
- ✅ Follows conventional commit format
- ✅ Changelog fragment added

Closes #87