### PR TITLE
feat(logging): structured JSON logging via python-json-logger

### DIFF
--- a/changes/79.feature.md
+++ b/changes/79.feature.md
@@ -1,0 +1,1 @@
+All log output is now structured JSON, making logs parseable by ELK, Splunk, CloudWatch, and other log aggregation tools. Each log line includes `timestamp`, `level`, `logger`, and `message` fields.

--- a/naas/app.py
+++ b/naas/app.py
@@ -8,9 +8,11 @@ Description: Main app setup/config
 """
 
 import logging
+import os
 
 from flask import Flask, request
 from flask_restful import Api
+from pythonjsonlogger.json import JsonFormatter
 
 from naas.config import app_configure
 from naas.library.errorhandlers import api_error_generator
@@ -25,7 +27,17 @@ app = Flask(__name__)
 
 app_configure(app)
 
-# Setup logging:
+# Structured JSON logging
+_handler = logging.StreamHandler()
+_handler.setFormatter(
+    JsonFormatter(
+        fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+        rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
+    )
+)
+logging.root.handlers = [_handler]
+logging.root.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
 logger = logging.getLogger(name="NAAS")
 app.logger.handlers = logger.handlers
 app.logger.setLevel(logger.level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "paramiko>=2.7.1",
     "pydantic>=2.0.0",
     "pyserial>=3.4",
+    "python-json-logger>=4.0.0",
     "pyyaml>=5.3",
     "redis>=3.4.1",
     "rq>=1.2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1131,6 +1131,7 @@ dependencies = [
     { name = "paramiko" },
     { name = "pydantic" },
     { name = "pyserial" },
+    { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "redis" },
     { name = "rq" },
@@ -1182,6 +1183,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-flask", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
+    { name = "python-json-logger", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=5.3" },
     { name = "redis", specifier = ">=3.4.1" },
     { name = "requests", marker = "extra == 'dev'", specifier = ">=2.31.0" },
@@ -1620,6 +1622,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/bf/eca6a3d43db1dae7070f70e160ab20b807627ba953663ba07928cdd3dc58/python_json_logger-4.0.0.tar.gz", hash = "sha256:f58e68eb46e1faed27e0f574a55a0455eecd7b8a5b88b85a784519ba3cff047f", size = 17683, upload-time = "2025-10-06T04:15:18.984Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e5/fecf13f06e5e5f67e8837d777d1bc43fac0ed2b77a676804df5c34744727/python_json_logger-4.0.0-py3-none-any.whl", hash = "sha256:af09c9daf6a813aa4cc7180395f50f2a9e5fa056034c9953aec92e381c5ba1e2", size = 15548, upload-time = "2025-10-06T04:15:17.553Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #79.

- Add `python-json-logger` dependency
- Configure root logger with `JsonFormatter` in `app.py`
- Output fields: `timestamp`, `level`, `logger`, `message`
- Log level driven by `LOG_LEVEL` env var (default `INFO`, `DEBUG` in dev)
- 107 tests, 100% coverage (logging setup covered at import time)

Closes #79