### PR TITLE
fix: set explicit job_timeout on enqueue to prevent hung workers (#226)

### DIFF
--- a/changes/226.bugfix.md
+++ b/changes/226.bugfix.md
@@ -1,0 +1,1 @@
+Set explicit job_timeout on enqueue to prevent hung workers holding for RQ's 180s default

--- a/naas/config.py
+++ b/naas/config.py
@@ -27,6 +27,7 @@ REDIS_PASSWORD = os.environ.get("REDIS_PASSWORD", "mah_redis_pw")
 # Job TTL config (seconds)
 JOB_TTL_SUCCESS = int(os.environ.get("JOB_TTL_SUCCESS", 86400))  # 24h
 JOB_TTL_FAILED = int(os.environ.get("JOB_TTL_FAILED", 604800))  # 7 days
+JOB_TIMEOUT = int(os.environ.get("JOB_TIMEOUT", 120))  # 2 minutes; covers delay_factor=1 + buffer
 
 # Circuit breaker config
 CIRCUIT_BREAKER_ENABLED = os.environ.get("CIRCUIT_BREAKER_ENABLED", "true").lower() == "true"

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -5,7 +5,7 @@ from flask_restful import Resource
 from spectree import Response
 
 from naas import __base_response__
-from naas.config import JOB_TTL_FAILED, JOB_TTL_SUCCESS
+from naas.config import JOB_TIMEOUT, JOB_TTL_FAILED, JOB_TTL_SUCCESS
 from naas.library.audit import emit_audit_event
 from naas.library.auth import device_lockout, job_locker
 from naas.library.decorators import valid_post
@@ -80,6 +80,7 @@ class SendCommand(Resource):
             delay_factor=validated.delay_factor,
             request_id=g.request_id,
             job_id=g.request_id,
+            job_timeout=JOB_TIMEOUT,
             result_ttl=JOB_TTL_SUCCESS,
             failure_ttl=JOB_TTL_FAILED,
         )

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -5,7 +5,7 @@ from flask_restful import Resource
 from spectree import Response
 
 from naas import __base_response__
-from naas.config import JOB_TTL_FAILED, JOB_TTL_SUCCESS
+from naas.config import JOB_TIMEOUT, JOB_TTL_FAILED, JOB_TTL_SUCCESS
 from naas.library.audit import emit_audit_event
 from naas.library.auth import device_lockout, job_locker
 from naas.library.decorators import valid_post
@@ -84,6 +84,7 @@ class SendConfig(Resource):
             delay_factor=validated.delay_factor,
             request_id=g.request_id,
             job_id=g.request_id,
+            job_timeout=JOB_TIMEOUT,
             result_ttl=JOB_TTL_SUCCESS,
             failure_ttl=JOB_TTL_FAILED,
         )


### PR DESCRIPTION
Adds `JOB_TIMEOUT` config var (default 120s, overridable via env) passed to `q.enqueue()` on both `send_command` and `send_config`. Previously RQ's 180s default applied, allowing hung Netmiko connections to hold workers for 3 minutes.\n\nCloses #226