### PR TITLE
ci: point CONTRIBUTING.md at /en/develop/ RTD build, restore full link checking

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,9 +5,6 @@
     },
     {
       "pattern": "^https://127.0.0.1"
-    },
-    {
-      "pattern": "^https://naas.readthedocs.io"
     }
   ],
   "timeout": "20s",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ PRs are merged via squash or rebase — no merge commits.
 
 ## Full development reference
 
-See the [Development Guide](https://naas.readthedocs.io/en/latest/development/) for:
+See the [Development Guide](https://naas.readthedocs.io/en/develop/development/) for:
 
 - Branching strategy and hotfix workflow
 - Commit message conventions

--- a/changes/150.doc.md
+++ b/changes/150.doc.md
@@ -1,0 +1,1 @@
+Configure Read the Docs to build the develop branch, making bleeding-edge documentation available at naas.readthedocs.io/en/develop/.


### PR DESCRIPTION
Closes #150.

- `CONTRIBUTING.md` now links to `/en/develop/development/` — correct for contributor-facing file, always reflects current `develop` branch docs
- Remove `naas.readthedocs.io` ignore pattern from `.markdown-link-check.json` — RTD `develop` build is live so all RTD links are now checkable by CI