### PR TITLE
feat(tracing): pass correlation ID into worker for end-to-end log tracing

### DIFF
--- a/changes/80.internal.md
+++ b/changes/80.internal.md
@@ -1,0 +1,1 @@
+Correlation ID (request_id/job_id) now flows from API request through to worker log messages, enabling end-to-end log tracing across API and worker.

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -29,6 +29,7 @@ def netmiko_send_command(
     port: int = 22,
     delay_factor: int = 1,
     verbose: bool = False,
+    request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
     """
     Instantiate a netmiko wrapper instance, feed me an IP, Platform Type, Username, Password, any commands to run.
@@ -40,6 +41,7 @@ def netmiko_send_command(
     :param port: What TCP Port are we connecting to?
     :param delay_factor: Netmiko delay factor, default of 1, higher is slower but more reliable on laggy links
     :param verbose: Turn on Netmiko verbose logging
+    :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
     """
 
@@ -58,29 +60,29 @@ def netmiko_send_command(
     }
 
     try:
-        logger.debug("%s:Establishing connection...", ip)
+        logger.debug("%s %s:Establishing connection...", request_id, ip)
         net_connect = netmiko.ConnectHandler(**netmiko_device)
 
         net_output = {}
         for command in commands:
-            logger.debug("%s:Sending %s", ip, command)
+            logger.debug("%s %s:Sending %s", request_id, ip, command)
             net_output[command] = net_connect.send_command(command, delay_factor=delay_factor)
 
         # Perform graceful disconnection of this SSH session
         net_connect.disconnect()
 
     except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
-        logger.debug("%s:Netmiko timed out connecting to device: %s", ip, e)
+        logger.debug("%s %s:Netmiko timed out connecting to device: %s", request_id, ip, e)
         return None, str(e)
     except netmiko.NetMikoAuthenticationException as e:
-        logger.debug("%s:Netmiko authentication failure connecting to device: %s", ip, e)
+        logger.debug("%s %s:Netmiko authentication failure connecting to device: %s", request_id, ip, e)
         tacacs_auth_lockout(username=credentials.username, report_failure=True)
         return None, str(e)
     except (ssh_exception.SSHException, ValueError) as e:
-        logger.debug("%s:Netmiko cannot connect to device: %s", ip, e)
+        logger.debug("%s %s:Netmiko cannot connect to device: %s", request_id, ip, e)
         return None, (f"Unknown SSH error connecting to device {ip}: {str(e)}")
 
-    logger.debug("%s:Netmiko executed successfully.", ip)
+    logger.debug("%s %s:Netmiko executed successfully.", request_id, ip)
     return net_output, None
 
 
@@ -94,6 +96,7 @@ def netmiko_send_config(
     commit: bool = False,
     delay_factor: int = 1,
     verbose: bool = False,
+    request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
     """
     Instantiate a netmiko wrapper instance, feed me an IP, Platform Type, Username, Password, any commands to run.
@@ -107,6 +110,7 @@ def netmiko_send_config(
     :param commit: Do you want to commit this candidate configuration to the running config?  Default: False
     :param delay_factor: Netmiko delay factor, default of 1, higher is slower but more reliable on laggy links
     :param verbose: Turn on Netmiko verbose logging
+    :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
     """
 
@@ -125,40 +129,47 @@ def netmiko_send_config(
     }
 
     try:
-        logger.debug("%s:Establishing connection...", ip)
+        logger.debug("%s %s:Establishing connection...", request_id, ip)
         net_connect = netmiko.ConnectHandler(**netmiko_device)
 
         net_output = {}
-        logger.debug("%s:Sending config_set: %s", ip, commands)
+        logger.debug("%s %s:Sending config_set: %s", request_id, ip, commands)
         net_output["config_set_output"] = net_connect.send_config_set(commands, delay_factor=delay_factor)
 
         if save_config:
             try:
-                logger.debug("%s: Saving configuration", ip)
+                logger.debug("%s %s: Saving configuration", request_id, ip)
                 net_connect.save_config()
             except NotImplementedError:
-                logger.debug("%s: This device_type (%s) does not support the save_config operation.", ip, device_type)
+                logger.debug(
+                    "%s %s: This device_type (%s) does not support the save_config operation.",
+                    request_id,
+                    ip,
+                    device_type,
+                )
 
         if commit:
             try:
-                logger.debug("%s: Committing configuration", ip)
+                logger.debug("%s %s: Committing configuration", request_id, ip)
                 net_connect.commit()
             except AttributeError:
-                logger.debug("%s: This device_type (%s) does not support the commit operation", ip, device_type)
+                logger.debug(
+                    "%s %s: This device_type (%s) does not support the commit operation", request_id, ip, device_type
+                )
 
         # Perform graceful disconnection of this SSH session
         net_connect.disconnect()
 
     except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
-        logger.debug("%s:Netmiko timed out connecting to device: %s", ip, e)
+        logger.debug("%s %s:Netmiko timed out connecting to device: %s", request_id, ip, e)
         return None, str(e)
     except netmiko.NetMikoAuthenticationException as e:
-        logger.debug("%s:Netmiko authentication failure connecting to device: %s", ip, e)
+        logger.debug("%s %s:Netmiko authentication failure connecting to device: %s", request_id, ip, e)
         tacacs_auth_lockout(username=credentials.username, report_failure=True)
         return None, str(e)
     except (ssh_exception.SSHException, ValueError) as e:
-        logger.debug("%s:Netmiko cannot connect to device: %s", ip, e)
+        logger.debug("%s %s:Netmiko cannot connect to device: %s", request_id, ip, e)
         return None, (f"Unknown SSH error connecting to device {ip}: {str(e)}")
 
-    logger.debug("%s:Netmiko executed successfully.", ip)
+    logger.debug("%s %s:Netmiko executed successfully.", request_id, ip)
     return net_output, None

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -71,6 +71,7 @@ class SendCommand(Resource):
             credentials=g.credentials,
             commands=validated.commands,
             delay_factor=validated.delay_factor,
+            request_id=g.request_id,
             job_id=g.request_id,
             result_ttl=86460,
             failure_ttl=86460,

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -75,6 +75,7 @@ class SendConfig(Resource):
             save_config=validated.save_config,
             commit=validated.commit,
             delay_factor=validated.delay_factor,
+            request_id=g.request_id,
             job_id=g.request_id,
             result_ttl=86460,
             failure_ttl=86460,


### PR DESCRIPTION
Implements #80.

The `request_id` (which is also the RQ `job_id`) now flows from the API layer into the worker functions, so all log lines across API → worker → device share the same correlation ID.

- Add `request_id: str = ""` param to `netmiko_send_command` and `netmiko_send_config`
- All worker log lines prefixed with `request_id`
- Pass `request_id=g.request_id` from both endpoints when enqueueing
- 107 tests, 100% coverage

Closes #80