### PR TITLE
ci: restore RTD link checking with temporary ignore until develop build configured

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ PRs are merged via squash or rebase — no merge commits.
 
 ## Full development reference
 
-See the [Development Guide](docs/development.md) for:
+See the [Development Guide](https://naas.readthedocs.io/en/latest/development/) for:
 
 - Branching strategy and hotfix workflow
 - Commit message conventions


### PR DESCRIPTION
Fixes the state left by #149.

- Restore `naas.readthedocs.io` RTD link in `CONTRIBUTING.md` (correct canonical URL)
- Add temporary ignore pattern in `.markdown-link-check.json` so link checker doesn't fail on pages that don't exist until RTD builds `develop` branch
- Track RTD develop build setup in #150 — once that's live, the ignore pattern can be removed

See #150 for the follow-on work.