### PR TITLE
test: justify pragma: no cover on cancel_job.py auth guard (#205)

### DIFF
--- a/changes/205.testing.md
+++ b/changes/205.testing.md
@@ -1,0 +1,1 @@
+Justify pragma: no cover on cancel_job.py auth guard with inline explanation

--- a/naas/resources/cancel_job.py
+++ b/naas/resources/cancel_job.py
@@ -33,7 +33,9 @@ class CancelJob(Resource):
         v.has_auth()
 
         auth = request.authorization
-        if not auth or not auth.username or not auth.password:  # pragma: no cover
+        if (
+            not auth or not auth.username or not auth.password
+        ):  # pragma: no cover  # v.has_auth() above guarantees auth is present; guard exists for type narrowing
             raise Forbidden
 
         creds = Credentials(username=auth.username, password=auth.password)


### PR DESCRIPTION
The auth guard after `v.has_auth()` is unreachable — `has_auth()` raises 401 if auth is missing. The `pragma: no cover` is retained (same pattern as `get_results.py`) but now has an inline justification comment.\n\nCloses #205