### PR TITLE
feat(api): add DELETE /v1/jobs/{job_id} endpoint for job cancellation

### DIFF
--- a/changes/178.feature.md
+++ b/changes/178.feature.md
@@ -1,0 +1,1 @@
+Add DELETE endpoint for job cancellation

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -490,6 +490,26 @@
         "tags": []
       }
     },
+    "/v1/jobs/{job_id}": {
+      "delete": {
+        "description": "Args:     job_id: UUID of the job to cancel.\n\nReturns:     Empty response with 204 status on success.     404 if job not found.     403 if wrong credentials.     409 if job already finished or failed.",
+        "operationId": "delete__v1_jobs_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Cancel a job by job_id.",
+        "tags": []
+      }
+    },
     "/v1/send_command": {
       "get": {
         "description": "",

--- a/naas/app.py
+++ b/naas/app.py
@@ -18,6 +18,7 @@ from pythonjsonlogger.json import JsonFormatter
 
 from naas.config import app_configure
 from naas.library.errorhandlers import api_error_generator
+from naas.resources.cancel_job import CancelJob
 from naas.resources.get_results import GetResults
 from naas.resources.healthcheck import HealthCheck
 from naas.resources.list_jobs import ListJobs
@@ -75,6 +76,7 @@ api.add_resource(SendCommand, "/v1/send_command")
 api.add_resource(SendConfig, "/v1/send_config")
 api.add_resource(GetResults, "/v1/send_command/<string:job_id>", "/v1/send_config/<string:job_id>")
 api.add_resource(ListJobs, "/v1/jobs")
+api.add_resource(CancelJob, "/v1/jobs/<string:job_id>")
 
 # Legacy unversioned routes (deprecated aliases — kept for backward compatibility)
 _LEGACY_PREFIXES = ("/send_command", "/send_config")

--- a/naas/resources/cancel_job.py
+++ b/naas/resources/cancel_job.py
@@ -1,0 +1,54 @@
+"""API resource for job cancellation."""
+
+from flask import current_app, request
+from flask_restful import Resource
+from werkzeug.exceptions import Conflict, Forbidden
+
+from naas import __base_response__
+from naas.library.auth import Credentials, job_unlocker
+from naas.library.validation import Validate
+
+
+class CancelJob(Resource):
+    """Resource for cancelling jobs."""
+
+    @staticmethod
+    def delete(job_id: str):
+        """
+        Cancel a job by job_id.
+
+        Args:
+            job_id: UUID of the job to cancel.
+
+        Returns:
+            Empty response with 204 status on success.
+            404 if job not found.
+            403 if wrong credentials.
+            409 if job already finished or failed.
+        """
+        v = Validate()
+        v.is_uuid(uuid=job_id)
+        v.has_auth()
+
+        auth = request.authorization
+        if not auth or not auth.username or not auth.password:  # pragma: no cover
+            raise Forbidden
+
+        creds = Credentials(username=auth.username, password=auth.password)
+        if not job_unlocker(salted_creds=creds.salted_hash(), job_id=job_id):
+            raise Forbidden
+
+        q = current_app.config["q"]
+        job = q.fetch_job(job_id)
+
+        if job is None:
+            r = {"job_id": job_id, "status": "not_found"}
+            r.update(__base_response__)
+            return r, 404
+
+        job_status = job.get_status()
+        if job_status in ("finished", "failed"):
+            raise Conflict(f"Job {job_id} already {job_status}")
+
+        job.cancel()
+        return "", 204


### PR DESCRIPTION
Implements job cancellation endpoint as specified in issue #178.

## Changes
- Add `CancelJob` resource with DELETE method at `/v1/jobs/{job_id}`
- Support cancellation of queued and started jobs via RQ's `job.cancel()` method
- Return 204 on success, 404 if not found, 403 if wrong credentials, 409 if already finished/failed
- Enforce same credential hash check as GET endpoints (only submitter can cancel)
- Add comprehensive test coverage (100%)
- Update OpenAPI spec automatically via pre-commit hook

## Testing
- All existing tests pass
- Added 6 new tests covering success, not found, already finished, no auth, wrong user, and started job scenarios
- Maintained 100% code coverage

Closes #178