### PR TITLE
refactor(netmiko): replace delay_factor with read_timeout (#216)

### DIFF
--- a/changes/216.breaking.md
+++ b/changes/216.breaking.md
@@ -1,0 +1,1 @@
+Replace delay_factor parameter with read_timeout (float, seconds) in send_command and send_config endpoints

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -2,6 +2,10 @@
 
 Detailed examples for common NAAS API operations.
 
+!!! warning "Breaking change in v1.3"
+    The `delay_factor` parameter was replaced with `read_timeout` (float, seconds).
+    Migrate by converting: `delay_factor=2` → `read_timeout=60.0` (approximate).
+
 ## Contents
 
 - [Authentication](#authentication)

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -72,13 +72,6 @@
             "title": "Commands",
             "type": "array"
           },
-          "delay_factor": {
-            "default": 1,
-            "description": "Netmiko delay factor",
-            "minimum": 1,
-            "title": "Delay Factor",
-            "type": "integer"
-          },
           "ip": {
             "description": "Device IP address",
             "format": "ipvanyaddress",
@@ -98,6 +91,13 @@
             "minimum": 1,
             "title": "Port",
             "type": "integer"
+          },
+          "read_timeout": {
+            "default": 30.0,
+            "description": "Read timeout in seconds for device responses",
+            "minimum": 1.0,
+            "title": "Read Timeout",
+            "type": "number"
           }
         },
         "required": [
@@ -150,13 +150,6 @@
             "description": "Configuration commands",
             "title": "Config"
           },
