### PR TITLE
chore: audit and fix all lint/type-checking exemptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
-        additional_dependencies: [types-redis, types-PyYAML]
+        additional_dependencies: [types-redis, types-PyYAML, types-paramiko]
         exclude: ^tests/integration/
 
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/changes/154.internal.md
+++ b/changes/154.internal.md
@@ -1,0 +1,1 @@
+Audit and fix all lint/type-checking exemptions: add types-paramiko stubs, fix hset int->str args, remove dead auth guard in get_results, add inline justification for all remaining ignores.

--- a/naas/library/auth.py
+++ b/naas/library/auth.py
@@ -63,7 +63,7 @@ def _is_locked_out(redis_key: str, redis: Redis, report_failure: bool = False) -
     if report_failure:
         redis.zadd(redis_key, {str(uuid4()): datetime.now().timestamp()})
         redis.expire(redis_key, 600)
-    return int(redis.zcard(redis_key)) >= 10  # type: ignore[arg-type]
+    return redis.zcard(redis_key) >= 10  # type: ignore[operator]  # redis stubs type zcard as Awaitable[Any]|Any; sync client always returns int
 
 
 def tacacs_auth_lockout(username: str, report_failure: bool = False) -> bool:

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 import netmiko
 import pybreaker
-from paramiko import ssh_exception  # type: ignore[import-untyped]
+from paramiko import ssh_exception
 from redis import Redis
 
 from naas.config import (
@@ -43,7 +43,7 @@ class RedisCircuitBreakerStorage(pybreaker.CircuitBreakerStorage):
     @property
     def state(self) -> str:
         """Get current circuit state."""
-        return self.redis.hget(self._key, "state") or "closed"  # type: ignore[return-value]
+        return self.redis.hget(self._key, "state") or "closed"  # type: ignore[return-value]  # redis stubs type hget as Awaitable[str|None]|str; sync client always returns str|None
 
     @state.setter
     def state(self, state: str) -> None:
@@ -56,7 +56,7 @@ class RedisCircuitBreakerStorage(pybreaker.CircuitBreakerStorage):
 
     def reset_counter(self) -> None:
         """Reset failure counter."""
-        self.redis.hset(self._key, "counter", 0)  # type: ignore[arg-type]
+        self.redis.hset(self._key, "counter", str(0))
 
     def increment_success_counter(self) -> None:
         """Increment success counter."""
@@ -64,25 +64,25 @@ class RedisCircuitBreakerStorage(pybreaker.CircuitBreakerStorage):
 
     def reset_success_counter(self) -> None:
         """Reset success counter."""
-        self.redis.hset(self._key, "success_counter", 0)  # type: ignore[arg-type]
+        self.redis.hset(self._key, "success_counter", str(0))
 
     @property
     def counter(self) -> int:
         """Get failure counter."""
         val = self.redis.hget(self._key, "counter")
-        return int(val) if val else 0  # type: ignore[arg-type]
+        return int(val) if val else 0  # type: ignore[arg-type]  # redis stubs type hget as Awaitable[str|None]|str; sync client always returns str|None
 
     @property
     def success_counter(self) -> int:
         """Get success counter."""
         val = self.redis.hget(self._key, "success_counter")
-        return int(val) if val else 0  # type: ignore[arg-type]
+        return int(val) if val else 0  # type: ignore[arg-type]  # redis stubs type hget as Awaitable[str|None]|str; sync client always returns str|None
 
     @property
     def opened_at(self) -> datetime | None:
         """Get when circuit was opened."""
         val = self.redis.hget(self._key, "opened_at")
-        return datetime.fromisoformat(val) if val else None  # type: ignore[arg-type]
+        return datetime.fromisoformat(val) if val else None  # type: ignore[arg-type]  # redis stubs type hget as Awaitable[str|None]|str; sync client always returns str|None
 
     @opened_at.setter
     def opened_at(self, dt: datetime) -> None:
@@ -136,7 +136,7 @@ def netmiko_send_command(
     if CIRCUIT_BREAKER_ENABLED:
         breaker = _get_circuit_breaker(ip)
         try:
-            return breaker.call(  # type: ignore[no-any-return]
+            return breaker.call(  # type: ignore[no-any-return]  # pybreaker.call() returns Any; no stubs available
                 _netmiko_send_command_impl,
                 ip,
                 credentials,
@@ -244,7 +244,7 @@ def netmiko_send_config(
     if CIRCUIT_BREAKER_ENABLED:
         breaker = _get_circuit_breaker(ip)
         try:
-            return breaker.call(  # type: ignore[no-any-return]
+            return breaker.call(  # type: ignore[no-any-return]  # pybreaker.call() returns Any; no stubs available
                 _netmiko_send_config_impl,
                 ip,
                 credentials,

--- a/naas/library/selfsigned.py
+++ b/naas/library/selfsigned.py
@@ -62,14 +62,14 @@ def generate_selfsigned_cert(
     # Allow addressing by IP, for when you don't have real DNS (common in most testing scenarios)
     if public_ip is not None:
         # openssl wants DNSnames for ips...
-        alt_names_list.append(x509.DNSName(str(public_ip)))  # type: ignore[arg-type]
+        alt_names_list.append(x509.DNSName(str(public_ip)))
         # ... whereas golang's crypto/tls is stricter, and needs IPAddresses
-        alt_names_list.append(x509.IPAddress(public_ip))  # type: ignore[arg-type]
+        alt_names_list.append(x509.IPAddress(public_ip))  # type: ignore[arg-type]  # cryptography stubs type alt_names_list as list[DNSName]; SubjectAlternativeName accepts both
     if private_ip is not None:
         # openssl wants DNSnames for ips...
-        alt_names_list.append(x509.DNSName(str(private_ip)))  # type: ignore[arg-type]
+        alt_names_list.append(x509.DNSName(str(private_ip)))
         # ... whereas golang's crypto/tls is stricter, and needs IPAddresses
-        alt_names_list.append(x509.IPAddress(private_ip))  # type: ignore[arg-type]
+        alt_names_list.append(x509.IPAddress(private_ip))  # type: ignore[arg-type]  # cryptography stubs type alt_names_list as list[DNSName]; SubjectAlternativeName accepts both
 
     alt_names = x509.SubjectAlternativeName(alt_names_list)
 

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -26,8 +26,7 @@ class GetResults(Resource):
 
         # Ensure this user can access the job...
         auth = request.authorization
-        if not auth or not auth.username or not auth.password:  # pragma: no cover
-            raise Forbidden
+        assert auth and auth.username and auth.password  # guaranteed by v.has_auth() above
 
         # Create a credentials object
         creds = Credentials(username=auth.username, password=auth.password)

--- a/naas/spec.py
+++ b/naas/spec.py
@@ -12,7 +12,7 @@ spec = SpecTree(
     security_schemes=[
         SecurityScheme(
             name="basicAuth",
-            data=SecuritySchemeData(type=SecureType.HTTP, scheme="basic"),  # type: ignore[call-arg]
+            data=SecuritySchemeData(type=SecureType.HTTP, scheme="basic"),  # type: ignore[call-arg]  # spectree stubs incorrectly mark all SecuritySchemeData fields as required; they have defaults
         )
     ],
     security=[{"basicAuth": []}],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,4 +150,5 @@ showcontent = false
 dev = [
     "mkdocs-material>=9.7.2",
     "mkdocstrings[python]>=1.0.3",
+    "types-paramiko>=4.0.0.20250822",
 ]

--- a/tests/unit/test_netmiko_lib.py
+++ b/tests/unit/test_netmiko_lib.py
@@ -4,15 +4,16 @@ from unittest.mock import MagicMock, patch
 
 import netmiko
 from fakeredis import FakeStrictRedis
-from paramiko import ssh_exception  # type: ignore[import-untyped]
+from paramiko import ssh_exception
 
-# Import module first, then replace Redis client
+# Must import the module first and patch _redis_client before importing the functions,
+# otherwise the module-level Redis client is initialized before fakeredis is injected.
 import naas.library.netmiko_lib
 from naas.library.auth import Credentials
 
 naas.library.netmiko_lib._redis_client = FakeStrictRedis(decode_responses=True)
 
-from naas.library.netmiko_lib import netmiko_send_command, netmiko_send_config  # noqa: E402
+from naas.library.netmiko_lib import netmiko_send_command, netmiko_send_config  # noqa: E402,I001  # must follow _redis_client patch above
 
 
 class TestNetmikoSendCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1161,6 +1161,7 @@ dev = [
 dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "types-paramiko" },
 ]
 
 [package.metadata]
@@ -1202,6 +1203,7 @@ provides-extras = ["dev"]
 dev = [
     { name = "mkdocs-material", specifier = ">=9.7.2" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
+    { name = "types-paramiko", specifier = ">=4.0.0.20250822" },
 ]
 
 [[package]]
@@ -1981,6 +1983,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-paramiko"
+version = "4.0.0.20250822"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/b8/c6ff3b10c2f7b9897650af746f0dc6c5cddf054db857bc79d621f53c7d22/types_paramiko-4.0.0.20250822.tar.gz", hash = "sha256:1b56b0cbd3eec3d2fd123c9eb2704e612b777e15a17705a804279ea6525e0c53", size = 28730, upload-time = "2025-08-22T03:03:43.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/a1/b3774ed924a66ee2c041224d89c36f0c21f4f6cf75036d6ee7698bf8a4b9/types_paramiko-4.0.0.20250822-py3-none-any.whl", hash = "sha256:55bdb14db75ca89039725ec64ae3fa26b8d57b6991cfb476212fa8f83a59753c", size = 38833, upload-time = "2025-08-22T03:03:42.072Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #154.

**Genuine fixes (wrong code):**
- `hset` calls passing `int` instead of `str` — fixed with `str(0)`
- Dead auth guard in `get_results.py` — unreachable after `has_auth()`, removed and replaced with `assert` for mypy narrowing
- `int(redis.zcard(...))` — redundant cast removed

**New stubs (removes ignores entirely):**
- Add `types-paramiko` to dev deps and pre-commit mypy hook — drops `type: ignore[import-untyped]` from `netmiko_lib.py` and `test_netmiko_lib.py`

**Legitimate ignores (kept, now with inline justification):**
- redis stubs type `hget`/`zcard` as `Awaitable[T]|T` — sync client always returns `T`
- `pybreaker.call()` returns `Any` — no stubs available
- spectree `SecuritySchemeData` stubs mark optional fields as required
- cryptography `list[DNSName]` too narrow — `SubjectAlternativeName` accepts both `DNSName` and `IPAddress`

**noqa:**
- `E402,I001` on out-of-order test import — must follow `_redis_client` patch; comment explains why