### PR TITLE
fix: pass Redis connection explicitly to lockout functions (#224)

### DIFF
--- a/changes/224.bugfix.md
+++ b/changes/224.bugfix.md
@@ -1,0 +1,1 @@
+Pass Redis connection explicitly to tacacs_auth_lockout and device_lockout, eliminating per-request TCP connection overhead

--- a/naas/library/auth.py
+++ b/naas/library/auth.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 from flask import current_app
 from redis import Redis
 
-from naas.config import REDIS_HOST, REDIS_PASSWORD, REDIS_PORT
 from naas.library.audit import emit_audit_event
 
 
@@ -75,15 +74,13 @@ def _is_locked_out(redis_key: str, redis: Redis, report_failure: bool = False) -
     return is_locked
 
 
-def tacacs_auth_lockout(username: str, report_failure: bool = False) -> bool:
+def tacacs_auth_lockout(username: str, redis: Redis, report_failure: bool = False) -> bool:
     """Check (and optionally record) a TACACS auth failure for a user."""
-    redis = Redis(host=REDIS_HOST, port=int(REDIS_PORT), password=REDIS_PASSWORD)
     return _is_locked_out(f"naas_failures_{username}", redis, report_failure)
 
 
-def device_lockout(ip: str, report_failure: bool = False) -> bool:
+def device_lockout(ip: str, redis: Redis, report_failure: bool = False) -> bool:
     """Check (and optionally record) a connection failure for a device IP."""
-    redis = Redis(host=REDIS_HOST, port=int(REDIS_PORT), password=REDIS_PASSWORD)
     return _is_locked_out(f"naas_failures_device_{ip}", redis, report_failure)
 
 

--- a/naas/library/circuit_breaker.py
+++ b/naas/library/circuit_breaker.py
@@ -138,11 +138,11 @@ def with_circuit_breaker(ip: str, request_id: str, fn: Callable[..., Any], *args
         return breaker.call(fn, *args, **kwargs)  # type: ignore[no-any-return]  # pybreaker.call() returns Any; no stubs available
     except pybreaker.CircuitBreakerError:
         logger.warning("%s %s:Circuit breaker open, rejecting connection attempt", request_id, ip)
-        device_lockout(ip=ip, report_failure=True)
+        device_lockout(ip=ip, redis=_get_redis(), report_failure=True)
         return None, f"Circuit breaker open for device {ip} - too many recent failures"
     except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
-        device_lockout(ip=ip, report_failure=True)
+        device_lockout(ip=ip, redis=_get_redis(), report_failure=True)
         return None, str(e)
     except (ssh_exception.SSHException, ValueError) as e:
-        device_lockout(ip=ip, report_failure=True)
+        device_lockout(ip=ip, redis=_get_redis(), report_failure=True)
         return None, f"Unknown SSH error connecting to device {ip}: {str(e)}"

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -15,7 +15,7 @@ from paramiko import ssh_exception
 from naas.config import CIRCUIT_BREAKER_ENABLED, CONNECTION_POOL_ENABLED, CONNECTION_POOL_KEEPALIVE
 from naas.library.audit import emit_audit_event
 from naas.library.auth import tacacs_auth_lockout
-from naas.library.circuit_breaker import with_circuit_breaker
+from naas.library.circuit_breaker import _get_redis, with_circuit_breaker
 from naas.library.connection_pool import pool
 
 if TYPE_CHECKING:
@@ -119,7 +119,7 @@ def _netmiko_send_command_impl(
         raise  # Re-raise to trigger circuit breaker
     except netmiko.NetMikoAuthenticationException as e:
         logger.debug("%s %s:Netmiko authentication failure connecting to device: %s", request_id, ip, e)
-        tacacs_auth_lockout(username=credentials.username, report_failure=True)
+        tacacs_auth_lockout(username=credentials.username, redis=_get_redis(), report_failure=True)
         duration_ms = int((time.time() - start_time) * 1000)
         emit_audit_event("job.completed", request_id=request_id, status="failed", duration_ms=duration_ms)
         return None, str(e)  # Don't trigger circuit breaker for auth failures
@@ -247,7 +247,7 @@ def _netmiko_send_config_impl(
         raise  # Re-raise to trigger circuit breaker
     except netmiko.NetMikoAuthenticationException as e:
         logger.debug("%s %s:Netmiko authentication failure connecting to device: %s", request_id, ip, e)
-        tacacs_auth_lockout(username=credentials.username, report_failure=True)
+        tacacs_auth_lockout(username=credentials.username, redis=_get_redis(), report_failure=True)
         duration_ms = int((time.time() - start_time) * 1000)
         emit_audit_event("job.completed", request_id=request_id, status="failed", duration_ms=duration_ms)
         return None, str(e)  # Don't trigger circuit breaker for auth failures

--- a/naas/library/validation.py
+++ b/naas/library/validation.py
@@ -44,7 +44,7 @@ class Validate:
     def locked_out() -> None:
         """Validate if this user is locked out from accessing the API."""
         if request.authorization and request.authorization.username:
-            if tacacs_auth_lockout(username=request.authorization.username):
+            if tacacs_auth_lockout(username=request.authorization.username, redis=current_app.config["redis"]):
                 current_app.logger.error(f"{request.authorization.username} is currently locked out.")
                 raise LockedOut
 

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -40,7 +40,7 @@ class SendCommand(Resource):
         validated: SendCommandRequest = request.context.json
         ip_str = str(validated.ip)
 
-        if device_lockout(ip=ip_str):
+        if device_lockout(ip=ip_str, redis=current_app.config["redis"]):
             current_app.logger.error("%s: Device %s is locked out", g.request_id, ip_str)
             raise LockedOut
 

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -42,7 +42,7 @@ class SendConfig(Resource):
         validated: SendConfigRequest = request.context.json
         ip_str = str(validated.ip)
 
-        if device_lockout(ip=ip_str):
+        if device_lockout(ip=ip_str, redis=current_app.config["redis"]):
             current_app.logger.error("%s: Device %s is locked out", g.request_id, ip_str)
             raise LockedOut
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -8,29 +8,29 @@ class TestLockout:
 
     def test_no_failures_not_locked(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
-        assert tacacs_auth_lockout(username="testuser") is False
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis) is False
 
     def test_first_failure_not_locked(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
-        assert tacacs_auth_lockout(username="testuser", report_failure=True) is False
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True) is False
 
     def test_nine_failures_not_locked(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
         for _ in range(9):
-            tacacs_auth_lockout(username="testuser", report_failure=True)
-        assert tacacs_auth_lockout(username="testuser") is False
+            tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True)
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis) is False
 
     def test_tenth_failure_triggers_lockout(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
         for _ in range(9):
-            tacacs_auth_lockout(username="testuser", report_failure=True)
-        assert tacacs_auth_lockout(username="testuser", report_failure=True) is True
+            tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True)
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True) is True
 
     def test_lockout_persists(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
         for _ in range(10):
-            tacacs_auth_lockout(username="testuser", report_failure=True)
-        assert tacacs_auth_lockout(username="testuser") is True
+            tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True)
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis) is True
 
     def test_old_failures_expire(self, fake_redis, monkeypatch):
         """Failures outside the 10-minute window are pruned and don't count."""
@@ -40,7 +40,7 @@ class TestLockout:
         old_ts = (datetime.now() - timedelta(minutes=30)).timestamp()
         for i in range(9):
             fake_redis.zadd("naas_failures_testuser", {f"old-{i}": old_ts})
-        assert tacacs_auth_lockout(username="testuser") is False
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis) is False
 
     def test_old_failures_plus_new_not_locked(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
@@ -49,24 +49,24 @@ class TestLockout:
         old_ts = (datetime.now() - timedelta(minutes=30)).timestamp()
         for i in range(9):
             fake_redis.zadd("naas_failures_testuser", {f"old-{i}": old_ts})
-        assert tacacs_auth_lockout(username="testuser", report_failure=True) is False
+        assert tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True) is False
 
     def test_device_lockout_no_failures(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
-        assert device_lockout(ip="192.0.2.1") is False
+        assert device_lockout(ip="192.0.2.1", redis=fake_redis) is False
 
     def test_device_lockout_triggers_at_ten(self, fake_redis, monkeypatch):
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
         for _ in range(9):
-            device_lockout(ip="192.0.2.1", report_failure=True)
-        assert device_lockout(ip="192.0.2.1", report_failure=True) is True
+            device_lockout(ip="192.0.2.1", redis=fake_redis, report_failure=True)
+        assert device_lockout(ip="192.0.2.1", redis=fake_redis, report_failure=True) is True
 
     def test_device_lockout_independent_of_user_lockout(self, fake_redis, monkeypatch):
         """Device and user lockouts use separate keys."""
         monkeypatch.setattr("naas.library.auth.Redis", lambda **kwargs: fake_redis)
         for _ in range(10):
-            tacacs_auth_lockout(username="testuser", report_failure=True)
-        assert device_lockout(ip="192.0.2.1") is False
+            tacacs_auth_lockout(username="testuser", redis=fake_redis, report_failure=True)
+        assert device_lockout(ip="192.0.2.1", redis=fake_redis) is False
 
 
 class TestJobUnlocker:

--- a/tests/unit/test_netmiko_lib.py
+++ b/tests/unit/test_netmiko_lib.py
@@ -1,6 +1,6 @@
 """Unit tests for netmiko_lib functions."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import netmiko
 from fakeredis import FakeStrictRedis
@@ -48,7 +48,9 @@ class TestNetmikoSendCommand:
                     mock_conn.send_command.return_value = "output"
                     mock_handler.return_value = mock_conn
 
-                    result, error = netmiko_send_command("192.168.1.1", creds, "cisco_ios", ["show version"])
+                    result, error = netmiko_send_command(
+                        "192.168.1.1", creds, "cisco_ios", ["show version"], MagicMock()
+                    )
 
                     assert error is None
                     mock_conn.disconnect.assert_called_once()
@@ -62,7 +64,9 @@ class TestNetmikoSendCommand:
         with patch("naas.library.netmiko_lib.pool.get", return_value=mock_conn):
             with patch("naas.library.netmiko_lib.pool.release") as mock_release:
                 with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
-                    result, error = netmiko_send_command("192.168.1.1", creds, "cisco_ios", ["show version"])
+                    result, error = netmiko_send_command(
+                        "192.168.1.1", creds, "cisco_ios", ["show version"], MagicMock()
+                    )
 
                     assert error is None
                     mock_handler.assert_not_called()
@@ -90,11 +94,13 @@ class TestNetmikoSendCommand:
                 with patch("naas.library.netmiko_lib.tacacs_auth_lockout") as mock_lockout:
                     mock_handler.side_effect = netmiko.NetMikoAuthenticationException("Auth failed")
 
-                    result, error = netmiko_send_command("192.168.1.1", creds, "cisco_ios", ["show version"])
+                    result, error = netmiko_send_command(
+                        "192.168.1.1", creds, "cisco_ios", ["show version"], MagicMock()
+                    )
 
                     assert result is None
                     assert "Auth failed" in error
-                    mock_lockout.assert_called_once_with(username="testuser", report_failure=True)
+                    mock_lockout.assert_called_once_with(username="testuser", redis=ANY, report_failure=True)
 
     def test_ssh_exception(self):
         """Test SSH exception handling."""
@@ -140,7 +146,9 @@ class TestNetmikoSendConfig:
             mock_conn.send_config_set.return_value = "config output"
             mock_handler.return_value = mock_conn
 
-            result, error = netmiko_send_config("192.168.1.1", creds, "cisco_ios", commands, save_config=True)
+            result, error = netmiko_send_config(
+                "192.168.1.1", creds, "cisco_ios", commands, MagicMock(), save_config=True
+            )
 
             assert error is None
             mock_conn.save_config.assert_called_once()
@@ -156,7 +164,9 @@ class TestNetmikoSendConfig:
             mock_conn.save_config.side_effect = NotImplementedError()
             mock_handler.return_value = mock_conn
 
-            result, error = netmiko_send_config("192.168.1.1", creds, "cisco_ios", commands, save_config=True)
+            result, error = netmiko_send_config(
+                "192.168.1.1", creds, "cisco_ios", commands, MagicMock(), save_config=True
+            )
 
             assert error is None
             assert result is not None
@@ -216,7 +226,7 @@ class TestNetmikoSendConfig:
 
                 assert result is None
                 assert "Auth failed" in error
-                mock_lockout.assert_called_once_with(username="testuser", report_failure=True)
+                mock_lockout.assert_called_once_with(username="testuser", redis=ANY, report_failure=True)
 
     def test_config_value_error(self):
         """Test config ValueError handling."""
@@ -246,12 +256,16 @@ class TestCircuitBreaker:
                         mock_conn.send_command.return_value = "output"
                         mock_handler.return_value = mock_conn
 
-                        result, error = netmiko_send_command("192.168.1.1", creds, "cisco_ios", ["show version"])
+                        result, error = netmiko_send_command(
+                            "192.168.1.1", creds, "cisco_ios", ["show version"], MagicMock()
+                        )
 
                         assert error is None
                         assert result == {"show version": "output"}
 
-                        result, error = netmiko_send_config("192.168.1.1", creds, "cisco_ios", ["interface Gi0/1"])
+                        result, error = netmiko_send_config(
+                            "192.168.1.1", creds, "cisco_ios", ["interface Gi0/1"], MagicMock()
+                        )
 
                         assert error is None
 
@@ -265,7 +279,9 @@ class TestCircuitBreaker:
 
                 # Trigger failures up to threshold
                 for _ in range(5):
-                    result, error = netmiko_send_command("192.168.1.2", creds, "cisco_ios", ["show version"])
+                    result, error = netmiko_send_command(
+                        "192.168.1.2", creds, "cisco_ios", ["show version"], MagicMock()
+                    )
                     assert result is None
 
                 # Next call should be rejected by circuit breaker
@@ -291,7 +307,9 @@ class TestCircuitBreaker:
                         netmiko_send_command("192.168.1.3", creds, "cisco_ios", ["show version"])
 
                     # Device 1 circuit should be open
-                    result, error = netmiko_send_command("192.168.1.3", creds, "cisco_ios", ["show version"])
+                    result, error = netmiko_send_command(
+                        "192.168.1.3", creds, "cisco_ios", ["show version"], MagicMock()
+                    )
                     assert "Circuit breaker open" in error
 
                     # Device 2 should still work
@@ -300,7 +318,9 @@ class TestCircuitBreaker:
                     mock_handler.side_effect = None
                     mock_handler.return_value = mock_conn
 
-                    result, error = netmiko_send_command("192.168.1.4", creds, "cisco_ios", ["show version"])
+                    result, error = netmiko_send_command(
+                        "192.168.1.4", creds, "cisco_ios", ["show version"], MagicMock()
+                    )
                     assert error is None
 
     def test_redis_storage_properties(self):

--- a/tests/unit/test_validation.py
+++ b/tests/unit/test_validation.py
@@ -1,5 +1,7 @@
 """Unit tests for validation functions."""
 
+from unittest.mock import MagicMock
+
 import pytest
 from flask import Flask
 from werkzeug.exceptions import BadRequest
@@ -14,6 +16,7 @@ def validation_app():
     app = Flask(__name__)
     app.config["TESTING"] = True
     app.config["q"] = None  # Mock queue
+    app.config["redis"] = MagicMock()
     return app
 
 


### PR DESCRIPTION
Makes `redis` a required parameter on `tacacs_auth_lockout()` and `device_lockout()`, eliminating a new TCP connection per call. API callers pass `current_app.config["redis"]`; worker callers (`circuit_breaker.py`, `netmiko_lib.py`) pass their own connection.\n\nCloses #224