### PR TITLE
fix(api): catch RedisError specifically in healthcheck instead of bare Exception

### DIFF
--- a/changes/163.bugfix.md
+++ b/changes/163.bugfix.md
@@ -1,0 +1,1 @@
+Fix bare except Exception in healthcheck.py to catch redis.exceptions.RedisError specifically

--- a/naas/resources/healthcheck.py
+++ b/naas/resources/healthcheck.py
@@ -4,6 +4,7 @@ import time
 
 from flask import current_app
 from flask_restful import Resource
+from redis.exceptions import RedisError
 
 from naas import __version__
 
@@ -20,7 +21,7 @@ class HealthCheck(Resource):
         try:
             redis.ping()
             redis_status = "healthy"
-        except Exception:
+        except RedisError:
             redis_status = "unhealthy"
 
         overall = "healthy" if redis_status == "healthy" else "degraded"

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -40,7 +40,9 @@ class TestHealthCheck:
 
     def test_get_redis_unhealthy(self, app, client):
         """Healthcheck should return degraded when Redis is unreachable."""
-        with patch.object(app.config["redis"], "ping", side_effect=Exception("connection refused")):
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        with patch.object(app.config["redis"], "ping", side_effect=RedisConnectionError("connection refused")):
             response = client.get("/healthcheck")
         data = response.get_json()
         assert data["status"] == "degraded"


### PR DESCRIPTION
Closes #163.

Bare `except Exception` in `healthcheck.py` would swallow programming errors. Changed to `except redis.exceptions.RedisError` which covers all Redis connectivity failures without masking unrelated exceptions.