### PR TITLE
feat(api): add dynamic OpenAPI spec generation with spectree

### DIFF
--- a/changes/120.feature.md
+++ b/changes/120.feature.md
@@ -1,0 +1,1 @@
+Add dynamic OpenAPI spec generation via spectree. The spec is served at `/apidoc/openapi.json` and Swagger UI at `/apidoc`, generated automatically from existing Pydantic request/response models.

--- a/naas/app.py
+++ b/naas/app.py
@@ -19,6 +19,7 @@ from naas.resources.healthcheck import HealthCheck
 from naas.resources.list_jobs import ListJobs
 from naas.resources.send_command import SendCommand
 from naas.resources.send_config import SendConfig
+from naas.spec import spec
 
 app = Flask(__name__)
 
@@ -41,3 +42,5 @@ api.add_resource(SendCommand, "/send_command")
 api.add_resource(SendConfig, "/send_config")
 api.add_resource(GetResults, "/send_command/<string:job_id>", "/send_config/<string:job_id>")
 api.add_resource(ListJobs, "/v1/jobs")
+
+spec.register(app)

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -2,12 +2,14 @@
 
 from flask import current_app, g, request
 from flask_restful import Resource
+from spectree import Response
 
 from naas import __base_response__
 from naas.library.auth import job_locker
 from naas.library.decorators import valid_post
 from naas.library.netmiko_lib import netmiko_send_config
-from naas.models import JobResponse, SendConfigRequest, validate_request
+from naas.models import JobResponse, SendConfigRequest
+from naas.spec import spec
 
 
 class SendConfig(Resource):
@@ -16,6 +18,7 @@ class SendConfig(Resource):
         return __base_response__
 
     @valid_post
+    @spec.validate(json=SendConfigRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """
         Will enqueue an attempt to use netmiko's send_config_set() method to run commands/put configuration on a device.
@@ -33,12 +36,7 @@ class SendConfig(Resource):
         Secured by Basic Auth, which is then passed to the network device.
         :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header
         """
-        # Validate request with Pydantic
-        result = validate_request(SendConfigRequest, request.json)
-        if not isinstance(result, SendConfigRequest):
-            return result
-        validated = result
-
+        validated: SendConfigRequest = request.context.json
         ip_str = str(validated.ip)
 
         # Log this request's details

--- a/naas/spec.py
+++ b/naas/spec.py
@@ -1,0 +1,5 @@
+"""Shared SpecTree instance for OpenAPI spec generation."""
+
+from spectree import SpecTree
+
+spec = SpecTree("flask", title="NAAS - Netmiko As A Service", version="v1", path="apidoc")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "redis>=3.4.1",
     "rq>=1.2.2",
     "scp>=0.13.2",
+    "spectree>=2.0.1",
     "textfsm>=1.1.0",
 ]
 

--- a/tests/unit/test_list_jobs.py
+++ b/tests/unit/test_list_jobs.py
@@ -129,7 +129,7 @@ class TestListJobs:
         response = client.get("/v1/jobs?page=0&per_page=200", headers={"Authorization": f"Basic {auth}"})
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_list_jobs_invalid_status(self, app, client):
         """Test GET with invalid status value returns 422."""
@@ -138,7 +138,7 @@ class TestListJobs:
         response = client.get("/v1/jobs?status=invalid", headers={"Authorization": f"Basic {auth}"})
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_list_jobs_failed_status(self, app, client):
         """Test GET with failed status filter."""

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -3,8 +3,6 @@
 from base64 import b64encode
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestSendCommand:
     """Test send_command resource."""
@@ -68,7 +66,7 @@ class TestSendCommand:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_send_command_empty_commands(self, app, client):
         """Test POST with empty commands list returns 422."""
@@ -86,7 +84,7 @@ class TestSendCommand:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_send_command_empty_string_in_commands(self, app, client):
         """Test POST with empty string in commands list returns 422."""
@@ -104,28 +102,7 @@ class TestSendCommand:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
-
-    def test_send_command_unexpected_error(self, app, client):
-        """Test POST with unexpected error during validation."""
-        auth = b64encode(b"testuser:testpass").decode()
-        app.config["redis"].set("naas_cred_salt", b"test-salt")
-
-        with (
-            patch("naas.library.validation.tacacs_auth_lockout", return_value=False),
-            patch("naas.resources.send_command.SendCommandRequest") as mock_model,
-        ):
-            mock_model.side_effect = RuntimeError("Unexpected error")
-
-            with pytest.raises(RuntimeError):
-                client.post(
-                    "/send_command",
-                    json={
-                        "ip": "192.0.2.1",
-                        "commands": ["show version"],
-                    },
-                    headers={"Authorization": f"Basic {auth}"},
-                )
+        assert isinstance(response.json, list)
 
     def test_send_command_invalid_port(self, app, client):
         """Test POST with invalid port returns 422."""
