### PR TITLE
feat(netmiko): support platform autodetect via SSHDetect (#222)

### DIFF
--- a/changes/222.feature.md
+++ b/changes/222.feature.md
@@ -1,0 +1,1 @@
+Add platform autodetect via SSHDetect for discovery workflows and heterogeneous environments

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -93,7 +93,7 @@
           },
           "platform": {
             "default": "cisco_ios",
-            "description": "Netmiko device type",
+            "description": "Netmiko device type (use 'autodetect' for SSHDetect)",
             "title": "Platform",
             "type": "string"
           },
@@ -171,7 +171,7 @@
           },
           "platform": {
             "default": "cisco_ios",
-            "description": "Netmiko device type",
+            "description": "Netmiko device type (use 'autodetect' for SSHDetect)",
             "title": "Platform",
             "type": "string"
           },

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -347,6 +347,26 @@ Common issues and solutions for NAAS deployment and operation.
    The `expect_string` is a regex matched against device output. Useful for commands that
    don't return to a standard prompt or have interactive elements.
 
+### Unknown or Heterogeneous Device Types
+
+**Symptom**: Managing devices with unknown or mixed platforms
+
+**Solution**: Use `platform: "autodetect"` to fingerprint devices via SSHDetect:
+
+   ```json
+   {
+     "ip": "192.168.1.1",
+     "platform": "autodetect",
+     "commands": ["show version"]
+   }
+   ```
+
+   The detected platform is returned in the job result as `detected_platform`. Note:
+
+- Adds a second SSH connection overhead (fingerprinting + actual commands)
+- Not compatible with connection pooling
+- Best for discovery workflows, not production automation against known devices
+
 3. Scale workers for parallel execution:
 
    ```bash

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -21,6 +21,34 @@ from naas.library.connection_pool import pool
 # Common error patterns across IOS, NX-OS, EOS, JunOS, and similar platforms
 _CONFIG_ERROR_PATTERN = r"(?i)(% invalid|% incomplete|% ambiguous|% error|error:|invalid input|syntax error)"
 
+
+def _autodetect_platform(
+    ip: str, port: int, username: str, password: str, enable: str, request_id: str
+) -> tuple[str | None, str | None]:
+    """
+    Use SSHDetect to fingerprint device platform.
+
+    Returns:
+        (detected_platform, error_string) — one will be None
+    """
+    try:
+        logger.debug("%s %s:Running SSHDetect...", request_id, ip)
+        guesser = netmiko.SSHDetect(
+            device_type="autodetect",
+            ip=ip,
+            port=port,
+            username=username,
+            password=password,
+            secret=enable,
+        )
+        best_match = guesser.autodetect()
+        logger.debug("%s %s:Detected platform: %s", request_id, ip, best_match)
+        return best_match, None
+    except Exception as e:
+        logger.debug("%s %s:SSHDetect failed: %s", request_id, ip, e)
+        return None, f"Platform autodetect failed: {str(e)}"
+
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -87,6 +115,23 @@ def _netmiko_send_command_impl(
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
     start_time = time.time()
+
+    # Handle platform autodetect
+    detected_platform = None
+    if device_type == "autodetect":
+        device_type_result, error = _autodetect_platform(
+            ip, port, credentials.username, credentials.password, credentials.enable, request_id
+        )
+        if error is not None:
+            duration_ms = int((time.time() - start_time) * 1000)
+            emit_audit_event("job.completed", request_id=request_id, status="failed", duration_ms=duration_ms)
+            return None, error
+        device_type = device_type_result  # type: ignore[assignment]  # autodetect guarantees non-None on success
+        detected_platform = device_type
+
+    # Skip pool for autodetect — can't pool without knowing platform upfront
+    use_pool = CONNECTION_POOL_ENABLED and detected_platform is None
+
     netmiko_device = {
         "device_type": device_type,
         "ip": ip,
@@ -104,12 +149,12 @@ def _netmiko_send_command_impl(
     try:
         net_connect = None
 
-        if CONNECTION_POOL_ENABLED:
+        if use_pool:
             net_connect = pool.get(ip, port, credentials.username, credentials.password, device_type)
 
         if net_connect is None:
             logger.debug("%s %s:Establishing connection...", request_id, ip)
-            netmiko_device["keepalive"] = CONNECTION_POOL_KEEPALIVE if CONNECTION_POOL_ENABLED else 0
+            netmiko_device["keepalive"] = CONNECTION_POOL_KEEPALIVE if use_pool else 0
             net_connect = netmiko.ConnectHandler(**netmiko_device)
         else:
             # Verify pooled connection is at a clean prompt before use
@@ -129,7 +174,7 @@ def _netmiko_send_command_impl(
                 kwargs["expect_string"] = expect_string
             net_output[command] = net_connect.send_command(command, **kwargs)
 
-        if CONNECTION_POOL_ENABLED:
+        if use_pool:
             pool.release(ip, port, credentials.username, credentials.password, device_type, net_connect)
         else:
             net_connect.disconnect()
@@ -154,6 +199,11 @@ def _netmiko_send_command_impl(
     logger.debug("%s %s:Netmiko executed successfully.", request_id, ip)
     duration_ms = int((time.time() - start_time) * 1000)
     emit_audit_event("job.completed", request_id=request_id, status="finished", duration_ms=duration_ms)
+
+    # Include detected_platform in results if autodetect was used
+    if detected_platform is not None:
+        net_output["_detected_platform"] = detected_platform
+
     return net_output, None
 
 

--- a/naas/models.py
+++ b/naas/models.py
@@ -40,7 +40,7 @@ class SendCommandRequest(BaseModel):
     ip: IPvAnyAddress = Field(..., description="Device IP address")
     commands: list[str] = Field(..., min_length=1, description="Commands to execute")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
-    platform: str = Field(default="cisco_ios", description="Netmiko device type")
+    platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
     expect_string: str | None = Field(
         default=None, description="Regex pattern to match in device output (overrides prompt detection)"
@@ -82,7 +82,7 @@ class SendConfigRequest(BaseModel):
     config: list[str] | None = Field(default=None, min_length=1, description="Configuration commands")
     commands: list[str] | None = Field(default=None, min_length=1, description="Configuration commands (alias)")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
-    platform: str = Field(default="cisco_ios", description="Netmiko device type")
+    platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
     save_config: bool = Field(default=False, description="Save configuration after applying")
     commit: bool = Field(default=False, description="Commit configuration (Juniper)")
@@ -133,6 +133,7 @@ class JobResultResponse(BaseModel):
     status: str
     results: Any | None = None
     error: str | None = None
+    detected_platform: str | None = None
 
 
 class ListJobsQuery(BaseModel):

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -52,8 +52,12 @@ class GetResults(Resource):
 
         if job_status == "finished":
             results = job.result
-            r["results"] = results[0]
+            result_dict = results[0]
+            r["results"] = result_dict
             r["error"] = results[1]
+            # Extract detected_platform if present
+            if result_dict and "_detected_platform" in result_dict:
+                r["detected_platform"] = result_dict.pop("_detected_platform")
         elif job_status == "failed":
             r["error"] = str(job.exc_info).strip() if job.exc_info else "Job failed"
 

--- a/tests/unit/test_netmiko_lib.py
+++ b/tests/unit/test_netmiko_lib.py
@@ -14,7 +14,33 @@ from naas.library.auth import Credentials
 naas.library.circuit_breaker._redis_client = FakeStrictRedis()
 
 from naas.library.circuit_breaker import RedisCircuitBreakerStorage  # noqa: E402,I001
-from naas.library.netmiko_lib import netmiko_send_command, netmiko_send_config  # noqa: E402,I001
+from naas.library.netmiko_lib import _autodetect_platform, netmiko_send_command, netmiko_send_config  # noqa: E402,I001
+
+
+class TestAutodetectPlatform:
+    """Tests for _autodetect_platform function."""
+
+    def test_autodetect_success(self):
+        """Test successful platform detection."""
+        with patch("naas.library.netmiko_lib.netmiko.SSHDetect") as mock_detect:
+            mock_guesser = MagicMock()
+            mock_guesser.autodetect.return_value = "cisco_nxos"
+            mock_detect.return_value = mock_guesser
+
+            platform, error = _autodetect_platform("192.168.1.1", 22, "user", "pass", "enable", "req-123")
+
+            assert platform == "cisco_nxos"
+            assert error is None
+
+    def test_autodetect_failure(self):
+        """Test platform detection failure."""
+        with patch("naas.library.netmiko_lib.netmiko.SSHDetect") as mock_detect:
+            mock_detect.side_effect = Exception("Connection failed")
+
+            platform, error = _autodetect_platform("192.168.1.1", 22, "user", "pass", "enable", "req-123")
+
+            assert platform is None
+            assert "Platform autodetect failed" in error
 
 
 class TestNetmikoSendCommand:
@@ -103,6 +129,33 @@ class TestNetmikoSendCommand:
                 mock_conn.send_command.assert_called_once_with(
                     "ping 8.8.8.8", read_timeout=30.0, expect_string=r"Success rate"
                 )
+
+    def test_autodetect_success(self):
+        """Test platform autodetect success path."""
+        creds = Credentials(username="testuser", password="testpass")
+
+        with patch("naas.library.netmiko_lib._autodetect_platform", return_value=("cisco_ios", None)):
+            with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
+                mock_conn = MagicMock()
+                mock_conn.send_command.return_value = "output"
+                mock_handler.return_value = mock_conn
+
+                result, error = netmiko_send_command("192.168.1.1", creds, "autodetect", ["show version"])
+
+                assert error is None
+                assert result["_detected_platform"] == "cisco_ios"
+                # Verify ConnectHandler was called with detected platform
+                assert mock_handler.call_args[1]["device_type"] == "cisco_ios"
+
+    def test_autodetect_failure(self):
+        """Test platform autodetect failure path."""
+        creds = Credentials(username="testuser", password="testpass")
+
+        with patch("naas.library.netmiko_lib._autodetect_platform", return_value=(None, "Detection failed")):
+            result, error = netmiko_send_command("192.168.1.1", creds, "autodetect", ["show version"])
+
+            assert result is None
+            assert "Detection failed" in error
 
     def test_timeout_error(self):
         """Test timeout exception handling."""

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -429,6 +429,34 @@ class TestGetResults:
         assert response.json["results"] == "command output"
         assert response.json["error"] is None
 
+    def test_get_results_with_detected_platform(self, app, client):
+        """Test GET with autodetect returns detected_platform."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        job_id = "33333333-3333-3333-3333-333333333333"
+
+        job = MagicMock()
+        job.get_status = lambda: "finished"
+        job.result = ({"show version": "output", "_detected_platform": "cisco_nxos"}, None)
+
+        def fetch_side_effect(job_id_param):
+            if job_id_param == job_id:
+                return job
+            return None
+
+        app.config["q"].fetch_job.side_effect = fetch_side_effect
+
+        with patch("naas.resources.get_results.job_unlocker", return_value=True):
+            response = client.get(
+                f"/v1/send_command/{job_id}",
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 200
+        assert response.json["detected_platform"] == "cisco_nxos"
+        assert "_detected_platform" not in response.json["results"]
+
     def test_get_results_no_auth(self, client):
         """Test GET without auth returns 401."""
         response = client.get("/v1/send_command/00000000-0000-0000-0000-000000000000")


### PR DESCRIPTION
Adds `platform: "autodetect"` support for discovery workflows and heterogeneous environments.

## How it works
- Pass `platform: "autodetect"` in the request
- NAAS runs `SSHDetect` to fingerprint the device
- Detected platform is returned in the job result as `detected_platform`
- The detected type is used for the actual command execution

## Caveats
- **Two SSH connections** per job (fingerprint + commands) — adds overhead
- **No connection pooling** for autodetect jobs (can't pool without knowing platform upfront)
- Best for discovery, not production automation against known devices

## Changes
- **Models**: `platform` description updated, `detected_platform` added to `JobResultResponse`
- **Library**: `_autodetect_platform()` helper, pooling disabled for autodetect
- **get_results**: extracts `_detected_platform` from results and adds to response
- **docs/troubleshooting.md**: autodetect example with caveats

Closes #222