### PR TITLE
chore: bump version to 1.1.0rc2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.1.0rc1"
+version = "1.1.0rc2"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Triggers release workflow to build changelog (keeping fragments), tag v1.1.0rc2, and publish GitHub pre-release.

Changes since rc1: #159 (assert guard), #160 (list_jobs memory), #161/#164 (circuit breaker refactor), #162 (dead validation), #163 (healthcheck exception).