### PR TITLE
ci: ignore codecov.io in link-check to prevent flaky badge failures (#234)

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://127.0.0.1"
+    },
+    {
+      "pattern": "^https://codecov.io"
     }
   ],
   "timeout": "20s",

--- a/changes/234.internal.md
+++ b/changes/234.internal.md
@@ -1,0 +1,1 @@
+Ignore codecov.io badge URLs in link-check to prevent flaky CI failures


### PR DESCRIPTION
Adds `codecov.io` to the link-check ignore list. The Codecov badge URL in `docs/COVERAGE.md` intermittently returns non-200 responses causing false CI failures on unrelated PRs. Badge URLs are decorative and don't need link validation.\n\nCloses #234