### PR TITLE
ci: enforce mypy in CI and fix pre-existing type errors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Check ruff formatting
         run: uv run ruff format --check naas/ tests/
 
+      - name: Run mypy
+        run: uv run mypy naas/
+
   check-changelog:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -60,10 +63,6 @@ jobs:
           fi
 
           echo "✅ Found changelog fragment(s)"
-
-      - name: Run mypy
-        run: uv run mypy naas/
-        continue-on-error: true
 
   lint-summary:
     name: Code Quality

--- a/changes/+enforce-mypy.internal.md
+++ b/changes/+enforce-mypy.internal.md
@@ -1,0 +1,1 @@
+Move mypy into the enforced lint job so type errors block CI. Previously mypy ran with continue-on-error=true in a separate job and failures were silently ignored.

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -43,7 +43,7 @@ class RedisCircuitBreakerStorage(pybreaker.CircuitBreakerStorage):
     @property
     def state(self) -> str:
         """Get current circuit state."""
-        return self.redis.hget(self._key, "state") or "closed"
+        return self.redis.hget(self._key, "state") or "closed"  # type: ignore[return-value]
 
     @state.setter
     def state(self, state: str) -> None:
@@ -56,7 +56,7 @@ class RedisCircuitBreakerStorage(pybreaker.CircuitBreakerStorage):
 
     def reset_counter(self) -> None:
         """Reset failure counter."""
-        self.redis.hset(self._key, "counter", 0)
+        self.redis.hset(self._key, "counter", 0)  # type: ignore[arg-type]
 
     def increment_success_counter(self) -> None:
         """Increment success counter."""
@@ -64,25 +64,25 @@ class RedisCircuitBreakerStorage(pybreaker.CircuitBreakerStorage):
 
     def reset_success_counter(self) -> None:
         """Reset success counter."""
-        self.redis.hset(self._key, "success_counter", 0)
+        self.redis.hset(self._key, "success_counter", 0)  # type: ignore[arg-type]
 
     @property
     def counter(self) -> int:
         """Get failure counter."""
         val = self.redis.hget(self._key, "counter")
-        return int(val) if val else 0
+        return int(val) if val else 0  # type: ignore[arg-type]
 
     @property
     def success_counter(self) -> int:
         """Get success counter."""
         val = self.redis.hget(self._key, "success_counter")
-        return int(val) if val else 0
+        return int(val) if val else 0  # type: ignore[arg-type]
 
     @property
     def opened_at(self) -> datetime | None:
         """Get when circuit was opened."""
         val = self.redis.hget(self._key, "opened_at")
-        return datetime.fromisoformat(val) if val else None
+        return datetime.fromisoformat(val) if val else None  # type: ignore[arg-type]
 
     @opened_at.setter
     def opened_at(self, dt: datetime) -> None:


### PR DESCRIPTION
## Problem

mypy was running with `continue-on-error: true` in the `check-changelog` job (wrong job, wrong flag). This meant type errors were silently ignored and never blocked merges — which is how 6 type errors in `CircuitBreakerRedisStorage` got into develop undetected.

## Changes

- Move mypy into the `lint` job so failures block the `Code Quality` check gate
- Remove `continue-on-error: true`
- Remove the misplaced mypy step from `check-changelog`
- Fix the 6 pre-existing `type: ignore` annotations in `CircuitBreakerRedisStorage` (redis-py sync stubs return `Awaitable | str` but we're using sync Redis)

No functional changes.