### PR TITLE
docs: document connection pool config vars in kubernetes.md and configmap.yaml (#191)

### DIFF
--- a/changes/191.doc.md
+++ b/changes/191.doc.md
@@ -1,0 +1,1 @@
+Document connection pool configuration variables in kubernetes.md and k8s/configmap.yaml

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -106,6 +106,23 @@ persistence configured.
 To use an external Redis, update `REDIS_HOST` and `REDIS_PORT` in `k8s/configmap.yaml`
 and remove the `k8s/redis/` manifests.
 
+## Connection Pooling
+
+NAAS reuses SSH connections across sequential jobs to the same device, reducing VTY session
+overhead on network equipment. Pooling is enabled by default.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONNECTION_POOL_ENABLED` | `true` | Set to `false` to disable pooling for all devices |
+| `CONNECTION_POOL_MAX_SIZE` | `10` | Max pooled connections per worker process |
+| `CONNECTION_POOL_IDLE_TIMEOUT` | `300` | Evict connections idle for this many seconds |
+| `CONNECTION_POOL_MAX_AGE` | `3600` | Evict connections older than this many seconds |
+| `CONNECTION_POOL_KEEPALIVE` | `60` | Paramiko SSH keepalive interval (seconds) |
+
+Disable pooling for specific environments where devices do not handle persistent SSH sessions
+well (e.g. older IOS, out-of-band management platforms). Per-device exclusions are tracked
+in [#187](https://github.com/lykinsbd/naas/issues/187).
+
 ## Scaling Workers
 
 Worker replicas are set to `2` by default. Increase `spec.replicas` in

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -14,3 +14,15 @@ data:
   # Number of RQ worker processes per pod. Scale horizontally via worker replicas
   # rather than increasing this value — each process adds ~7MB memory overhead.
   NAAS_WORKER_PROCESSES: "10"
+
+  # Connection pooling — reuses SSH sessions across jobs to reduce VTY overhead on devices.
+  # Disable for devices known to behave poorly with persistent SSH sessions.
+  CONNECTION_POOL_ENABLED: "true"
+  # Max pooled connections per worker process (not per pod).
+  CONNECTION_POOL_MAX_SIZE: "10"
+  # Seconds before an idle connection is evicted from the pool.
+  CONNECTION_POOL_IDLE_TIMEOUT: "300"
+  # Max connection age in seconds regardless of activity.
+  CONNECTION_POOL_MAX_AGE: "3600"
+  # Paramiko SSH keepalive interval in seconds. Prevents NAT/firewall idle drops.
+  CONNECTION_POOL_KEEPALIVE: "60"


### PR DESCRIPTION
Adds a Connection Pooling section to `docs/kubernetes.md` with a config variable table, and adds all pool vars with comments to `k8s/configmap.yaml`.\n\nCloses #191