@@ -144,7 +121,7 @@ class TestSendCommand:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_send_command_invalid_platform(self, app, client):
         """Test POST with invalid platform returns 422."""
@@ -163,7 +140,7 @@ class TestSendCommand:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_send_command_device_type_backward_compat(self, app, client):
         """Test POST with deprecated device_type maps to platform."""
@@ -280,7 +257,7 @@ class TestSendConfig:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_send_config_missing_both_config_and_commands(self, app, client):
         """Test POST without config or commands returns 422."""
@@ -297,7 +274,7 @@ class TestSendConfig:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
+        assert isinstance(response.json, list)
 
     def test_send_config_invalid_platform(self, app, client):
         """Test POST with invalid platform returns 422."""
@@ -316,28 +293,7 @@ class TestSendConfig:
             )
 
         assert response.status_code == 422
-        assert "errors" in response.json
-
-    def test_send_config_unexpected_error(self, app, client):
-        """Test POST with unexpected error during validation."""
-        auth = b64encode(b"testuser:testpass").decode()
-        app.config["redis"].set("naas_cred_salt", b"test-salt")
-
-        with (
-            patch("naas.library.validation.tacacs_auth_lockout", return_value=False),
-            patch("naas.resources.send_config.SendConfigRequest") as mock_model,
-        ):
-            mock_model.side_effect = RuntimeError("Unexpected error")
-
-            with pytest.raises(RuntimeError):
-                client.post(
-                    "/send_config",
-                    json={
-                        "ip": "192.0.2.1",
-                        "commands": ["interface gi0/1"],
-                    },
-                    headers={"Authorization": f"Basic {auth}"},
-                )
+        assert isinstance(response.json, list)
 
     def test_send_config_post_no_auth(self, client):
         """Test POST without auth returns 401."""

--- a/uv.lock
+++ b/uv.lock
@@ -1135,6 +1135,7 @@ dependencies = [
     { name = "redis" },
     { name = "rq" },
     { name = "scp" },
+    { name = "spectree" },
     { name = "textfsm" },
 ]
 
@@ -1187,6 +1188,7 @@ requires-dist = [
     { name = "rq", specifier = ">=1.2.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "scp", specifier = ">=0.13.2" },
+    { name = "spectree", specifier = ">=2.0.1" },
     { name = "textfsm", specifier = ">=1.1.0" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = ">=23.11.0" },
 ]
@@ -1846,6 +1848,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "spectree"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/3d/1380581a90b714a56cb1669982e5889557b6edcda85e9ee3d538804f4726/spectree-2.0.1.tar.gz", hash = "sha256:280dd6beb10a9c5f023254650d3d8f4494077d556f7de92c1fbebd1203efe39c", size = 58970, upload-time = "2025-12-16T01:38:52.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/9c/889999a8e8c1c9c56b55f20038e807e234199887b3ba706bd708b57ce9d8/spectree-2.0.1-py3-none-any.whl", hash = "sha256:fd30dadca93afdd82573d886365ae27f0b3eea4ed43a9daf6f6616483520b673", size = 44438, upload-time = "2025-12-16T01:38:51.011Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Integrates [spectree](https://github.com/0b01001001/spectree) to generate OpenAPI 3.0 spec dynamically from existing Pydantic models.

## Changes

- `naas/spec.py` — shared `SpecTree` instance (separate module avoids circular imports with `app.py`)
- `naas/app.py` — import and register spec after routes
- `naas/models.py` — remove `validate_request()` helper; document strict vs non-strict `model_config` rule
- `naas/resources/send_command.py` — `@spec.validate(json=SendCommandRequest, resp=Response(HTTP_202=JobResponse))`
- `naas/resources/send_config.py` — `@spec.validate(json=SendConfigRequest, resp=Response(HTTP_202=JobResponse))`
- `naas/resources/list_jobs.py` — `@spec.validate(query=ListJobsQuery)`
- Tests updated for spectree's raw error list response format

## Endpoints

- `GET /apidoc/openapi.json` — OpenAPI 3.0 spec
- `GET /apidoc` — Swagger UI

## Testing

105 tests, 100% coverage.

Closes #120