### PR TITLE
chore(k8s): add file-based heartbeat and liveness probe to worker (#200)

### DIFF
--- a/changes/200.internal.md
+++ b/changes/200.internal.md
@@ -1,0 +1,1 @@
+Add file-based heartbeat to worker process and liveness probe to k8s worker deployment

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -113,6 +113,11 @@ Worker replicas are set to `2` by default. Increase `spec.replicas` in
 handles one job at a time per process; the number of concurrent jobs equals the number
 of worker replicas.
 
+The worker process writes a heartbeat file to `/tmp/worker_heartbeat` every 30 seconds.
+The liveness probe checks this file was modified within the last 2 minutes — if the
+parent process hangs, Kubernetes will restart the pod. Override the path via the
+`WORKER_HEARTBEAT_FILE` environment variable if needed.
+
 ## Monitoring
 
 The `/metrics` endpoint on the API pods exposes Prometheus metrics. Configure your

--- a/k8s/worker/deployment.yaml
+++ b/k8s/worker/deployment.yaml
@@ -42,3 +42,13 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - find
+                - /tmp/worker_heartbeat
+                - -mmin
+                - "-2"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3

--- a/worker.py
+++ b/worker.py
@@ -7,11 +7,13 @@ Author: Brett Lykins (lykinsbd@gmail.com)
 Description: Handle launching of rq workers
 """
 
+import os
 import signal
 from argparse import ArgumentParser, Namespace
 from collections.abc import Sequence
 from logging import basicConfig, getLogger
 from multiprocessing import Process
+from pathlib import Path
 from socket import gethostname
 from time import sleep
 
@@ -61,6 +63,23 @@ def main() -> None:
         )
         processes.append(proc)
         proc.start()
+
+    # Main loop: write heartbeat file and monitor child processes
+    heartbeat_file = Path(os.environ.get("WORKER_HEARTBEAT_FILE", "/tmp/worker_heartbeat"))
+    _running = True
+
+    def _stop(signum, frame):
+        nonlocal _running
+        _running = False
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    while _running and any(p.is_alive() for p in processes):
+        heartbeat_file.touch()
+        sleep(30)
+
+    heartbeat_file.unlink(missing_ok=True)
 
 
 def arg_parsing() -> Namespace:


### PR DESCRIPTION
## Summary
Adds a liveness probe to the worker deployment so Kubernetes can detect and restart hung worker processes.

## How it works
- `worker.py` main loop touches `/tmp/worker_heartbeat` every 30s while any child process is alive
- k8s liveness probe: `find /tmp/worker_heartbeat -mmin -2` — fails if file not updated in 2 minutes (4× write interval)
- `WORKER_HEARTBEAT_FILE` env var overrides the default path
- On clean shutdown, heartbeat file is removed

## Documentation
`docs/kubernetes.md` updated with heartbeat/probe explanation.

Closes #200