### PR TITLE
fix(api): paginate list_jobs unfiltered path per-registry

### DIFF
--- a/changes/160.bugfix.md
+++ b/changes/160.bugfix.md
@@ -1,0 +1,1 @@
+Fix list_jobs unfiltered path to paginate per-registry instead of fetching all job IDs into memory; fix total_count to use registry.count rather than len of fetched IDs

--- a/tests/unit/test_list_jobs.py
+++ b/tests/unit/test_list_jobs.py
@@ -28,14 +28,17 @@ class TestListJobs:
         ):
             # Setup mock registries
             mock_finished_inst = MagicMock()
+            mock_finished_inst.count = 2
             mock_finished_inst.get_job_ids.return_value = ["job1", "job2"]
             mock_finished.return_value = mock_finished_inst
 
             mock_failed_inst = MagicMock()
+            mock_failed_inst.count = 0
             mock_failed_inst.get_job_ids.return_value = []
             mock_failed.return_value = mock_failed_inst
 
             mock_started_inst = MagicMock()
+            mock_started_inst.count = 0
             mock_started_inst.get_job_ids.return_value = []
             mock_started.return_value = mock_started_inst
 
@@ -99,14 +102,17 @@ class TestListJobs:
         ):
             # Setup mock registries
             mock_finished_inst = MagicMock()
+            mock_finished_inst.count = 0
             mock_finished_inst.get_job_ids.return_value = []
             mock_finished.return_value = mock_finished_inst
 
             mock_failed_inst = MagicMock()
+            mock_failed_inst.count = 0
             mock_failed_inst.get_job_ids.return_value = []
             mock_failed.return_value = mock_failed_inst
 
             mock_started_inst = MagicMock()
+            mock_started_inst.count = 0
             mock_started_inst.get_job_ids.return_value = []
             mock_started.return_value = mock_started_inst
 
@@ -218,3 +224,91 @@ class TestListJobs:
         assert response.status_code == 200
         data = response.json
         assert data["pagination"]["total"] == 4
+
+    def test_list_jobs_unfiltered_stops_early(self, app, client):
+        """Unfiltered pagination: stops iterating sources once per_page is satisfied."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_finished,
+            patch("naas.resources.list_jobs.FailedJobRegistry") as mock_failed,
+            patch("naas.resources.list_jobs.StartedJobRegistry") as mock_started,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            mock_finished_inst = MagicMock()
+            mock_finished_inst.count = 1
+            mock_finished_inst.get_job_ids.return_value = ["job1"]
+            mock_finished.return_value = mock_finished_inst
+
+            mock_failed_inst = MagicMock()
+            mock_failed_inst.count = 1
+            mock_failed_inst.get_job_ids.return_value = ["job2"]
+            mock_failed.return_value = mock_failed_inst
+
+            mock_started_inst = MagicMock()
+            mock_started_inst.count = 0
+            mock_started_inst.get_job_ids.return_value = []
+            mock_started.return_value = mock_started_inst
+
+            app.config["q"].__len__ = MagicMock(return_value=0)
+            app.config["q"].get_job_ids = MagicMock(return_value=[])
+
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job1"
+            mock_job.get_status.return_value = "finished"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = datetime(2026, 2, 23, 12, 0, 5)
+            mock_job_fetch.return_value = mock_job
+
+            # per_page=1 means finished fills the page; failed registry should not be fetched
+            response = client.get("/v1/jobs?per_page=1", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["total"] == 2
+        assert len(data["jobs"]) == 1
+        mock_failed_inst.get_job_ids.assert_not_called()
+        """Unfiltered pagination: page 2 skips finished registry and pulls from queue."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        with (
+            patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_finished,
+            patch("naas.resources.list_jobs.FailedJobRegistry") as mock_failed,
+            patch("naas.resources.list_jobs.StartedJobRegistry") as mock_started,
+            patch("naas.resources.list_jobs.Job.fetch") as mock_job_fetch,
+        ):
+            mock_finished_inst = MagicMock()
+            mock_finished_inst.count = 1  # page 2 skips this entirely
+            mock_finished_inst.get_job_ids.return_value = []
+            mock_finished.return_value = mock_finished_inst
+
+            mock_failed_inst = MagicMock()
+            mock_failed_inst.count = 0
+            mock_failed_inst.get_job_ids.return_value = []
+            mock_failed.return_value = mock_failed_inst
+
+            mock_started_inst = MagicMock()
+            mock_started_inst.count = 0
+            mock_started_inst.get_job_ids.return_value = []
+            mock_started.return_value = mock_started_inst
+
+            # Queue has the job for page 2
+            app.config["q"].__len__ = MagicMock(return_value=1)
+            app.config["q"].get_job_ids = MagicMock(return_value=["job2"])
+
+            mock_job = MagicMock(spec=Job)
+            mock_job.id = "job2"
+            mock_job.get_status.return_value = "queued"
+            mock_job.created_at = datetime(2026, 2, 23, 12, 0, 0)
+            mock_job.ended_at = None
+            mock_job_fetch.return_value = mock_job
+
+            response = client.get("/v1/jobs?page=2&per_page=1", headers={"Authorization": f"Basic {auth}"})
+
+        assert response.status_code == 200
+        data = response.json
+        assert data["pagination"]["total"] == 2  # 1 finished + 1 queued
+        assert len(data["jobs"]) == 1
+        assert data["jobs"][0]["job_id"] == "job2"
+        # Verify queue was called (is_queue branch) and finished registry was skipped
+        app.config["q"].get_job_ids.assert_called_once_with(offset=0, length=1)

--- a/uv.lock
+++ b/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.1.0a1"
+version = "1.1.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Closes #160.

Previously the unfiltered path called `get_job_ids()` with no args on all registries, loading every job ID into memory before slicing in Python. On a busy instance this could be thousands of IDs.

Now walks registries in order using `start`/`end` args, stopping as soon as `per_page` is satisfied. `total_count` now sums `registry.count` values rather than `len` of the fetched slice.