### PR TITLE
docs: document TLS cert encoding requirements for k8s secret (#192)

### DIFF
--- a/changes/192.doc.md
+++ b/changes/192.doc.md
@@ -1,0 +1,1 @@
+Document TLS certificate encoding requirements for NAAS_CERT/NAAS_KEY/NAAS_CA_BUNDLE in kubernetes.md

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -73,8 +73,17 @@ via your cluster's ingress controller or a `LoadBalancer` service as appropriate
 environment.
 
 **With a custom certificate:** populate `NAAS_CERT`, `NAAS_KEY`, and optionally
-`NAAS_CA_BUNDLE` in `k8s/secret.yaml`. NAAS writes these to disk at startup for Gunicorn
-to use.
+`NAAS_CA_BUNDLE` in `k8s/secret.yaml`. These values must be the **raw PEM content**
+(not a file path), base64-encoded for the Kubernetes Secret.
+
+```bash
+# Encode a certificate file for use in secret.yaml
+cat cert.pem | base64 -w 0
+```
+
+The double-encoding works as follows: Kubernetes decodes the base64 value from the Secret
+and injects the raw PEM string as an environment variable. NAAS writes that string to disk
+at startup for Gunicorn to use.
 
 **Without a certificate:** NAAS generates a self-signed certificate at startup. Suitable
 for dev/internal use where clients can skip TLS verification or trust the self-signed cert.

--- a/k8s/secret.yaml.example
+++ b/k8s/secret.yaml.example
@@ -1,10 +1,10 @@
 # Copy this file to secret.yaml, fill in base64-encoded values, and apply.
-# Generate base64: echo -n 'value' | base64
+#
+# Values must be the RAW PEM CONTENT (not a file path), base64-encoded:
+#   echo -n 'your-redis-password' | base64        # for string values
+#   cat cert.pem | base64 -w 0                    # for certificate files
 #
 # DO NOT commit secret.yaml to version control.
-#
-# For production, use an external secrets operator (e.g., External Secrets Operator,
-# Vault Agent Injector) to populate these values instead of managing them manually.
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Clarifies that `NAAS_CERT`/`NAAS_KEY`/`NAAS_CA_BUNDLE` must be raw PEM content (not file paths), base64-encoded for the k8s Secret. Adds encoding examples to both `docs/kubernetes.md` and `k8s/secret.yaml.example`.\n\nCloses #192