### PR TITLE
feat(auth): device IP lockout and refactor user lockout to sorted-set

### DIFF
--- a/changes/2.feature.1.md
+++ b/changes/2.feature.1.md
@@ -1,0 +1,1 @@
+Device IP lockout: after 10 connection failures within 10 minutes, all access to that device is blocked for 10 minutes, preventing credential-spray abuse across multiple users. Also refactors the user lockout to use the same Redis sorted-set sliding-window implementation.

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -21,7 +21,7 @@ from naas.config import (
     REDIS_PASSWORD,
     REDIS_PORT,
 )
-from naas.library.auth import tacacs_auth_lockout
+from naas.library.auth import device_lockout, tacacs_auth_lockout
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -149,10 +149,13 @@ def netmiko_send_command(
             )
         except pybreaker.CircuitBreakerError:
             logger.warning("%s %s:Circuit breaker open, rejecting connection attempt", request_id, ip)
+            device_lockout(ip=ip, report_failure=True)
             return None, f"Circuit breaker open for device {ip} - too many recent failures"
         except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
+            device_lockout(ip=ip, report_failure=True)
             return None, str(e)
         except (ssh_exception.SSHException, ValueError) as e:
+            device_lockout(ip=ip, report_failure=True)
             return None, f"Unknown SSH error connecting to device {ip}: {str(e)}"
     else:
         return _netmiko_send_command_impl(
@@ -256,10 +259,13 @@ def netmiko_send_config(
             )
         except pybreaker.CircuitBreakerError:
             logger.warning("%s %s:Circuit breaker open, rejecting connection attempt", request_id, ip)
+            device_lockout(ip=ip, report_failure=True)
             return None, f"Circuit breaker open for device {ip} - too many recent failures"
         except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
+            device_lockout(ip=ip, report_failure=True)
             return None, str(e)
         except (ssh_exception.SSHException, ValueError) as e:
+            device_lockout(ip=ip, report_failure=True)
             return None, f"Unknown SSH error connecting to device {ip}: {str(e)}"
     else:
         return _netmiko_send_config_impl(

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -6,8 +6,9 @@ from spectree import Response
 
 from naas import __base_response__
 from naas.config import JOB_TTL_FAILED, JOB_TTL_SUCCESS
-from naas.library.auth import job_locker
+from naas.library.auth import device_lockout, job_locker
 from naas.library.decorators import valid_post
+from naas.library.errorhandlers import LockedOut
 from naas.library.netmiko_lib import netmiko_send_command
 from naas.models import JobResponse, SendCommandRequest
 from naas.spec import spec
@@ -37,6 +38,10 @@ class SendCommand(Resource):
         """
         validated: SendCommandRequest = request.context.json
         ip_str = str(validated.ip)
+
+        if device_lockout(ip=ip_str):
+            current_app.logger.error("%s: Device %s is locked out", g.request_id, ip_str)
+            raise LockedOut
 
         # Log this request's details
         current_app.logger.info(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,12 @@
+"""Unit test configuration and shared fixtures."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_device_lockout(monkeypatch):
+    """Prevent device_lockout from connecting to Redis in unit tests."""
+    monkeypatch.setattr("naas.library.auth.device_lockout", lambda **kwargs: False)
+    monkeypatch.setattr("naas.library.netmiko_lib.device_lockout", lambda **kwargs: False)
+    monkeypatch.setattr("naas.resources.send_command.device_lockout", lambda **kwargs: False)
+    monkeypatch.setattr("naas.resources.send_config.device_lockout", lambda **kwargs: False)

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -58,6 +58,21 @@ class TestSendCommand:
 
         assert response.status_code == 401
 
+    def test_send_command_device_locked_out(self, client):
+        """Test that a locked-out device returns 403."""
+        from base64 import b64encode
+        from unittest.mock import patch
+
+        auth = b64encode(b"testuser:testpass").decode()
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            with patch("naas.resources.send_command.device_lockout", return_value=True):
+                response = client.post(
+                    "/v1/send_command",
+                    json={"ip": "192.168.1.1", "commands": ["show version"]},
+                    headers={"Authorization": f"Basic {auth}"},
+                )
+        assert response.status_code == 403
+
     def test_send_command_invalid_ip(self, app, client):
         """Test POST with invalid IP returns 422."""
         auth = b64encode(b"testuser:testpass").decode()
@@ -322,6 +337,21 @@ class TestSendConfig:
         )
 
         assert response.status_code == 401
+
+    def test_send_config_device_locked_out(self, client):
+        """Test that a locked-out device returns 403."""
+        from base64 import b64encode
+        from unittest.mock import patch
+
+        auth = b64encode(b"testuser:testpass").decode()
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            with patch("naas.resources.send_config.device_lockout", return_value=True):
+                response = client.post(
+                    "/v1/send_config",
+                    json={"ip": "192.168.1.1", "commands": ["interface gi0/1"]},
+                    headers={"Authorization": f"Basic {auth}"},
+                )
+        assert response.status_code == 403
 
 
 class TestGetResults:


### PR DESCRIPTION
Implements #2 (child of #93).

## Changes

**Device lockout:** After 10 connection failures within 10 minutes, all access to that device is blocked — preventing credential-spray abuse where different users hammer the same device.

**Lockout refactor:** Replaced the ~80-line pickle-based hash implementation with a 5-line Redis sorted-set sliding window. Same policy (10 failures / 10 min), dramatically simpler code.

- `_is_locked_out(key, redis, report_failure)` — generic helper using `ZADD`/`ZREMRANGEBYSCORE`/`ZCARD`
- `tacacs_auth_lockout` and `device_lockout` are thin wrappers
- Device lockout checked in `send_command` and `send_config` before enqueueing (returns 403)
- Device failures reported from `netmiko_lib` on circuit breaker trip, timeout, and SSH errors
- `tests/unit/conftest.py` autouse fixture prevents Redis connections in unit tests

117 tests, 100% coverage, mypy clean.

Closes #2