### PR TITLE
docs: fix security.md phantom TLS environment variables

### DIFF
--- a/changes/145.doc.md
+++ b/changes/145.doc.md
@@ -1,0 +1,1 @@
+Fix security.md to remove phantom TLS_MIN_VERSION and TLS_CIPHERS environment variables. Document actual TLS behavior: hardcoded secure defaults (TLS 1.2+, HIGH cipher suite) configured in Gunicorn.


### PR DESCRIPTION
Closes #145.

`TLS_MIN_VERSION` and `TLS_CIPHERS` don't exist — TLS version and cipher suite are hardcoded in `gunicorn.py` (`ssl_version=5` = TLS 1.2+, `ciphers=HIGH:!aNULL:...`). Replaced the phantom docker-compose example with accurate documentation of the actual behavior. Also fixed the certificate rotation example to include `NAAS_CA_BUNDLE`.