### PR TITLE
fix: call redis.ping() at startup to fail fast on Redis unavailability (#227)

### DIFF
--- a/changes/227.bugfix.md
+++ b/changes/227.bugfix.md
@@ -1,0 +1,1 @@
+Call redis.ping() at startup to fail fast if Redis is unavailable

--- a/naas/config.py
+++ b/naas/config.py
@@ -80,6 +80,7 @@ def app_configure(app):
 
     # Initialize a Redis connection and store it for later
     redis = Redis(host=REDIS_HOST, port=REDIS_PORT, password=REDIS_PASSWORD)
+    redis.ping()  # Fail fast if Redis is unavailable at startup
     app.config["redis"] = redis
 
     # Create a random string to use as a Salt for the UN/PW hashes, stash it in redis.


### PR DESCRIPTION
Adds `redis.ping()` immediately after creating the Redis connection in `app_configure()`. If Redis is unavailable at startup the process now exits immediately with a connection error rather than starting and serving 500s on every request.\n\nCloses #227