### PR TITLE
chore: bump version to 1.1.0rc4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.1.0rc3"
+version = "1.1.0rc4"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Validates release notes extraction fix — should now show only the current version's changelog without old history.