-          "delay_factor": {
-            "default": 1,
-            "description": "Netmiko delay factor",
-            "minimum": 1,
-            "title": "Delay Factor",
-            "type": "integer"
-          },
           "ip": {
             "description": "Device IP address",
             "format": "ipvanyaddress",
@@ -176,6 +169,13 @@
             "minimum": 1,
             "title": "Port",
             "type": "integer"
+          },
+          "read_timeout": {
+            "default": 30.0,
+            "description": "Read timeout in seconds for device responses",
+            "minimum": 1.0,
+            "title": "Read Timeout",
+            "type": "number"
           },
           "save_config": {
             "default": false,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -321,10 +321,13 @@ Common issues and solutions for NAAS deployment and operation.
    {
      "ip": "192.168.1.1",
      "platform": "cisco_ios",
-     "delay_factor": 2,
+     "read_timeout": 60.0,
      "commands": ["show version"]
    }
    ```
+
+   **Note:** Prior to v1.3, this parameter was `delay_factor` (integer multiplier).
+   Migrate by converting: `delay_factor=2` → `read_timeout=60.0` (approximate).
 
 3. Scale workers for parallel execution:
 

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -36,7 +36,7 @@ def netmiko_send_command(
     device_type: str,
     commands: "Sequence[str]",
     port: int = 22,
-    delay_factor: int = 1,
+    read_timeout: float = 30.0,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -48,7 +48,7 @@ def netmiko_send_command(
     :param commands: List of the commands to issue to the device
     :param device_type: What Netmiko device type are we connecting to?
     :param port: What TCP Port are we connecting to?
-    :param delay_factor: Netmiko delay factor, default of 1, higher is slower but more reliable on laggy links
+    :param read_timeout: Read timeout in seconds for device responses
     :param verbose: Turn on Netmiko verbose logging
     :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
@@ -63,11 +63,11 @@ def netmiko_send_command(
             device_type,
             commands,
             port,
-            delay_factor,
+            read_timeout,
             verbose,
             request_id,
         )
-    return _netmiko_send_command_impl(ip, credentials, device_type, commands, port, delay_factor, verbose, request_id)
+    return _netmiko_send_command_impl(ip, credentials, device_type, commands, port, read_timeout, verbose, request_id)
 
 
 def _netmiko_send_command_impl(
@@ -76,7 +76,7 @@ def _netmiko_send_command_impl(
     device_type: str,
     commands: "Sequence[str]",
     port: int = 22,
-    delay_factor: int = 1,
+    read_timeout: float = 30.0,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -118,7 +118,7 @@ def _netmiko_send_command_impl(
         net_output = {}
         for command in commands:
             logger.debug("%s %s:Sending %s", request_id, ip, command)
-            net_output[command] = net_connect.send_command(command, delay_factor=delay_factor)
+            net_output[command] = net_connect.send_command(command, read_timeout=read_timeout)
 
         if CONNECTION_POOL_ENABLED:
             pool.release(ip, port, credentials.username, credentials.password, device_type, net_connect)
@@ -156,7 +156,7 @@ def netmiko_send_config(
     port: int = 22,
     save_config: bool = False,
     commit: bool = False,
-    delay_factor: int = 1,
+    read_timeout: float = 30.0,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -170,7 +170,7 @@ def netmiko_send_config(
     :param port: What TCP Port are we connecting to?
     :param save_config: Do you want to save this configuration upon insertion?  Default: False, don't save the config
     :param commit: Do you want to commit this candidate configuration to the running config?  Default: False
-    :param delay_factor: Netmiko delay factor, default of 1, higher is slower but more reliable on laggy links
+    :param read_timeout: Read timeout in seconds for device responses
     :param verbose: Turn on Netmiko verbose logging
     :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
@@ -187,12 +187,12 @@ def netmiko_send_config(
             port,
             save_config,
             commit,
-            delay_factor,
+            read_timeout,
             verbose,
             request_id,
         )
     return _netmiko_send_config_impl(
-        ip, credentials, device_type, commands, port, save_config, commit, delay_factor, verbose, request_id
+        ip, credentials, device_type, commands, port, save_config, commit, read_timeout, verbose, request_id
     )
 
 
@@ -204,7 +204,7 @@ def _netmiko_send_config_impl(
     port: int = 22,
     save_config: bool = False,
     commit: bool = False,
-    delay_factor: int = 1,
+    read_timeout: float = 30.0,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -230,7 +230,7 @@ def _netmiko_send_config_impl(
         net_output = {}
         logger.debug("%s %s:Sending config_set: %s", request_id, ip, commands)
         net_output["config_set_output"] = net_connect.send_config_set(
-            commands, delay_factor=delay_factor, error_pattern=_CONFIG_ERROR_PATTERN
+            commands, read_timeout=read_timeout, error_pattern=_CONFIG_ERROR_PATTERN
         )
 
         if save_config:

--- a/naas/models.py
+++ b/naas/models.py
@@ -41,7 +41,7 @@ class SendCommandRequest(BaseModel):
     commands: list[str] = Field(..., min_length=1, description="Commands to execute")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type")
-    delay_factor: int = Field(default=1, ge=1, description="Netmiko delay factor")
+    read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
 
     @model_validator(mode="before")
     @classmethod
@@ -80,7 +80,7 @@ class SendConfigRequest(BaseModel):
     commands: list[str] | None = Field(default=None, min_length=1, description="Configuration commands (alias)")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type")
-    delay_factor: int = Field(default=1, ge=1, description="Netmiko delay factor")
+    read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
     save_config: bool = Field(default=False, description="Save configuration after applying")
     commit: bool = Field(default=False, description="Commit configuration (Juniper)")
 

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -77,7 +77,7 @@ class SendCommand(Resource):
             device_type=validated.platform,
             credentials=g.credentials,
             commands=validated.commands,
-            delay_factor=validated.delay_factor,
+            read_timeout=validated.read_timeout,
             request_id=g.request_id,
             job_id=g.request_id,
             job_timeout=JOB_TIMEOUT,

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -81,7 +81,7 @@ class SendConfig(Resource):
             commands=validated.config,
             save_config=validated.save_config,
             commit=validated.commit,
-            delay_factor=validated.delay_factor,
+            read_timeout=validated.read_timeout,
             request_id=g.request_id,
             job_id=g.request_id,
             job_timeout=JOB_TIMEOUT,

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -36,7 +36,7 @@ class TestSendCommand:
                     "port": 22,
                     "platform": "cisco_ios",
                     "commands": ["show version"],
-                    "delay_factor": 1,
+                    "read_timeout": 30.0,
                 },
                 headers={"Authorization": f"Basic {auth}"},
             )
@@ -216,7 +216,7 @@ class TestSendCommand:
                     "port": 22,
                     "platform": "cisco_ios",
                     "commands": ["show version"],
-                    "delay_factor": 1,
+                    "read_timeout": 30.0,
                 },
                 headers={"Authorization": f"Basic {auth}", "X-Request-ID": custom_id},
             )
@@ -260,7 +260,7 @@ class TestSendConfig:
                     "port": 22,
                     "platform": "cisco_ios",
                     "commands": ["interface gi0/1", "description test"],
-                    "delay_factor": 1,
+                    "read_timeout": 30.0,
                     "save_config": False,
                     "commit": False,
                 },


### PR DESCRIPTION
**BREAKING CHANGE**: `delay_factor` (int) replaced with `read_timeout` (float, seconds).

## Why
Netmiko 4.x deprecated `delay_factor` in favor of explicit `read_timeout`. `delay_factor=2` is opaque — callers have no intuitive sense of the resulting wall-clock timeout.

## Migration
- `delay_factor=1` → `read_timeout=30.0` (default)
- `delay_factor=2` → `read_timeout=60.0` (approximate)

## Changes
- **Models**: `SendCommandRequest` and `SendConfigRequest` now accept `read_timeout: float` (default 30.0s)
- **Library**: `netmiko_send_command` and `netmiko_send_config` pass `read_timeout` to Netmiko
- **Docs**: migration note in `api-usage.md`, example updated in `troubleshooting.md`

Closes #216