### PR TITLE
docs: update guidance for documentation PRs to target main

### DIFF
--- a/.kiro/agents/naas-dev-prompt.md
+++ b/.kiro/agents/naas-dev-prompt.md
@@ -146,7 +146,7 @@ Need to make a change?
   │    └─→ Branch from release/1.0, target release/1.0
   │
   └─ Documentation-only change?
-       └─→ Can branch from develop OR main (if urgent)
+       └─→ Branch from main, target main (required for Read the Docs)
 ```
 
 **ALWAYS ASK:** "What's the correct base branch for this work?"
@@ -200,6 +200,7 @@ chore(deps): upgrade netmiko to 4.6.0
 
 - **ONLY target these branches:** `develop`, `main`, or `release/X.Y`
 - **NEVER target feature branches** - PRs must go to protected branches
+- **Documentation PRs target `main`** - Required for Read the Docs integration
 - Feature branches merge to develop, not to other feature branches
 - Hotfix branches merge to release/X.Y, then main, then develop
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,14 +103,14 @@ NAAS uses a **Git Flow-inspired** branching model with long-lived release branch
 
 ### Short-lived Feature Branches
 
-Branch off `develop` using these prefixes:
+Branch off `develop` using these prefixes (except `docs/` which branches from `main`):
 
-- `feature/` - New features
-- `fix/` - Bug fixes
-- `docs/` - Documentation changes
-- `test/` - Test additions or modifications
-- `chore/` - Maintenance (dependencies, config, tooling)
-- `refactor/` - Code refactoring without behavior changes
+- `feature/` - New features (from develop)
+- `fix/` - Bug fixes (from develop)
+- `docs/` - Documentation changes (from **main** - required for Read the Docs)
+- `test/` - Test additions or modifications (from develop)
+- `chore/` - Maintenance (dependencies, config, tooling) (from develop)
+- `refactor/` - Code refactoring without behavior changes (from develop)
 
 ### Short-lived Hotfix Branches
 
@@ -161,6 +161,21 @@ git commit -m "feat: add API versioning support"
 
 # Create PR targeting develop
 gh pr create --base develop --title "Add API versioning"
+```
+
+#### Documentation Changes
+
+```bash
+# Documentation changes target main (for Read the Docs)
+git checkout main
+git pull
+git checkout -b docs/update-api-guide
+
+# Update docs and commit
+git commit -m "docs: update API usage guide"
+
+# Create PR targeting main
+gh pr create --base main --title "Update API usage guide"
 ```
 
 #### Bug Fix in Development


### PR DESCRIPTION
## Summary

Updates documentation workflow guidance to clarify that documentation PRs must target `main` instead of `develop`.

## Changes

**CONTRIBUTING.md:**
- Updated branch prefix guidance to specify `docs/` branches from `main`
- Added documentation workflow example showing main as target
- Clarified Read the Docs requirement

**Agent Config (.kiro/agents/naas-dev-prompt.md):**
- Updated decision tree: "Documentation-only change? → Branch from main, target main"
- Added note in PR Target Branch section about docs PRs targeting main

## Rationale

Read the Docs requires configuration files (`.readthedocs.yaml`, `mkdocs.yml`) and documentation content to be in the default branch (`main`) to:
- Enable automatic builds
- Configure version management properly
- Build docs for all branches/tags from the main branch config

This is different from code changes which target `develop`.

## Related

- Complements PR #111 (MkDocs setup targeting main)
- Updates guidance from #76 implementation