### PR TITLE
refactor: remove dead validation methods from Validate class

### DIFF
--- a/changes/162.internal.md
+++ b/changes/162.internal.md
@@ -1,0 +1,1 @@
+Remove dead validation methods from Validate class (has_port, is_ip_addr, save_config, commit, is_command_set, has_platform, has_delay_factor) — Pydantic models in models.py handle all request validation now

--- a/naas/library/validation.py
+++ b/naas/library/validation.py
@@ -2,52 +2,36 @@
 # -*- coding: UTF-8 -*-
 
 
-import ipaddress
 from uuid import UUID
 
 from flask import current_app, request
-from werkzeug.exceptions import BadRequest, UnprocessableEntity
+from werkzeug.exceptions import BadRequest
 
 from naas.library.auth import tacacs_auth_lockout
-from naas.library.errorhandlers import DuplicateRequestID, InvalidIP, LockedOut, NoAuth, NoJSON
+from naas.library.errorhandlers import DuplicateRequestID, LockedOut, NoAuth, NoJSON
 
 
 class Validate:
     """
-    This class contains many validation methods for ensuring we get correct/well formed requests.
+    This class contains validation methods for ensuring we get correct/well formed requests.
 
     This class can be accessed directly or via a decorator in the `naas.library.decorators` module.
-
-    It is not necessary (or possible) to use all validations on one request.
     """
 
     def __init__(self) -> None:
-        """
-        Initialize with some basic information hung on this object:
-        self.headers for HTTP header information of this request
-        self.method for the HTTP method of this request
-        :return:
-        """
-
         self.headers = {k.lower(): v for k, v in request.headers.items()}
         self.method = request.method
 
     @staticmethod
     def is_json() -> None:
-        """
-        Validate if the request is recognized as JSON
-        :return:
-        """
+        """Validate if the request is recognized as JSON."""
         if not request.json:
             current_app.logger.error("payload did not contain JSON")
             raise NoJSON
 
     @staticmethod
     def has_auth() -> None:
-        """
-        Ensure that the request has provided authorization headers (basic with username and password)
-        :return:
-        """
+        """Ensure that the request has provided authorization headers (basic with username and password)."""
         if (
             not request.authorization
             or request.authorization.username is None
@@ -58,46 +42,15 @@ class Validate:
 
     @staticmethod
     def locked_out() -> None:
-        """
-        Validate if this user is locked out from accessing the API
-        :return:
-        """
+        """Validate if this user is locked out from accessing the API."""
         if request.authorization and request.authorization.username:
             if tacacs_auth_lockout(username=request.authorization.username):
                 current_app.logger.error(f"{request.authorization.username} is currently locked out.")
                 raise LockedOut
 
     @staticmethod
-    def has_port() -> None:
-        """
-        If "port" is in payload, don't do anything, otherwise set it to 22
-        :return:
-        """
-        request.json.setdefault("port", 22)
-
-    @staticmethod
-    def is_ip_addr() -> None:
-        """
-        Validate that an IP address field is present in the request JSON and that it is a valid IPv4 address.
-        :return:
-        """
-        ip = request.json.get("ip", None)
-        if ip is None:
-            current_app.logger.error("no 'ip' field found in payload")
-            raise BadRequest
-        try:
-            ipaddress.ip_address(ip)
-        except ValueError:
-            current_app.logger.error("'ip' field in payload did not contain a valid IPv4 Address")
-            raise InvalidIP
-
-    @staticmethod
     def is_uuid(uuid: str) -> None:
-        """
-        Validate that a provided string is a version 4 UUID
-        :param uuid:
-        :return:
-        """
+        """Validate that a provided string is a version 4 UUID."""
         try:
             _ = UUID(uuid, version=4)
         except ValueError:
@@ -106,90 +59,6 @@ class Validate:
 
     @staticmethod
     def is_duplicate_job(job_id: str) -> None:
-        """
-        Validate there isn't already a job by this ID
-        :param job_id: str of a job_id to check
-        :return:
-        """
-
+        """Validate there isn't already a job by this ID."""
         if current_app.config["q"].fetch_job(job_id=job_id) is not None:
             raise DuplicateRequestID
-
-    @staticmethod
-    def save_config() -> None:
-        """
-        If "save_config" bool is in payload, don't do anything, otherwise set it to False
-        :return:
-        """
-        request.json.setdefault("save_config", False)
-
-        # If it _was_ set, but it ain't a bool, get outta here fool
-        if not isinstance(request.json["save_config"], bool):
-            current_app.logger.error("save_config must be a Boolean")
-            raise UnprocessableEntity
-
-    @staticmethod
-    def commit() -> None:
-        """
-        If "commit" bool is in payload, don't do anything, otherwise set it to False
-        :return:
-        """
-        request.json.setdefault("commit", False)
-
-        # If it _was_ set, but it ain't a bool, get outta here fool
-        if not isinstance(request.json["commit"], bool):
-            current_app.logger.error("commit must be a Boolean")
-            raise UnprocessableEntity
-
-    @staticmethod
-    def is_command_set() -> None:
-        """
-        Validate that the field `commands` exists in a request payload, and that it is a list.
-        :return:
-        """
-        if not request.json.get("commands"):
-            current_app.logger.error("'commands' field not found in payload")
-            raise BadRequest
-        if not isinstance(request.json["commands"], list):
-            current_app.logger.error("'commands' not provided in a list")
-            raise UnprocessableEntity
-
-    @staticmethod
-    def has_platform() -> None:
-        """
-        Validate that the field `platform` exists in a request payload (set it to `cisco_ios` by default)
-        and that it is a string if it did already exist.
-
-        Supports backward compatibility with deprecated `device_type` parameter.
-        :return:
-        """
-        # Backward compatibility: accept device_type and map to platform
-        if "device_type" in request.json:
-            current_app.logger.warning(
-                "Parameter 'device_type' is deprecated, use 'platform' instead. "
-                "Support for 'device_type' will be removed in v2.0"
-            )
-            if "platform" not in request.json:
-                request.json["platform"] = request.json["device_type"]
-
-        # Set default if neither provided
-        if not request.json.get("platform"):
-            request.json["platform"] = "cisco_ios"
-
-        # Validate type
-        if not isinstance(request.json["platform"], str):
-            current_app.logger.error("'platform' not provided as a string")
-            raise UnprocessableEntity
-
-    @staticmethod
-    def has_delay_factor() -> None:
-        """
-        Validate that the field `delay_factor` exists in a request payload (set it to `1` by default)
-        and that it is an int if it did already exist.
-        :return:
-        """
-        if not request.json.get("delay_factor"):
-            request.json["delay_factor"] = 1
-        if not isinstance(request.json["delay_factor"], int):
-            current_app.logger.error("'delay_factor not provided as an integer")
-            raise UnprocessableEntity


### PR DESCRIPTION
Closes #162.

`has_port`, `is_ip_addr`, `save_config`, `commit`, `is_command_set`, `has_platform`, and `has_delay_factor` are all unreachable — Pydantic models in `models.py` handle all request validation since v1.1. Also removes the duplicate `device_type` deprecation logic.

- `validation.py`: 197 → 63 lines
- `test_validation.py`: 298 → 107 lines (22 dead tests removed)