### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.1.0rc6"
+version = "1.1.0"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1118,7 +1118,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.1.0rc6"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Final release. Merging this triggers the release workflow to build and delete changelog fragments, tag v1.1.0, and publish the GitHub release.