### PR TITLE
fix(security): include password hash in connection pool key (#196)

### DIFF
--- a/changes/196.bugfix.md
+++ b/changes/196.bugfix.md
@@ -1,0 +1,1 @@
+Fix connection pool key to include password hash, preventing credential sharing between users with the same username

--- a/naas/library/connection_pool.py
+++ b/naas/library/connection_pool.py
@@ -4,6 +4,7 @@ Per-process SSH connection pool for reusing Netmiko connections across jobs.
 Reduces VTY session overhead on network devices.
 """
 
+import hashlib
 import logging
 import time
 from dataclasses import dataclass, field
@@ -32,35 +33,61 @@ class ConnectionPool:
     """
     Per-process pool of reusable Netmiko SSH connections.
 
-    Pool key: (ip, port, username, platform) — connections are only reused
-    when credentials match exactly. RQ workers are single-threaded so no
-    locking is required within a process.
+    Pool key: (ip, port, sha512(username:password+salt), platform) — credentials
+    must match exactly. The salt is fetched from Redis at worker startup via
+    set_salt() and matches the salt used by Credentials.salted_hash() in the API.
+
+    RQ workers are single-threaded so no locking is required within a process.
     """
 
     def __init__(self) -> None:
         self._pool: dict[tuple, _PoolEntry] = {}
+        self._salt: str | None = None
+
+    def set_salt(self, salt: str) -> None:
+        """
+        Set the credential salt used for pool key hashing.
+        Must be called at worker startup before any jobs run.
+
+        Args:
+            salt: The naas_cred_salt value from Redis.
+        """
+        self._salt = salt
+
+    def _cred_hash(self, username: str, password: str) -> str | None:
+        """Return SHA512 hash of username:password+salt, or None if salt not set."""
+        if self._salt is None:
+            return None
+        return hashlib.sha512(f"{username}:{password}{self._salt}".encode()).hexdigest()
 
     def get(
         self,
         ip: str,
         port: int,
         username: str,
+        password: str,
         platform: str,
     ) -> "netmiko.BaseConnection | None":
         """
         Return a live pooled connection for the given key, or None if unavailable.
-        Evicts stale/dead entries on access.
+        Evicts stale/dead entries on access. Returns None if salt not yet set.
 
         Args:
             ip: Device IP address
             port: SSH port
             username: Device username
+            password: Device password
             platform: Netmiko device_type
 
         Returns:
             A live BaseConnection, or None if no valid pooled connection exists.
         """
-        key = (ip, port, username, platform)
+        cred_hash = self._cred_hash(username, password)
+        if cred_hash is None:
+            logger.debug("Pool skipping: salt not set")
+            return None
+
+        key = (ip, port, cred_hash, platform)
         entry = self._pool.get(key)
         if entry is None:
             return None
@@ -88,20 +115,31 @@ class ConnectionPool:
         ip: str,
         port: int,
         username: str,
+        password: str,
         platform: str,
         connection: "netmiko.BaseConnection",
     ) -> None:
         """
         Return a connection to the pool after successful use.
-        Discards if pool is at capacity.
+        Discards if pool is at capacity or salt not set.
 
         Args:
             ip: Device IP address
             port: SSH port
             username: Device username
+            password: Device password
             platform: Netmiko device_type
             connection: The connection to return
         """
+        cred_hash = self._cred_hash(username, password)
+        if cred_hash is None:
+            logger.debug("Pool skipping release: salt not set")
+            try:
+                connection.disconnect()
+            except Exception:
+                pass
+            return
+
         if len(self._pool) >= CONNECTION_POOL_MAX_SIZE:
             logger.debug("Pool at capacity (%d), discarding connection to %s:%s", CONNECTION_POOL_MAX_SIZE, ip, port)
             try:
@@ -110,7 +148,7 @@ class ConnectionPool:
                 pass
             return
 
-        key = (ip, port, username, platform)
+        key = (ip, port, cred_hash, platform)
         entry = self._pool.get(key)
         if entry is not None:
             entry.last_used = time.monotonic()

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -95,7 +95,7 @@ def _netmiko_send_command_impl(
         net_connect = None
 
         if CONNECTION_POOL_ENABLED:
-            net_connect = pool.get(ip, port, credentials.username, device_type)
+            net_connect = pool.get(ip, port, credentials.username, credentials.password, device_type)
 
         if net_connect is None:
             logger.debug("%s %s:Establishing connection...", request_id, ip)
@@ -108,7 +108,7 @@ def _netmiko_send_command_impl(
             net_output[command] = net_connect.send_command(command, delay_factor=delay_factor)
 
         if CONNECTION_POOL_ENABLED:
-            pool.release(ip, port, credentials.username, device_type, net_connect)
+            pool.release(ip, port, credentials.username, credentials.password, device_type, net_connect)
         else:
             net_connect.disconnect()
 

--- a/tests/unit/test_connection_pool.py
+++ b/tests/unit/test_connection_pool.py
@@ -6,9 +6,18 @@ import pytest
 
 from naas.library.connection_pool import ConnectionPool
 
+SALT = "testsalt"
+
 
 @pytest.fixture
 def pool():
+    p = ConnectionPool()
+    p.set_salt(SALT)
+    return p
+
+
+@pytest.fixture
+def pool_no_salt():
     return ConnectionPool()
 
 
@@ -19,47 +28,67 @@ def mock_conn():
     return conn
 
 
+class TestConnectionPoolSetSalt:
+    """Tests for ConnectionPool.set_salt()."""
+
+    def test_set_salt_enables_pooling(self, pool_no_salt, mock_conn):
+        """Pool returns None before salt is set, works after."""
+        assert pool_no_salt.get("1.2.3.4", 22, "user", "pass", "cisco_ios") is None
+        pool_no_salt.set_salt(SALT)
+        pool_no_salt.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        assert pool_no_salt.get("1.2.3.4", 22, "user", "pass", "cisco_ios") is mock_conn
+
+
 class TestConnectionPoolGet:
     """Tests for ConnectionPool.get()."""
 
     def test_get_miss_returns_none(self, pool):
         """Returns None when no pooled connection exists."""
-        assert pool.get("1.2.3.4", 22, "user", "cisco_ios") is None
+        assert pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios") is None
+
+    def test_get_no_salt_returns_none(self, pool_no_salt):
+        """Returns None when salt not set."""
+        assert pool_no_salt.get("1.2.3.4", 22, "user", "pass", "cisco_ios") is None
 
     def test_get_hit_returns_connection(self, pool, mock_conn):
         """Returns pooled connection on cache hit."""
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
-        result = pool.get("1.2.3.4", 22, "user", "cisco_ios")
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        result = pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios")
         assert result is mock_conn
 
     def test_get_evicts_dead_connection(self, pool, mock_conn):
         """Evicts and returns None when is_alive() is False."""
         mock_conn.is_alive.return_value = False
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
-        result = pool.get("1.2.3.4", 22, "user", "cisco_ios")
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        result = pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios")
         assert result is None
         mock_conn.disconnect.assert_called_once()
 
     def test_get_evicts_idle_connection(self, pool, mock_conn):
         """Evicts and returns None when idle timeout exceeded."""
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
         with patch("naas.library.connection_pool.CONNECTION_POOL_IDLE_TIMEOUT", 0):
-            result = pool.get("1.2.3.4", 22, "user", "cisco_ios")
+            result = pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios")
         assert result is None
         mock_conn.disconnect.assert_called_once()
 
     def test_get_evicts_aged_connection(self, pool, mock_conn):
         """Evicts and returns None when max age exceeded."""
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
         with patch("naas.library.connection_pool.CONNECTION_POOL_MAX_AGE", 0):
-            result = pool.get("1.2.3.4", 22, "user", "cisco_ios")
+            result = pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios")
         assert result is None
         mock_conn.disconnect.assert_called_once()
 
-    def test_get_key_includes_credentials(self, pool, mock_conn):
+    def test_get_key_includes_password(self, pool, mock_conn):
+        """Different passwords produce different pool keys."""
+        pool.release("1.2.3.4", 22, "user", "pass1", "cisco_ios", mock_conn)
+        assert pool.get("1.2.3.4", 22, "user", "pass2", "cisco_ios") is None
+
+    def test_get_key_includes_username(self, pool, mock_conn):
         """Different usernames produce different pool keys."""
-        pool.release("1.2.3.4", 22, "user1", "cisco_ios", mock_conn)
-        assert pool.get("1.2.3.4", 22, "user2", "cisco_ios") is None
+        pool.release("1.2.3.4", 22, "user1", "pass", "cisco_ios", mock_conn)
+        assert pool.get("1.2.3.4", 22, "user2", "pass", "cisco_ios") is None
 
 
 class TestConnectionPoolRelease:
@@ -67,8 +96,19 @@ class TestConnectionPoolRelease:
 
     def test_release_stores_connection(self, pool, mock_conn):
         """Connection is stored and retrievable after release."""
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
-        assert pool.get("1.2.3.4", 22, "user", "cisco_ios") is mock_conn
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        assert pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios") is mock_conn
+
+    def test_release_no_salt_disconnects(self, pool_no_salt, mock_conn):
+        """Disconnects and discards when salt not set."""
+        pool_no_salt.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        mock_conn.disconnect.assert_called_once()
+
+    def test_release_no_salt_handles_disconnect_error(self, pool_no_salt):
+        """Handles disconnect error gracefully when salt not set."""
+        conn = MagicMock()
+        conn.disconnect.side_effect = Exception("disconnect failed")
+        pool_no_salt.release("1.2.3.4", 22, "user", "pass", "cisco_ios", conn)  # Should not raise
 
     def test_release_at_capacity_disconnects(self, pool):
         """Discards and disconnects connection when pool is at capacity."""
@@ -76,8 +116,8 @@ class TestConnectionPoolRelease:
             conn1 = MagicMock()
             conn1.is_alive.return_value = True
             conn2 = MagicMock()
-            pool.release("1.2.3.4", 22, "user", "cisco_ios", conn1)
-            pool.release("1.2.3.5", 22, "user", "cisco_ios", conn2)
+            pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", conn1)
+            pool.release("1.2.3.5", 22, "user", "pass", "cisco_ios", conn2)
             conn2.disconnect.assert_called_once()
 
     def test_release_at_capacity_handles_disconnect_error(self, pool):
@@ -87,13 +127,13 @@ class TestConnectionPoolRelease:
             conn1.is_alive.return_value = True
             conn2 = MagicMock()
             conn2.disconnect.side_effect = Exception("disconnect failed")
-            pool.release("1.2.3.4", 22, "user", "cisco_ios", conn1)
-            pool.release("1.2.3.5", 22, "user", "cisco_ios", conn2)  # Should not raise
+            pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", conn1)
+            pool.release("1.2.3.5", 22, "user", "pass", "cisco_ios", conn2)  # Should not raise
 
     def test_release_updates_existing_entry(self, pool, mock_conn):
         """Re-releasing same key updates last_used timestamp."""
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
         assert len(pool._pool) == 1
 
 
@@ -105,7 +145,7 @@ class TestConnectionPoolDrain:
         conns = [MagicMock() for _ in range(3)]
         for i, conn in enumerate(conns):
             conn.is_alive.return_value = True
-            pool.release(f"1.2.3.{i}", 22, "user", "cisco_ios", conn)
+            pool.release(f"1.2.3.{i}", 22, "user", "pass", "cisco_ios", conn)
 
         pool.drain()
 
@@ -116,6 +156,6 @@ class TestConnectionPoolDrain:
     def test_drain_handles_disconnect_error(self, pool, mock_conn):
         """drain() continues even if disconnect raises."""
         mock_conn.disconnect.side_effect = Exception("disconnect failed")
-        pool.release("1.2.3.4", 22, "user", "cisco_ios", mock_conn)
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
         pool.drain()  # Should not raise
         assert len(pool._pool) == 0

--- a/worker.py
+++ b/worker.py
@@ -139,6 +139,15 @@ def worker_launch(
     )
     w = Worker(queues=queues, name=name, connection=redis_conn)
 
+    # Fetch credential salt from Redis and configure the connection pool
+    from naas.library.connection_pool import pool
+
+    salt = redis_conn.get("naas_cred_salt")
+    if salt:
+        pool.set_salt(salt.decode())
+    else:
+        logger.warning("naas_cred_salt not found in Redis — connection pooling will be disabled until salt is set")
+
     # Setup signal handlers for graceful shutdown
     def request_stop(signum, frame):
         logger.info("Received signal %s, requesting graceful shutdown", signum)


### PR DESCRIPTION
## Security fix
Pool key was `(ip, port, username, platform)` — two users with the same username but different passwords would share a pooled SSH connection, allowing user A's authenticated session to be handed to user B.

## Fix
Pool key is now `(ip, port, sha512(username:password+salt), platform)`. The salt is fetched from Redis at worker startup via `pool.set_salt()` and matches the salt used by `Credentials.salted_hash()` in the API layer — consistent hashing across the system.

## Safe degradation
If `set_salt()` has not been called (race at startup), `get()` returns `None` and `release()` disconnects cleanly. No unsalted hashing, no credential sharing.

## Changes
- `connection_pool.py`: added `set_salt()`, `_cred_hash()`; updated `get()`/`release()` signatures to accept `password`
- `netmiko_lib.py`: pass `credentials.password` to pool calls
- `worker.py`: fetch salt from Redis and call `pool.set_salt()` before `w.work()`
- Tests: updated for new signatures, added salt/no-salt coverage

Closes #196