### PR TITLE
chore: bump version to 1.1.0rc6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.1.0rc5"
+version = "1.1.0rc6"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.1.0rc5"
+version = "1.1.0rc6"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Validates improved release notes: correlation ID in Features, job.get_id() bugfix, internal changes with descriptions, uv.lock sync.