### PR TITLE
docs: improve docstrings and kubernetes.md monitoring section (#193 #194 #195)

### DIFF
--- a/changes/193.doc.md
+++ b/changes/193.doc.md
@@ -1,0 +1,1 @@
+Add 400 status code to CancelJob.delete() docstring

--- a/changes/194.doc.md
+++ b/changes/194.doc.md
@@ -1,0 +1,1 @@
+Document required fields per event type in emit_audit_event docstring

--- a/changes/195.doc.md
+++ b/changes/195.doc.md
@@ -1,0 +1,1 @@
+Add exposed metrics list to Monitoring section in kubernetes.md

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -149,3 +149,10 @@ parent process hangs, Kubernetes will restart the pod. Override the path via the
 The `/metrics` endpoint on the API pods exposes Prometheus metrics. Configure your
 Prometheus instance to scrape port `443` (HTTPS) with the appropriate TLS config, or
 use a `ServiceMonitor` if running the Prometheus Operator.
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `naas_http_requests_total` | Counter | Total HTTP requests by endpoint, method, and status code |
+| `naas_http_request_duration_seconds` | Histogram | Request latency by endpoint |
+| `naas_queue_depth` | Gauge | Number of jobs waiting in the RQ queue |
+| `naas_workers_active` | Gauge | Number of active RQ worker processes (cached, 10s TTL) |

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -492,7 +492,7 @@
     },
     "/v1/jobs/{job_id}": {
       "delete": {
-        "description": "Args:     job_id: UUID of the job to cancel.\n\nReturns:     Empty response with 204 status on success.     404 if job not found.     403 if wrong credentials.     409 if job already finished or failed.",
+        "description": "Args:     job_id: UUID of the job to cancel.\n\nReturns:     Empty response with 204 status on success.     400 if job_id is not a valid UUID.     403 if credentials do not match the job submitter.     404 if job not found.     409 if job already finished or failed.",
         "operationId": "delete__v1_jobs_{job_id}",
         "parameters": [
           {

--- a/naas/library/audit.py
+++ b/naas/library/audit.py
@@ -19,8 +19,14 @@ def emit_audit_event(event_type: str, **fields: str | int) -> None:
     Emit a structured audit event at INFO level.
 
     Args:
-        event_type: Type of audit event (e.g., "job.submitted").
-        **fields: Event-specific fields as defined in schema.
+        event_type: Type of audit event. Must be one of:
+            - ``job.submitted``: ip, platform, port, command_count, user_hash, request_id
+            - ``job.completed``: request_id, status, duration_ms
+            - ``job.cancelled``: request_id, cancelled_by_hash
+            - ``device.locked_out``: ip, failure_count
+            - ``circuit.opened``: ip
+            - ``circuit.closed``: ip
+        **fields: Event-specific fields as listed above.
 
     Raises:
         ValueError: If event_type is unknown or required fields are missing.

--- a/naas/resources/cancel_job.py
+++ b/naas/resources/cancel_job.py
@@ -23,8 +23,9 @@ class CancelJob(Resource):
 
         Returns:
             Empty response with 204 status on success.
+            400 if job_id is not a valid UUID.
+            403 if credentials do not match the job submitter.
             404 if job not found.
-            403 if wrong credentials.
             409 if job already finished or failed.
         """
         v = Validate()


### PR DESCRIPTION
Three small documentation fixes:\n\n- **#193** `CancelJob.delete()`: add 400 status code (invalid UUID) to docstring\n- **#194** `emit_audit_event()`: document required fields per event type inline\n- **#195** `docs/kubernetes.md`: add metrics table to Monitoring section\n\nCloses #193, #194, #195