### PR TITLE
fix(docs): add Material theme to Read the Docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,8 +10,4 @@ mkdocs:
 
 python:
   install:
-    - requirements: requirements.lock
-    - method: pip
-      path: .
-      extra_requirements:
-        - dev
+    - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs>=1.6.0
+mkdocs-material>=9.5.0
+mkdocstrings[python]>=0.24.0


### PR DESCRIPTION
## Summary

Fixes Read the Docs build error by adding Material theme dependencies.

## Problem

RTD build failed with:
```
ERROR - Config value 'theme': Unrecognised theme name: 'material'
```

## Solution

- Created `docs/requirements.txt` with mkdocs-material and mkdocstrings
- Updated `.readthedocs.yaml` to install from docs requirements
- RTD doesn't have access to full project dependencies, needs separate file

## Testing

Will verify RTD build succeeds after merge.