### PR TITLE
feat(netmiko): add optional expect_string parameter to send_command (#220)

### DIFF
--- a/changes/220.feature.md
+++ b/changes/220.feature.md
@@ -1,0 +1,1 @@
+Add optional expect_string parameter to send_command for custom prompt matching

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -72,6 +72,19 @@
             "title": "Commands",
             "type": "array"
           },
+          "expect_string": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Regex pattern to match in device output (overrides prompt detection)",
+            "title": "Expect String"
+          },
           "ip": {
             "description": "Device IP address",
             "format": "ipvanyaddress",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -329,6 +329,24 @@ Common issues and solutions for NAAS deployment and operation.
    **Note:** Prior to v1.3, this parameter was `delay_factor` (integer multiplier).
    Migrate by converting: `delay_factor=2` → `read_timeout=60.0` (approximate).
 
+### Commands That Don't Return to Standard Prompt
+
+**Symptom**: Jobs hang or timeout on commands like `ping`, `traceroute`, or interactive prompts
+
+**Solution**: Use `expect_string` to match the expected output pattern instead of relying on prompt detection:
+
+   ```json
+   {
+     "ip": "192.168.1.1",
+     "platform": "cisco_ios",
+     "expect_string": "Success rate",
+     "commands": ["ping 8.8.8.8"]
+   }
+   ```
+
+   The `expect_string` is a regex matched against device output. Useful for commands that
+   don't return to a standard prompt or have interactive elements.
+
 3. Scale workers for parallel execution:
 
    ```bash

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -37,6 +37,7 @@ def netmiko_send_command(
     commands: "Sequence[str]",
     port: int = 22,
     read_timeout: float = 30.0,
+    expect_string: str | None = None,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -49,6 +50,7 @@ def netmiko_send_command(
     :param device_type: What Netmiko device type are we connecting to?
     :param port: What TCP Port are we connecting to?
     :param read_timeout: Read timeout in seconds for device responses
+    :param expect_string: Regex pattern to match in device output (overrides prompt detection)
     :param verbose: Turn on Netmiko verbose logging
     :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
@@ -64,10 +66,13 @@ def netmiko_send_command(
             commands,
             port,
             read_timeout,
+            expect_string,
             verbose,
             request_id,
         )
-    return _netmiko_send_command_impl(ip, credentials, device_type, commands, port, read_timeout, verbose, request_id)
+    return _netmiko_send_command_impl(
+        ip, credentials, device_type, commands, port, read_timeout, expect_string, verbose, request_id
+    )
 
 
 def _netmiko_send_command_impl(
@@ -77,6 +82,7 @@ def _netmiko_send_command_impl(
     commands: "Sequence[str]",
     port: int = 22,
     read_timeout: float = 30.0,
+    expect_string: str | None = None,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -118,7 +124,10 @@ def _netmiko_send_command_impl(
         net_output = {}
         for command in commands:
             logger.debug("%s %s:Sending %s", request_id, ip, command)
-            net_output[command] = net_connect.send_command(command, read_timeout=read_timeout)
+            kwargs: dict[str, float | str] = {"read_timeout": read_timeout}
+            if expect_string is not None:
+                kwargs["expect_string"] = expect_string
+            net_output[command] = net_connect.send_command(command, **kwargs)
 
         if CONNECTION_POOL_ENABLED:
             pool.release(ip, port, credentials.username, credentials.password, device_type, net_connect)

--- a/naas/models.py
+++ b/naas/models.py
@@ -42,6 +42,9 @@ class SendCommandRequest(BaseModel):
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
+    expect_string: str | None = Field(
+        default=None, description="Regex pattern to match in device output (overrides prompt detection)"
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -78,6 +78,7 @@ class SendCommand(Resource):
             credentials=g.credentials,
             commands=validated.commands,
             read_timeout=validated.read_timeout,
+            expect_string=validated.expect_string,
             request_id=g.request_id,
             job_id=g.request_id,
             job_timeout=JOB_TIMEOUT,

--- a/tests/unit/test_netmiko_lib.py
+++ b/tests/unit/test_netmiko_lib.py
@@ -85,6 +85,25 @@ class TestNetmikoSendCommand:
                         assert error is None
                         mock_handler.assert_called_once()
 
+    def test_expect_string(self):
+        """Test that expect_string is passed to send_command."""
+        creds = Credentials(username="testuser", password="testpass")
+
+        with patch("naas.library.netmiko_lib.pool.get", return_value=None):
+            with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
+                mock_conn = MagicMock()
+                mock_conn.send_command.return_value = "output"
+                mock_handler.return_value = mock_conn
+
+                result, error = netmiko_send_command(
+                    "192.168.1.1", creds, "cisco_ios", ["ping 8.8.8.8"], expect_string=r"Success rate"
+                )
+
+                assert error is None
+                mock_conn.send_command.assert_called_once_with(
+                    "ping 8.8.8.8", read_timeout=30.0, expect_string=r"Success rate"
+                )
+
     def test_timeout_error(self):
         """Test timeout exception handling."""
         creds = Credentials(username="testuser", password="testpass")


### PR DESCRIPTION
Adds `expect_string` parameter to `send_command` for commands that don't return to a standard prompt.

## Use cases
- `ping` commands (match "Success rate")
- `traceroute` (match completion pattern)
- Interactive prompts or `--More--` pagers on platforms without auto-paging

## Changes
- **SendCommandRequest**: add `expect_string: str | None = None`
- **netmiko_send_command**: pass `expect_string` to Netmiko's `send_command()` when set
- **docs/troubleshooting.md**: add example section with ping use case

Closes #220