### PR TITLE
docs: fix license section to reference existing MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Contributions welcome! See the [Contributing Guide](https://naas.readthedocs.io/
 
 ## License
 
-[License information coming soon]
+MIT License - see [LICENSE](LICENSE) file for details
 
 ---
 

--- a/changes/+license-fix.doc.md
+++ b/changes/+license-fix.doc.md
@@ -1,0 +1,1 @@
+Fix license section to reference existing MIT license file


### PR DESCRIPTION
## Summary

Fixes the license section in README to reference the existing MIT LICENSE file instead of saying "coming soon".

## Changes

- Changed from `[License information coming soon]` to `MIT License - see [LICENSE](LICENSE) file for details`

## Context

The repository has had an MIT LICENSE file since 2019, but the README still said the license information was "coming soon".