### PR TITLE
chore: bump version to 1.1.0rc1

### DIFF
--- a/.kiro/agents/naas-dev-prompt.md
+++ b/.kiro/agents/naas-dev-prompt.md
@@ -268,9 +268,9 @@ chore(deps): upgrade netmiko to 4.6.0
 
 ### Current State
 
-- **Version:** v1.0.0 released, develop at v1.1.0a1
+- **Version:** v1.0.0 released, v1.1.0rc1 on release/1.1, develop at v1.1.0a1
 - **Active branches:** main, develop, release/1.0, release/1.1
-- **Milestone:** v1.1 (30+ issues planned)
+- **Milestone:** v1.2 (next development cycle)
 
 ### Key Technologies
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.1.0a1"
+version = "1.1.0rc1"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Triggers the release workflow to build changelog (keeping fragments), create tag `v1.1.0rc1`, and publish GitHub pre-release.