### PR TITLE
feat(api): add /v1/ URL versioning to all endpoints

### DIFF
--- a/changes/84.feature.md
+++ b/changes/84.feature.md
@@ -1,0 +1,1 @@
+All API endpoints are now available under the `/v1/` prefix. Legacy unversioned routes (`/send_command`, `/send_config`) remain functional but return `X-API-Deprecated: true` and `X-API-Sunset: 2027-01-01` headers. All responses include `X-API-Version: v1`.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -33,7 +33,7 @@ Execute show commands on network devices.
 ### Basic Example
 
 ```bash
-curl -k -X POST https://localhost:8443/send_command \
+curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -46,7 +46,7 @@ curl -k -X POST https://localhost:8443/send_command \
 ### With Custom Port
 
 ```bash
-curl -k -X POST https://localhost:8443/send_command \
+curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -60,7 +60,7 @@ curl -k -X POST https://localhost:8443/send_command \
 ### With Enable Password
 
 ```bash
-curl -k -X POST https://localhost:8443/send_command \
+curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -76,7 +76,7 @@ curl -k -X POST https://localhost:8443/send_command \
 Track your requests with custom IDs:
 
 ```bash
-curl -k -X POST https://localhost:8443/send_command \
+curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -H "X-Request-ID: my-custom-id-12345" \
@@ -105,7 +105,7 @@ Push configuration changes to devices.
 ### Basic Configuration
 
 ```bash
-curl -k -X POST https://localhost:8443/send_config \
+curl -k -X POST https://localhost:8443/v1/send_config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -124,7 +124,7 @@ curl -k -X POST https://localhost:8443/send_config \
 Automatically save configuration after changes:
 
 ```bash
-curl -k -X POST https://localhost:8443/send_config \
+curl -k -X POST https://localhost:8443/v1/send_config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -143,7 +143,7 @@ curl -k -X POST https://localhost:8443/send_config \
 For platforms that require commit:
 
 ```bash
-curl -k -X POST https://localhost:8443/send_config \
+curl -k -X POST https://localhost:8443/v1/send_config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -161,7 +161,7 @@ curl -k -X POST https://localhost:8443/send_config \
 ### Check Job Status
 
 ```bash
-curl -k https://localhost:8443/send_command/550e8400-e29b-41d4-a716-446655440000 \
+curl -k https://localhost:8443/v1/send_command/550e8400-e29b-41d4-a716-446655440000 \
   -u "admin:password"
 ```
 
@@ -276,7 +276,7 @@ from aiohttp import BasicAuth
 async def send_command(session, device_ip, commands):
     """Send command to device via NAAS."""
     async with session.post(
-        "https://localhost:8443/send_command",
+        "https://localhost:8443/v1/send_command",
         json={
             "ip": device_ip,
             "platform": "cisco_ios",
@@ -291,7 +291,7 @@ async def get_results(session, job_id):
     """Poll for job results."""
     while True:
         async with session.get(
-            f"https://localhost:8443/send_command/{job_id}",
+            f"https://localhost:8443/v1/send_command/{job_id}",
             ssl=False
         ) as response:
             data = await response.json()
@@ -377,7 +377,7 @@ def send_command_safe(ip, commands):
     """Send command with error handling."""
     try:
         response = requests.post(
-            "https://localhost:8443/send_command",
+            "https://localhost:8443/v1/send_command",
             auth=HTTPBasicAuth("admin", "password"),
             verify=False,
             json={

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,7 +37,7 @@ Send a command to a network device:
 
 ```bash
 # Send command (replace with your device credentials)
-curl -k -X POST https://localhost:8443/send_command \
+curl -k -X POST https://localhost:8443/v1/send_command \
   -u "device_username:device_password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -62,7 +62,7 @@ Check the job status and retrieve results:
 
 ```bash
 # Get results (use the job_id from previous response)
-curl -k https://localhost:8443/send_command/550e8400-e29b-41d4-a716-446655440000 \
+curl -k https://localhost:8443/v1/send_command/550e8400-e29b-41d4-a716-446655440000 \
   -u "device_username:device_password"
 ```
 
