### PR TITLE
fix(security): set readOnlyRootFilesystem on API and worker containers (#206)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ WORKDIR /app
 COPY naas/ /app/naas/
 COPY gunicorn.py worker.py /app/
 
+# Pre-compile Python bytecode so runtime writes to __pycache__ are not needed
+RUN python -m compileall -q /app/naas /app/gunicorn.py /app/worker.py
+
 # Set ownership and switch to non-root user
 RUN chown -R naas:naas /app
 USER naas

--- a/changes/206.security.md
+++ b/changes/206.security.md
@@ -1,0 +1,1 @@
+Set readOnlyRootFilesystem on API and worker containers; pre-compile Python bytecode in Dockerfile

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -20,11 +20,15 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
               add:
                 - NET_BIND_SERVICE
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           ports:
             - containerPort: 443
           envFrom:
@@ -75,3 +79,6 @@ spec:
               scheme: HTTPS
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/worker/deployment.yaml
+++ b/k8s/worker/deployment.yaml
@@ -20,9 +20,13 @@ spec:
             runAsNonRoot: true
             runAsUser: 1000
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
           command:
             - python
             - worker.py
@@ -59,3 +63,6 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
Resolves the second deferred v1.2 security issue.

## Changes
- **Dockerfile**: `python -m compileall` bakes bytecode into the image — no `__pycache__` writes at runtime
- **k8s/api**: `readOnlyRootFilesystem: true` + `emptyDir` on `/tmp` (TLS cert writes)
- **k8s/worker**: same + `emptyDir` on `/tmp` (heartbeat file)

## Tested locally
- `docker run --read-only` with `/tmp` mounted — imports succeed, certs write to `/tmp`, no filesystem errors

Closes #206