### PR TITLE
feat(jobs): retry with exponential backoff on transient failures

### DIFF
--- a/changes/97.feature.md
+++ b/changes/97.feature.md
@@ -1,0 +1,1 @@
+Failed jobs now automatically retry with exponential backoff (1s, 2s, 4s, 8s, 16s). Retry count is configurable via `JOB_MAX_RETRIES` env var (default: 3). Auth failures are not retried. Failed job results now include error detail in the API response.

--- a/naas/config.py
+++ b/naas/config.py
@@ -27,6 +27,7 @@ REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "mah_redis_pw")
 # Job TTL config (seconds)
 JOB_TTL_SUCCESS = int(os.environ.get("JOB_TTL_SUCCESS", 86400))  # 24h
 JOB_TTL_FAILED = int(os.environ.get("JOB_TTL_FAILED", 604800))  # 7 days
+JOB_MAX_RETRIES = int(os.environ.get("JOB_MAX_RETRIES", 3))
 
 # Circuit breaker config
 CIRCUIT_BREAKER_ENABLED = os.environ.get("CIRCUIT_BREAKER_ENABLED", "true").lower() == "true"

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -151,12 +151,12 @@ def netmiko_send_command(
             logger.warning("%s %s:Circuit breaker open, rejecting connection attempt", request_id, ip)
             device_lockout(ip=ip, report_failure=True)
             return None, f"Circuit breaker open for device {ip} - too many recent failures"
-        except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
+        except (TimeoutError, netmiko.NetMikoTimeoutException):
             device_lockout(ip=ip, report_failure=True)
-            return None, str(e)
-        except (ssh_exception.SSHException, ValueError) as e:
+            raise
+        except (ssh_exception.SSHException, ValueError):
             device_lockout(ip=ip, report_failure=True)
-            return None, f"Unknown SSH error connecting to device {ip}: {str(e)}"
+            raise
     else:
         return _netmiko_send_command_impl(
             ip, credentials, device_type, commands, port, delay_factor, verbose, request_id
@@ -261,12 +261,12 @@ def netmiko_send_config(
             logger.warning("%s %s:Circuit breaker open, rejecting connection attempt", request_id, ip)
             device_lockout(ip=ip, report_failure=True)
             return None, f"Circuit breaker open for device {ip} - too many recent failures"
-        except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
+        except (TimeoutError, netmiko.NetMikoTimeoutException):
             device_lockout(ip=ip, report_failure=True)
-            return None, str(e)
-        except (ssh_exception.SSHException, ValueError) as e:
+            raise
+        except (ssh_exception.SSHException, ValueError):
             device_lockout(ip=ip, report_failure=True)
-            return None, f"Unknown SSH error connecting to device {ip}: {str(e)}"
+            raise
     else:
         return _netmiko_send_config_impl(
             ip, credentials, device_type, commands, port, save_config, commit, delay_factor, verbose, request_id

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -52,6 +52,8 @@ class GetResults(Resource):
             results = job.result
             r["results"] = results[0]
             r["error"] = results[1]
+        elif job_status == "failed":
+            r["error"] = str(job.exc_info).strip() if job.exc_info else "Job failed"
 
         r.update(__base_response__)
         return r

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -2,10 +2,11 @@
 
 from flask import current_app, g, request
 from flask_restful import Resource
+from rq import Retry
 from spectree import Response
 
 from naas import __base_response__
-from naas.config import JOB_TTL_FAILED, JOB_TTL_SUCCESS
+from naas.config import JOB_MAX_RETRIES, JOB_TTL_FAILED, JOB_TTL_SUCCESS
 from naas.library.auth import device_lockout, job_locker
 from naas.library.decorators import valid_post
 from naas.library.errorhandlers import LockedOut
@@ -81,6 +82,7 @@ class SendCommand(Resource):
             job_id=g.request_id,
             result_ttl=JOB_TTL_SUCCESS,
             failure_ttl=JOB_TTL_FAILED,
+            retry=Retry(max=JOB_MAX_RETRIES, interval=[1, 2, 4, 8, 16]),
         )
         job_id = job.get_id()
         current_app.logger.info("%s: Enqueued job for %s@%s:%s", job_id, g.credentials.username, ip_str, validated.port)


### PR DESCRIPTION
Implements #97 (child of #93).

## Changes

**Retry policy:** Jobs now retry on transient failures (timeout, SSH errors) with exponential backoff. Auth failures and circuit-breaker-open responses are not retried — they're not transient.

- `JOB_MAX_RETRIES` env var (default: 3)
- Backoff intervals: 1s, 2s, 4s, 8s, 16s (via RQ's native `Retry`)
- Re-raise timeout/SSH errors from outer wrapper so RQ retry triggers
- Circuit breaker open → still returns `(None, error)` (no retry — device is known-bad)
- Auth failures → still returns `(None, error)` (no retry — not transient)

**Failed job error detail:** `GET /v1/send_command/{job_id}` now includes `error` field when `status == "failed"`, surfacing the exception info for observability.

**Test fixes:** Circuit breaker tests now use per-test isolated circuit breakers via a monkeypatched `_get_circuit_breaker`. Also fixed off-by-one: breaker opens on the Nth call (not N+1).

118 tests, 100% coverage, mypy clean.

Closes #97