### PR TITLE
test(contract): accept no_workers status in healthcheck contract test

### DIFF
--- a/changes/+fix-contract-test.testing.md
+++ b/changes/+fix-contract-test.testing.md
@@ -1,0 +1,1 @@
+Fix contract test to accept no_workers healthcheck status

--- a/tests/contract/test_api_endpoints.py
+++ b/tests/contract/test_api_endpoints.py
@@ -58,7 +58,7 @@ class TestHealthcheck:
         assert "version" in data
         assert "uptime_seconds" in data
         assert "components" in data
-        assert data["status"] in ("healthy", "degraded")
+        assert data["status"] in ("healthy", "degraded", "no_workers")
         assert isinstance(data["version"], str)
 
 


### PR DESCRIPTION
Fixes contract test failure introduced by PR #182 which added the `no_workers` status to the healthcheck endpoint.

## Changes
- Update healthcheck contract test to accept `no_workers` as a valid status value alongside `healthy` and `degraded`

## Testing
- Contract tests now pass (19/19)
- All other tests unaffected

This unblocks PR #183 which was failing CI due to this test.