@@ -84,7 +84,7 @@ Response when complete:
 Push configuration changes:
 
 ```bash
-curl -k -X POST https://localhost:8443/send_config \
+curl -k -X POST https://localhost:8443/v1/send_config \
   -u "device_username:device_password" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -410,6 +410,16 @@
         "tags": []
       }
     },
+    "/v1/healthcheck": {
+      "get": {
+        "description": "",
+        "operationId": "get__v1_healthcheck",
+        "parameters": [],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      }
+    },
     "/v1/jobs": {
       "get": {
         "description": "",
@@ -467,6 +477,144 @@
         ],
         "responses": {},
         "summary": "List jobs with pagination and filtering. Query parameters: - page: Page number (default: 1) - per_page: Results per page (default: 20, max: 100) - status: Filter by status (finished, failed, started, queued) :return: Dict with jobs list and pagination info",
+        "tags": []
+      }
+    },
+    "/v1/send_command": {
+      "get": {
+        "description": "",
+        "operationId": "get__v1_send_command",
+        "parameters": [],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "Requires you submit the following in the payload:     ip: str     commands: Sequence[str] Optional:     port: int - Default 22     platform: str - Default cisco_ios     enable: Optional[str] - Default the password provided for basic auth\n\nSecured by Basic Auth, which is then passed to the network device. :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header",
+        "operationId": "post__v1_send_command",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendCommandRequest.c5eb086"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse.c5eb086"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "summary": "Will enqueue an attempt to run commands on a device.",
+        "tags": []
+      }
+    },
+    "/v1/send_command/{job_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__v1_send_command_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Given the requested job_id, return status and/or any results if finished. :param job_id: :return: A dict of job status and/or results if finished.",
+        "tags": []
+      }
+    },
+    "/v1/send_config": {
+      "get": {
+        "description": "",
+        "operationId": "get__v1_send_config",
+        "parameters": [],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "Requires you submit the following in the payload:     ip: str     commands: Sequence[str] Optional:     port: int - Default 22     platform: str - Default cisco_ios     enable: Optional[str] - Default the password provided for basic auth     save_config: bool     commit: bool\n\nSecured by Basic Auth, which is then passed to the network device. :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header",
+        "operationId": "post__v1_send_config",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendConfigRequest.c5eb086"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse.c5eb086"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "summary": "Will enqueue an attempt to use netmiko's send_config_set() method to run commands/put configuration on a device.",
+        "tags": []
+      }
+    },
+    "/v1/send_config/{job_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__v1_send_config_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Given the requested job_id, return status and/or any results if finished. :param job_id: :return: A dict of job status and/or results if finished.",
         "tags": []
       }
     }

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -9,10 +9,18 @@ class TestSendCommand:
 
     def test_send_command_get(self, client):
         """Test GET returns base response."""
-        response = client.get("/send_command")
+        response = client.get("/v1/send_command")
         assert response.status_code == 200
         assert "app" in response.json
         assert response.json["app"] == "naas"
+        assert response.headers["X-API-Version"] == "v1"
+
+    def test_send_command_legacy_route_deprecated(self, client):
+        """Test legacy /send_command route returns deprecation headers."""
+        response = client.get("/send_command")
+        assert response.status_code == 200
+        assert response.headers["X-API-Deprecated"] == "true"
+        assert "X-API-Sunset" in response.headers
 
     def test_send_command_post_success(self, app, client):
         """Test POST enqueues job successfully."""
@@ -22,7 +30,7 @@ class TestSendCommand:
         # Mock tacacs_auth_lockout to avoid Redis connection in validation
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.168.1.1",
                     "port": 22,
@@ -41,7 +49,7 @@ class TestSendCommand:
     def test_send_command_post_no_auth(self, client):
         """Test POST without auth returns 401."""
         response = client.post(
-            "/send_command",
+            "/v1/send_command",
             json={
                 "ip": "192.168.1.1",
                 "commands": ["show version"],
@@ -57,7 +65,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "not-an-ip",
                     "commands": ["show version"],
@@ -75,7 +83,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.168.1.1",
                     "commands": [],
@@ -93,7 +101,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.0.2.1",
                     "commands": ["show version", "  ", "show run"],
@@ -111,7 +119,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.168.1.1",
                     "port": 99999,
@@ -130,7 +138,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.0.2.1",
                     "commands": ["show version"],
@@ -149,7 +157,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.0.2.1",
                     "commands": ["show version"],
@@ -167,7 +175,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.0.2.1",
                     "commands": ["show version"],
@@ -187,7 +195,7 @@ class TestSendCommand:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_command",
+                "/v1/send_command",
                 json={
                     "ip": "192.168.1.1",
                     "port": 22,
@@ -210,10 +218,18 @@ class TestSendConfig:
 
     def test_send_config_get(self, client):
         """Test GET returns base response."""
-        response = client.get("/send_config")
+        response = client.get("/v1/send_config")
         assert response.status_code == 200
         assert "app" in response.json
         assert response.json["app"] == "naas"
+        assert response.headers["X-API-Version"] == "v1"
+
+    def test_send_config_legacy_route_deprecated(self, client):
+        """Test legacy /send_config route returns deprecation headers."""
+        response = client.get("/send_config")
+        assert response.status_code == 200
+        assert response.headers["X-API-Deprecated"] == "true"
+        assert "X-API-Sunset" in response.headers
 
     def test_send_config_post_success(self, app, client):
         """Test POST enqueues job successfully."""
@@ -223,7 +239,7 @@ class TestSendConfig:
         # Mock tacacs_auth_lockout to avoid Redis connection in validation
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_config",
+                "/v1/send_config",
                 json={
                     "ip": "192.168.1.1",
                     "port": 22,
@@ -248,7 +264,7 @@ class TestSendConfig:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_config",
+                "/v1/send_config",
                 json={
                     "ip": "192.0.2.1",
                     "commands": ["interface gi0/1", "  ", "description test"],
@@ -266,7 +282,7 @@ class TestSendConfig:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_config",
+                "/v1/send_config",
                 json={
                     "ip": "192.0.2.1",
                 },
@@ -283,7 +299,7 @@ class TestSendConfig:
 
         with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
             response = client.post(
-                "/send_config",
+                "/v1/send_config",
                 json={
                     "ip": "192.0.2.1",
                     "commands": ["interface gi0/1"],
@@ -298,7 +314,7 @@ class TestSendConfig:
     def test_send_config_post_no_auth(self, client):
         """Test POST without auth returns 401."""
         response = client.post(
-            "/send_config",
+            "/v1/send_config",
             json={
                 "ip": "192.168.1.1",
                 "commands": ["interface gi0/1"],
@@ -319,7 +335,7 @@ class TestGetResults:
         # Mock job_unlocker to always return True (auth passes)
         with patch("naas.resources.get_results.job_unlocker", return_value=True):
             response = client.get(
-                "/send_command/00000000-0000-0000-0000-000000000000",
+                "/v1/send_command/00000000-0000-0000-0000-000000000000",
                 headers={"Authorization": f"Basic {auth}"},
             )
 
@@ -346,7 +362,7 @@ class TestGetResults:
 
         with patch("naas.resources.get_results.job_unlocker", return_value=True):
             response = client.get(
-                f"/send_command/{job_id}",
+                f"/v1/send_command/{job_id}",
                 headers={"Authorization": f"Basic {auth}"},
             )
 
@@ -374,7 +390,7 @@ class TestGetResults:
 
         with patch("naas.resources.get_results.job_unlocker", return_value=True):
             response = client.get(
-                f"/send_command/{job_id}",
+                f"/v1/send_command/{job_id}",
                 headers={"Authorization": f"Basic {auth}"},
             )
 
@@ -385,7 +401,7 @@ class TestGetResults:
 
     def test_get_results_no_auth(self, client):
         """Test GET without auth returns 401."""
-        response = client.get("/send_command/00000000-0000-0000-0000-000000000000")
+        response = client.get("/v1/send_command/00000000-0000-0000-0000-000000000000")
         assert response.status_code == 401
 
     def test_get_results_wrong_user(self, app, client):
@@ -407,7 +423,7 @@ class TestGetResults:
         # Mock job_unlocker to return False (wrong user)
         with patch("naas.resources.get_results.job_unlocker", return_value=False):
             response = client.get(
-                f"/send_command/{job_id}",
+                f"/v1/send_command/{job_id}",
                 headers={"Authorization": f"Basic {auth}"},
             )
 


### PR DESCRIPTION
Implements URL-based API versioning (#84).

- All endpoints registered under `/v1/`
- Legacy `/send_command` and `/send_config` kept as deprecated aliases
- `after_request` hook: `X-API-Version: v1` on all responses; `X-API-Deprecated: true` + `X-API-Sunset: 2027-01-01` on legacy routes
- Docs and OpenAPI spec updated
- 107 tests, 100% coverage

Closes #84