### PR TITLE
chore(k8s): pin manifest image tags to release version (#197)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           uv lock
-          git add CHANGELOG.md uv.lock
+          # Pin k8s manifest image tags to the release version
+          sed -i "s|ghcr.io/lykinsbd/naas:.*|ghcr.io/lykinsbd/naas:${{ needs.check-version.outputs.version }}|g" \
+            k8s/api/deployment.yaml k8s/worker/deployment.yaml
+          git add CHANGELOG.md uv.lock k8s/api/deployment.yaml k8s/worker/deployment.yaml
           if [[ "${{ needs.check-version.outputs.is_prerelease }}" == "false" ]]; then
             # Only commit fragment deletions on final release
             git add changes/

--- a/changes/197.internal.md
+++ b/changes/197.internal.md
@@ -1,0 +1,1 @@
+Release workflow now pins k8s manifest image tags to the release version

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -8,6 +8,11 @@ NAAS ships plain YAML manifests in `k8s/` for deploying to any Kubernetes cluste
 - `kubectl` configured for your cluster
 - A container image of NAAS (built and pushed to a registry your cluster can pull from)
 
+> The manifests in `main` reference the image tag for that release. The manifests in `develop`
+> use `latest`. For production deployments, always deploy from a tagged release branch and
+> verify the image tag in `k8s/api/deployment.yaml` and `k8s/worker/deployment.yaml` matches
+> the version you intend to run.
+
 ## Local Development with k3d
 
 [k3d](https://k3d.io) runs a lightweight k3s cluster inside Docker — no cloud account needed.


### PR DESCRIPTION
## Summary
Release workflow now pins k8s manifest image tags to the release version, making deployments reproducible.

## Behaviour
- On release: `sed` updates `k8s/api/deployment.yaml` and `k8s/worker/deployment.yaml` image tags to `ghcr.io/lykinsbd/naas:<version>` before committing
- On develop: manifests retain `:latest` for CI use
- docs/kubernetes.md: added note directing operators to verify image tag matches intended version

Closes #197