### PR TITLE
refactor: pass Job object to job_locker to avoid redundant Redis fetch (#228)

### DIFF
--- a/changes/228.internal.md
+++ b/changes/228.internal.md
@@ -1,0 +1,1 @@
+Pass Job object directly to job_locker to avoid redundant Redis fetch after enqueue

--- a/naas/library/auth.py
+++ b/naas/library/auth.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime, timedelta
 from hashlib import sha512
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from flask import current_app
@@ -9,18 +10,18 @@ from redis import Redis
 
 from naas.library.audit import emit_audit_event
 
+if TYPE_CHECKING:
+    from rq.job import Job
 
-def job_locker(salted_creds: str, job_id: str) -> None:
+
+def job_locker(salted_creds: str, job: "Job") -> None:
     """
     Stash the job ID under the SHA512 (salted) hash of the username/password, so only that user can retrieve it
     :param salted_creds: The pre-salted username/password combo
-    :param job_id:
+    :param job: The RQ Job object to lock
     :return:
     """
-
-    q = current_app.config["q"]
-    current_app.logger.debug("Locking job %s with %s", job_id, salted_creds)
-    job = q.fetch_job(job_id=job_id)
+    current_app.logger.debug("Locking job %s with %s", job.id, salted_creds)
     job.meta["hash"] = salted_creds
     job.save_meta()
 

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -91,7 +91,7 @@ class SendCommand(Resource):
         user_hash = g.credentials.salted_hash()
 
         # Stash the job_id in redis, with the user/pass hash so that only that user can retrieve results
-        job_locker(salted_creds=user_hash, job_id=job_id)
+        job_locker(salted_creds=user_hash, job=job)
 
         # Emit audit event
         emit_audit_event(

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -95,7 +95,7 @@ class SendConfig(Resource):
         user_hash = g.credentials.salted_hash()
 
         # Stash the job_id in redis, with the user/pass hash so that only that user can retrieve results
-        job_locker(salted_creds=user_hash, job_id=job_id)
+        job_locker(salted_creds=user_hash, job=job)
 
         # Emit audit event
         emit_audit_event(


### PR DESCRIPTION
`job_locker()` previously called `q.fetch_job(job_id)` immediately after `enqueue()` — a redundant Redis round-trip. Now accepts the `Job` object returned by `enqueue()` directly.\n\nCloses #228