### PR TITLE
perf: cache Worker.all() with 10s TTL (#199)

### DIFF
--- a/changes/199.internal.md
+++ b/changes/199.internal.md
@@ -1,0 +1,1 @@
+Cache Worker.all() result with 10s TTL to avoid repeated Redis scans on every request

--- a/naas/app.py
+++ b/naas/app.py
@@ -18,6 +18,7 @@ from pythonjsonlogger.json import JsonFormatter
 
 from naas.config import app_configure
 from naas.library.errorhandlers import api_error_generator
+from naas.library.worker_cache import get_cached_workers
 from naas.resources.cancel_job import CancelJob
 from naas.resources.get_results import GetResults
 from naas.resources.healthcheck import HealthCheck
@@ -44,9 +45,7 @@ def _update_queue_metrics() -> None:
     if q is not None:
         _queue_depth.set(len(q))
     if redis is not None:
-        from rq import Worker
-
-        _workers_active.set(len(Worker.all(connection=redis)))
+        _workers_active.set(len(get_cached_workers(redis)))
 
 
 # Structured JSON logging

--- a/naas/library/worker_cache.py
+++ b/naas/library/worker_cache.py
@@ -1,0 +1,26 @@
+"""Cached Worker.all() helper to avoid repeated Redis scans on every request."""
+
+import time
+
+from rq import Worker
+
+_cache: list = []
+_cache_ts: float = 0.0
+_TTL = 10.0  # seconds
+
+
+def get_cached_workers(redis) -> list:  # type: ignore[type-arg]
+    """Return cached Worker.all() result, refreshing if TTL expired.
+
+    Args:
+        redis: Redis connection.
+
+    Returns:
+        List of RQ Worker objects, cached for up to 10 seconds.
+    """
+    global _cache, _cache_ts
+    now = time.monotonic()
+    if now - _cache_ts > _TTL:
+        _cache = Worker.all(connection=redis)
+        _cache_ts = now
+    return _cache

--- a/naas/resources/healthcheck.py
+++ b/naas/resources/healthcheck.py
@@ -5,9 +5,9 @@ import time
 from flask import current_app
 from flask_restful import Resource
 from redis.exceptions import RedisError
-from rq import Worker
 
 from naas import __version__
+from naas.library.worker_cache import get_cached_workers
 
 _START_TIME = time.time()
 
@@ -26,7 +26,7 @@ class HealthCheck(Resource):
             redis_status = "unhealthy"
 
         # Check workers — count unique hostnames (pods/hosts), not individual processes
-        workers = Worker.all(connection=redis) if redis_status == "healthy" else []
+        workers = get_cached_workers(redis) if redis_status == "healthy" else []
         worker_count = len({w.hostname for w in workers})
         active_jobs = sum(1 for w in workers if w.get_current_job() is not None)
         worker_status = "healthy" if worker_count > 0 else "no_workers"

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -44,9 +44,12 @@ class TestHealthCheck:
         """Healthcheck returns healthy status when workers are present."""
         from unittest.mock import MagicMock
 
+        import naas.library.worker_cache as wc
+
         mock_worker = MagicMock()
         mock_worker.get_current_job.return_value = None
-        monkeypatch.setattr("naas.resources.healthcheck.Worker.all", lambda connection: [mock_worker])
+        monkeypatch.setattr("naas.library.worker_cache.Worker.all", lambda connection: [mock_worker])
+        monkeypatch.setattr(wc, "_cache_ts", 0.0)
         response = client.get("/healthcheck")
         data = response.get_json()
         assert data["status"] == "healthy"
@@ -58,9 +61,12 @@ class TestHealthCheck:
         """Healthcheck counts active jobs on workers."""
         from unittest.mock import MagicMock
 
+        import naas.library.worker_cache as wc
+
         mock_worker = MagicMock()
         mock_worker.get_current_job.return_value = MagicMock()
-        monkeypatch.setattr("naas.resources.healthcheck.Worker.all", lambda connection: [mock_worker])
+        monkeypatch.setattr("naas.library.worker_cache.Worker.all", lambda connection: [mock_worker])
+        monkeypatch.setattr(wc, "_cache_ts", 0.0)
         response = client.get("/healthcheck")
         data = response.get_json()
         assert data["components"]["workers"]["active_jobs"] == 1


### PR DESCRIPTION
## Summary
`Worker.all()` is an O(N) Redis scan that was being called on every HTTP request (Prometheus `before_request` hook) and every healthcheck request.

## Fix
New `naas/library/worker_cache.py` module with a 10s TTL cache. Both `app.py` and `healthcheck.py` now call `get_cached_workers(redis)` instead of `Worker.all()` directly.

TTL of 10s is well within the RQ worker heartbeat interval (60s) — no meaningful staleness.

Closes #199