### PR TITLE
feat(api): add Basic Auth security scheme to OpenAPI spec

### DIFF
--- a/changes/83.feature.md
+++ b/changes/83.feature.md
@@ -1,0 +1,1 @@
+OpenAPI spec now includes Basic Auth security scheme, enabling 'Try it out' authentication in Swagger UI at /apidoc.

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -238,6 +238,12 @@
         "title": "ValidationErrorElement",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "basicAuth": {
+        "scheme": "basic",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -465,6 +471,10 @@
       }
     }
   },
-  "security": [],
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
   "tags": []
 }

--- a/naas/spec.py
+++ b/naas/spec.py
@@ -1,5 +1,19 @@
 """Shared SpecTree instance for OpenAPI spec generation."""
 
 from spectree import SpecTree
+from spectree.config import SecurityScheme
+from spectree.models import SecureType, SecuritySchemeData
 
-spec = SpecTree("flask", title="NAAS - Netmiko As A Service", version="v1", path="apidoc")
+spec = SpecTree(
+    "flask",
+    title="NAAS - Netmiko As A Service",
+    version="v1",
+    path="apidoc",
+    security_schemes=[
+        SecurityScheme(
+            name="basicAuth",
+            data=SecuritySchemeData(type=SecureType.HTTP, scheme="basic"),  # type: ignore[call-arg]
+        )
+    ],
+    security=[{"basicAuth": []}],
+)


### PR DESCRIPTION
## Summary

Wires HTTP Basic Auth into the spectree OpenAPI spec so the Swagger UI 'Authorize' button works for 'Try it out'.

## Changes

- `naas/spec.py` — add `basicAuth` security scheme (`type: http, scheme: basic`) applied globally
- `docs/swagger/openapi.json` — regenerated with `securitySchemes` and `security` sections

## Testing

105 tests, 100% coverage.

Closes #83