### PR TITLE
fix(api): surface error detail for failed jobs in GetResults

### DIFF
--- a/changes/+failed-job-error.bugfix.md
+++ b/changes/+failed-job-error.bugfix.md
@@ -1,0 +1,1 @@
+Failed jobs now include error detail in the API response. Previously `GET /v1/send_command/{job_id}` returned no error information when a job had status `failed`.

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -52,6 +52,8 @@ class GetResults(Resource):
             results = job.result
             r["results"] = results[0]
             r["error"] = results[1]
+        elif job_status == "failed":
+            r["error"] = str(job.exc_info).strip() if job.exc_info else "Job failed"
 
         r.update(__base_response__)
         return r


### PR DESCRIPTION
Small standalone fix salvaged from the closed retry PR (#142).

Previously `GET /v1/send_command/{job_id}` with `status: failed` returned no error information — the `error` field was always `null`. Now includes `job.exc_info` so callers know why the job failed.

118 tests, 100% coverage.