### PR TITLE
docs: require PR review for all merges to main

### DIFF
--- a/.kiro/agents/naas-dev-prompt.md
+++ b/.kiro/agents/naas-dev-prompt.md
@@ -200,9 +200,11 @@ chore(deps): upgrade netmiko to 4.6.0
 
 - **ONLY target these branches:** `develop`, `main`, or `release/X.Y`
 - **NEVER target feature branches** - PRs must go to protected branches
+- **ALL merges to `main` require PR review** - Including release/hotfix branches
 - **Documentation PRs target `main`** - Required for Read the Docs integration
 - Feature branches merge to develop, not to other feature branches
-- Hotfix branches merge to release/X.Y, then main, then develop
+- Hotfix branches: PR to release/X.Y, then PR to main, then PR to develop
+- Release branches: PR to main (never direct merge)
 
 **Merge Strategy:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,32 +118,38 @@ Branch off the appropriate `release/X.Y` branch:
 
 - `hotfix/` - Critical fixes for released versions
 
+**IMPORTANT:** All merges to `main` must go through pull requests, including:
+
+- Release branches → main
+- Hotfix branches → main
+- Never merge directly to main without PR review
+
 ### Branch Lifecycle
 
 ```text
 develop (v1.1.0a1) ─────────────────────────────────────┐
   │                                                      │
-  ├─ feature/new-feature ─→ develop                     │
+  ├─ feature/new-feature ─→ develop (via PR)            │
   │                                                      │
   └─→ release/1.1 (created for v1.1 release) ───────────┤
         │                                                │
         ├─ v1.1.0b1 (beta testing)                      │
         ├─ v1.1.0rc1 (release candidate)                │
-        └─→ main (v1.1.0 released) ─────────────────────┤
+        └─→ main (v1.1.0 released via PR) ──────────────┤
               │                                          │
               └─→ develop (sync back) ───────────────────┘
 
 release/1.1 (KEPT for v1.1.x maintenance)
   │
-  ├─ hotfix/fix-bug ─→ release/1.1 (v1.1.1)
+  ├─ hotfix/fix-bug ─→ release/1.1 (v1.1.1 via PR)
   │                      │
-  │                      ├─→ main (v1.1.1 released)
-  │                      └─→ develop (merge back)
+  │                      ├─→ main (v1.1.1 released via PR)
+  │                      └─→ develop (merge back via PR)
   │
-  └─ hotfix/another-fix ─→ release/1.1 (v1.1.2)
+  └─ hotfix/another-fix ─→ release/1.1 (v1.1.2 via PR)
                            │
-                           ├─→ main (v1.1.2 released)
-                           └─→ develop (merge back)
+                           ├─→ main (v1.1.2 released via PR)
+                           └─→ develop (merge back via PR)
 ```
 
 ### Workflow Examples

--- a/changes/+require-pr-main.doc.md
+++ b/changes/+require-pr-main.doc.md
@@ -1,0 +1,1 @@
+Document requirement that all merges to main must go through pull requests


### PR DESCRIPTION
## Summary

Documents the requirement that all merges to `main` must go through pull request review, including release and hotfix branches.

## Changes

**CONTRIBUTING.md:**
- Added explicit statement: "All merges to main must go through pull requests"
- Updated branch lifecycle diagram with "via PR" annotations
- Clarified that release branches PR to main (not direct merge)

**Agent Config:**
- Added "ALL merges to main require PR review" to critical rules
- Updated hotfix workflow: PR to release/X.Y, then PR to main, then PR to develop
- Added "Release branches: PR to main (never direct merge)"

## Rationale

This prevents accidental direct merges to main (like the v1.0.1 release merge) and ensures proper code review for all production changes.

## Related

- Addresses lesson learned from v1.0.1 release process