### PR TITLE
fix(api): replace assert with explicit raise in get_results auth guard

### DIFF
--- a/changes/159.bugfix.1.md
+++ b/changes/159.bugfix.1.md
@@ -1,0 +1,1 @@
+Fix auth guard in get_results.py to use explicit raise instead of assert (assert is stripped by python -O)

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -26,7 +26,10 @@ class GetResults(Resource):
 
         # Ensure this user can access the job...
         auth = request.authorization
-        assert auth and auth.username and auth.password  # guaranteed by v.has_auth() above
+        if (
+            not auth or not auth.username or not auth.password
+        ):  # pragma: no cover  # has_auth() in valid_get guarantees this; guard exists because assert is stripped by python -O
+            raise Forbidden
 
         # Create a credentials object
         creds = Credentials(username=auth.username, password=auth.password)

--- a/uv.lock
+++ b/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.1.0a1"
+version = "1.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Closes #159.

`assert` is stripped by `python -O`. The guard is unreachable in normal flow (`has_auth()` in the decorator guarantees auth is present) but must exist as a proper conditional for correctness under optimized mode. `pragma: no cover` retained with justification comment.