### PR TITLE
fix(netmiko): error_pattern, find_prompt, fast_cli, worker_cache comment (#217 #218 #221 #229)

### DIFF
--- a/changes/217.bugfix.md
+++ b/changes/217.bugfix.md
@@ -1,0 +1,1 @@
+Detect config errors via error_pattern in send_config_set, returning error string instead of silently succeeding

--- a/changes/218.bugfix.md
+++ b/changes/218.bugfix.md
@@ -1,0 +1,1 @@
+Call find_prompt() after connection pool hit to verify clean CLI state before issuing commands

--- a/changes/221.internal.md
+++ b/changes/221.internal.md
@@ -1,0 +1,1 @@
+Explicitly set fast_cli=True on ConnectHandler for consistent throughput across all platforms

--- a/changes/229.internal.md
+++ b/changes/229.internal.md
@@ -1,0 +1,1 @@
+Add comment to worker_cache documenting per-process global state assumption

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -18,6 +18,9 @@ from naas.library.auth import tacacs_auth_lockout
 from naas.library.circuit_breaker import _get_redis, with_circuit_breaker
 from naas.library.connection_pool import pool
 
+# Common error patterns across IOS, NX-OS, EOS, JunOS, and similar platforms
+_CONFIG_ERROR_PATTERN = r"(?i)(% invalid|% incomplete|% ambiguous|% error|error:|invalid input|syntax error)"
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -88,6 +91,7 @@ def _netmiko_send_command_impl(
         "ssh_config_file": "/app/naas/ssh_config",
         "allow_agent": False,
         "use_keys": False,
+        "fast_cli": True,
         "verbose": verbose,
     }
 
@@ -101,6 +105,15 @@ def _netmiko_send_command_impl(
             logger.debug("%s %s:Establishing connection...", request_id, ip)
             netmiko_device["keepalive"] = CONNECTION_POOL_KEEPALIVE if CONNECTION_POOL_ENABLED else 0
             net_connect = netmiko.ConnectHandler(**netmiko_device)
+        else:
+            # Verify pooled connection is at a clean prompt before use
+            try:
+                net_connect.find_prompt()
+            except Exception:
+                logger.debug("%s %s:Pooled connection in bad state, reconnecting", request_id, ip)
+                pool._evict((ip, port, pool._cred_hash(credentials.username, credentials.password), device_type))
+                netmiko_device["keepalive"] = CONNECTION_POOL_KEEPALIVE
+                net_connect = netmiko.ConnectHandler(**netmiko_device)
 
         net_output = {}
         for command in commands:
@@ -206,6 +219,7 @@ def _netmiko_send_config_impl(
         "ssh_config_file": "/app/naas/ssh_config",
         "allow_agent": False,
         "use_keys": False,
+        "fast_cli": True,
         "verbose": verbose,
     }
 
@@ -215,7 +229,9 @@ def _netmiko_send_config_impl(
 
         net_output = {}
         logger.debug("%s %s:Sending config_set: %s", request_id, ip, commands)
-        net_output["config_set_output"] = net_connect.send_config_set(commands, delay_factor=delay_factor)
+        net_output["config_set_output"] = net_connect.send_config_set(
+            commands, delay_factor=delay_factor, error_pattern=_CONFIG_ERROR_PATTERN
+        )
 
         if save_config:
             try:
@@ -240,6 +256,11 @@ def _netmiko_send_config_impl(
 
         net_connect.disconnect()
 
+    except netmiko.ConfigInvalidException as e:
+        logger.debug("%s %s:Config rejected by device: %s", request_id, ip, e)
+        duration_ms = int((time.time() - start_time) * 1000)
+        emit_audit_event("job.completed", request_id=request_id, status="failed", duration_ms=duration_ms)
+        return None, str(e)  # Config error — do not trigger circuit breaker
     except (TimeoutError, netmiko.NetMikoTimeoutException) as e:
         logger.debug("%s %s:Netmiko timed out connecting to device: %s", request_id, ip, e)
         duration_ms = int((time.time() - start_time) * 1000)

--- a/naas/library/worker_cache.py
+++ b/naas/library/worker_cache.py
@@ -4,6 +4,10 @@ import time
 
 from rq import Worker
 
+# Module-level cache — one per process. This is correct for the current deployment
+# (single gunicorn worker process per API pod). If gunicorn is ever configured with
+# multiple worker processes (workers > 1), each process will have its own independent
+# cache with no coordination. Keep gunicorn workers=1 or move to a shared cache.
 _cache: list = []
 _cache_ts: float = 0.0
 _TTL = 10.0  # seconds

--- a/tests/unit/test_netmiko_lib.py
+++ b/tests/unit/test_netmiko_lib.py
@@ -64,13 +64,26 @@ class TestNetmikoSendCommand:
         with patch("naas.library.netmiko_lib.pool.get", return_value=mock_conn):
             with patch("naas.library.netmiko_lib.pool.release") as mock_release:
                 with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
-                    result, error = netmiko_send_command(
-                        "192.168.1.1", creds, "cisco_ios", ["show version"], MagicMock()
-                    )
+                    result, error = netmiko_send_command("192.168.1.1", creds, "cisco_ios", ["show version"])
 
                     assert error is None
                     mock_handler.assert_not_called()
                     mock_release.assert_called_once()
+
+    def test_pool_hit_bad_state_reconnects(self):
+        """Test that a pooled connection in bad state triggers reconnect."""
+        creds = Credentials(username="testuser", password="testpass")
+        mock_conn = MagicMock()
+        mock_conn.find_prompt.side_effect = Exception("stuck in sub-mode")
+
+        with patch("naas.library.netmiko_lib.pool.get", return_value=mock_conn):
+            with patch("naas.library.netmiko_lib.pool._evict"):
+                with patch("naas.library.netmiko_lib.pool.release"):
+                    with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
+                        mock_handler.return_value.send_command.return_value = "output"
+                        result, error = netmiko_send_command("192.168.1.1", creds, "cisco_ios", ["show version"])
+                        assert error is None
+                        mock_handler.assert_called_once()
 
     def test_timeout_error(self):
         """Test timeout exception handling."""
@@ -239,6 +252,18 @@ class TestNetmikoSendConfig:
 
             assert result is None
             assert "Unknown SSH error" in error
+
+    def test_config_invalid_exception(self):
+        """Test that ConfigInvalidException is returned as error without raising."""
+        creds = Credentials(username="testuser", password="testpass")
+
+        with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
+            mock_handler.return_value.send_config_set.side_effect = netmiko.ConfigInvalidException("% Invalid input")
+
+            result, error = netmiko_send_config("192.168.1.1", creds, "cisco_ios", ["bad command"])
+
+            assert result is None
+            assert "% Invalid input" in error
 
 
 class TestCircuitBreaker:


### PR DESCRIPTION
Four quick wins batched together:

- **#217** `send_config_set` now passes `error_pattern` covering common IOS/NX-OS/EOS/JunOS error strings. `ConfigInvalidException` is caught and returned as an error string (no circuit breaker trigger).
- **#218** `find_prompt()` called after pool hit to verify clean CLI state. On failure, evicts the connection and reconnects fresh.
- **#221** `fast_cli=True` explicitly set on both `ConnectHandler` calls for consistent throughput across all platforms.
- **#229** Comment added to `worker_cache.py` documenting the per-process global state assumption.

Closes #217, #218, #221, #229