### PR TITLE
chore: bump version to 1.1.0rc3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.1.0rc2"
+version = "1.1.0rc3"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Validates towncrier template fix — release notes should now render with proper bullet point formatting.