### PR TITLE
feat(netmiko): add circuit breaker pattern for failing devices

### DIFF
--- a/changes/96.feature.md
+++ b/changes/96.feature.md
@@ -1,0 +1,1 @@
+Circuit breaker pattern prevents repeated connection attempts to failing devices with configurable thresholds and automatic recovery

--- a/naas/config.py
+++ b/naas/config.py
@@ -28,6 +28,11 @@ REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "mah_redis_pw")
 JOB_TTL_SUCCESS = int(os.environ.get("JOB_TTL_SUCCESS", 86400))  # 24h
 JOB_TTL_FAILED = int(os.environ.get("JOB_TTL_FAILED", 604800))  # 7 days
 
+# Circuit breaker config
+CIRCUIT_BREAKER_ENABLED = os.environ.get("CIRCUIT_BREAKER_ENABLED", "true").lower() == "true"
+CIRCUIT_BREAKER_THRESHOLD = int(os.environ.get("CIRCUIT_BREAKER_THRESHOLD", 5))
+CIRCUIT_BREAKER_TIMEOUT = int(os.environ.get("CIRCUIT_BREAKER_TIMEOUT", 300))  # 5 minutes
+
 # Graceful shutdown config (seconds)
 SHUTDOWN_TIMEOUT = int(os.environ.get("SHUTDOWN_TIMEOUT", 30))  # 30s
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "gunicorn>=20.0.4",
     "netmiko>=3.0.0",
     "paramiko>=2.7.1",
+    "pybreaker>=1.4.1",
     "pydantic>=2.0.0",
     "pyserial>=3.4",
     "python-json-logger>=4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1129,6 +1129,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "netmiko" },
     { name = "paramiko" },
+    { name = "pybreaker" },
     { name = "pydantic" },
     { name = "pyserial" },
     { name = "python-json-logger" },
@@ -1177,6 +1178,7 @@ requires-dist = [
     { name = "netmiko", specifier = ">=3.0.0" },
     { name = "paramiko", specifier = ">=2.7.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pybreaker", specifier = ">=1.4.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pyserial", specifier = ">=3.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
@@ -1367,6 +1369,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "pybreaker"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #96.

Adds circuit breaker pattern to prevent repeated connection attempts to failing devices using the pybreaker library.

**Changes:**
- Added `pybreaker` dependency
- Implemented per-device circuit breakers in `netmiko_lib.py`
- Circuit opens after 5 failures (configurable via `CIRCUIT_BREAKER_THRESHOLD`)
- Auto-recovery after 300s timeout (configurable via `CIRCUIT_BREAKER_TIMEOUT`)
- Circuit breaker can be disabled via `CIRCUIT_BREAKER_ENABLED=false`
- Authentication failures don't trigger circuit breaker (user error, not device failure)
- Connection timeouts and SSH errors trigger circuit breaker
- Added 3 unit tests for circuit breaker functionality
- All 114 tests pass with 100% coverage

**Configuration:**
```bash
CIRCUIT_BREAKER_ENABLED=true  # default
CIRCUIT_BREAKER_THRESHOLD=5   # failures before opening
CIRCUIT_BREAKER_TIMEOUT=300   # seconds before retry
```

**Behavior:**
- Each device gets its own circuit breaker (per-IP)
- After threshold failures, circuit opens and rejects new connections
- After timeout, circuit enters half-open state and allows one test connection
- Successful connection closes circuit and resets failure count

Closes #96