### PR TITLE
fix: use setnx for naas_cred_salt to survive API restarts (#223)

### DIFF
--- a/changes/223.bugfix.md
+++ b/changes/223.bugfix.md
@@ -1,0 +1,1 @@
+Use setnx for naas_cred_salt so API restarts do not invalidate existing connection pool keys and in-flight job auth

--- a/naas/config.py
+++ b/naas/config.py
@@ -81,8 +81,10 @@ def app_configure(app):
     redis = Redis(host=REDIS_HOST, port=REDIS_PORT, password=REDIS_PASSWORD)
     app.config["redis"] = redis
 
-    # Create a random string to use as a Salt for the UN/PW hashes, stash it in redis
-    redis.set("naas_cred_salt", "".join(random.choice(string.ascii_lowercase) for _ in range(10)))
+    # Create a random string to use as a Salt for the UN/PW hashes, stash it in redis.
+    # Use setnx so the salt persists across API restarts — overwriting it would invalidate
+    # all connection pool keys and in-flight job auth checks.
+    redis.setnx("naas_cred_salt", "".join(random.choice(string.ascii_lowercase) for _ in range(10)))
 
     # Initialize an rq Queue and store it for later
     q = Queue("naas", connection=redis)


### PR DESCRIPTION
Replaces `redis.set()` with `redis.setnx()` for `naas_cred_salt` so the salt persists across API restarts. Previously, any pod restart would generate a new salt, invalidating all connection pool keys and breaking auth checks for in-flight jobs.\n\nCloses #223