### PR TITLE
fix(docs): add spaces around table pipe separators (MD060)

### DIFF
--- a/changes/+md060-table-fix.doc.md
+++ b/changes/+md060-table-fix.doc.md
@@ -1,0 +1,1 @@
+Fix MD060 table column style violations across documentation files.

--- a/docs/COVERAGE.md
+++ b/docs/COVERAGE.md
@@ -10,7 +10,7 @@
 ## Coverage Breakdown
 
 | Module | Coverage |
-|--------|----------|
+| -------- | ---------- |
 | `naas/__init__.py` | 100% |
 | `naas/app.py` | 100% |
 | `naas/config.py` | 100% |

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -5,7 +5,7 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 ## Redis
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `REDIS_HOST` | `redis` | Redis hostname |
 | `REDIS_PORT` | `6379` | Redis port |
 | `REDIS_PASSWORD` | `mah_redis_pw` | Redis password |
@@ -13,27 +13,27 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 ## Application
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `APP_ENVIRONMENT` | `production` | Set to `dev` for debug logging and relaxed settings |
 | `LOG_LEVEL` | `INFO` | Log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). Overridden to `DEBUG` when `APP_ENVIRONMENT=dev` |
 
 ## Jobs
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `JOB_TTL_SUCCESS` | `86400` | Seconds to retain successful job results in Redis (default: 24h) |
 | `JOB_TTL_FAILED` | `604800` | Seconds to retain failed job results in Redis (default: 7 days) |
 
 ## Worker
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `SHUTDOWN_TIMEOUT` | `60` | Seconds to wait for an in-flight job to complete before force-exiting on SIGTERM |
 
 ## Circuit Breaker
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `CIRCUIT_BREAKER_ENABLED` | `true` | Set to `false` to disable the circuit breaker entirely |
 | `CIRCUIT_BREAKER_THRESHOLD` | `5` | Number of consecutive failures before a device's circuit opens |
 | `CIRCUIT_BREAKER_TIMEOUT` | `300` | Seconds before a tripped circuit attempts recovery (half-open state) |
@@ -41,7 +41,7 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 ## Connection Pool
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `CONNECTION_POOL_ENABLED` | `true` | Enable persistent SSH connection pooling |
 | `CONNECTION_POOL_MAX_SIZE` | `10` | Maximum connections per worker |
 | `CONNECTION_POOL_TTL` | `300` | Idle timeout in seconds before closing connections |

--- a/docs/development.md
+++ b/docs/development.md
@@ -35,7 +35,7 @@ NAAS uses a Git Flow-inspired model with long-lived release branches.
 ### Long-lived branches
 
 | Branch | Purpose |
-|---|---|
+| --- | --- |
 | `main` | Production releases only (`v1.0.0`, `v1.1.0`) |
 | `develop` | Integration branch (`v1.2.0a1`) |
 | `release/X.Y` | Maintenance branches — kept permanently |
@@ -43,7 +43,7 @@ NAAS uses a Git Flow-inspired model with long-lived release branches.
 ### Feature branch types (from `develop`)
 
 | Prefix | Use |
-|---|---|
+| --- | --- |
 | `feature/` | New features |
 | `fix/` | Bug fixes in unreleased code |
 | `docs/` | Documentation changes |
@@ -72,7 +72,7 @@ All commits must follow [Conventional Commits](https://www.conventionalcommits.o
 ```
 
 | Type | Use |
-|---|---|
+| --- | --- |
 | `feat` | New feature |
 | `fix` | Bug fix |
 | `docs` | Documentation only |
@@ -154,7 +154,7 @@ uv run invoke changelog-draft
 ### Fragment types
 
 | Type | Shown to users | Use |
-|---|---|---|
+| --- | --- | --- |
 | `feature` | ✅ | New features |
 | `bugfix` | ✅ | Bug fixes |
 | `security` | ✅ | Security improvements |
@@ -316,7 +316,7 @@ git push
 ### Common mistakes to avoid
 
 | ❌ Don't | ✅ Do |
-|---|---|
+| --- | --- |
 | Run `towncrier build` manually | Let CI build changelog |
 | Bump version on `develop` before release | Only bump on `release/X.Y` |
 | Create release branch from `main` | Always branch from `develop` |

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -104,7 +104,7 @@ targeting the `naas-api` Service and mount the resulting secret into the API pod
 The manifests include conservative defaults suitable for a small deployment:
 
 | Component | Memory request | Memory limit | CPU request | CPU limit |
-|-----------|---------------|--------------|-------------|-----------|
+| ----------- | --------------- | -------------- | ------------- | ----------- |
 | API | 256Mi | 768Mi | 100m | 500m |
 | Worker | 128Mi | 512Mi | 100m | 500m |
 | Redis | 64Mi | 256Mi | 50m | 200m |
@@ -128,7 +128,7 @@ NAAS reuses SSH connections across sequential jobs to the same device, reducing 
 overhead on network equipment. Pooling is enabled by default.
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| ---------- | --------- | ------------- |
 | `CONNECTION_POOL_ENABLED` | `true` | Set to `false` to disable pooling for all devices |
 | `CONNECTION_POOL_MAX_SIZE` | `10` | Max pooled connections per worker process |
 | `CONNECTION_POOL_IDLE_TIMEOUT` | `300` | Evict connections idle for this many seconds |
@@ -162,7 +162,7 @@ Prometheus instance to scrape port `443` (HTTPS) with the appropriate TLS config
 use a `ServiceMonitor` if running the Prometheus Operator.
 
 | Metric | Type | Description |
-|--------|------|-------------|
+| -------- | ------ | ------------- |
 | `naas_http_requests_total` | Counter | Total HTTP requests by endpoint, method, and status code |
 | `naas_http_request_duration_seconds` | Histogram | Request latency by endpoint |
 | `naas_queue_depth` | Gauge | Number of jobs waiting in the RQ queue |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,7 +14,7 @@ NAAS provides structured logging, request tracing, and Prometheus metrics for mo
 All log output is JSON. Each line includes:
 
 | Field | Description |
-|---|---|
+| --- | --- |
 | `timestamp` | ISO 8601 timestamp |
 | `level` | Log level (`INFO`, `DEBUG`, `WARNING`, `ERROR`) |
 | `logger` | Logger name (e.g. `NAAS`) |

--- a/docs/release-notes/v1.1.md
+++ b/docs/release-notes/v1.1.md
@@ -133,7 +133,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 Repeated connection failures to a device automatically open a circuit breaker, fast-failing subsequent requests to that device for a configurable timeout period. This prevents a single unreachable device from exhausting the worker pool.
 
 | Environment variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `CIRCUIT_BREAKER_THRESHOLD` | `5` | Failures before circuit opens |
 | `CIRCUIT_BREAKER_TIMEOUT` | `300` | Seconds before circuit attempts recovery |
 
@@ -148,7 +148,7 @@ If 10 connection failures to the same device IP occur within 10 minutes (across 
 Workers now handle `SIGTERM` gracefully — finishing any in-flight job before exiting. This prevents job loss during container restarts and deployments.
 
 | Environment variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `SHUTDOWN_TIMEOUT` | `60` | Seconds to wait for in-flight job before force-exit |
 
 ### Configurable job TTLs
@@ -156,7 +156,7 @@ Workers now handle `SIGTERM` gracefully — finishing any in-flight job before e
 Job results are retained in Redis for a configurable period:
 
 | Environment variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `JOB_TTL_SUCCESS` | `86400` (24h) | Retention for successful job results |
 | `JOB_TTL_FAILED` | `604800` (7 days) | Retention for failed job results |
 

--- a/docs/release-notes/v1.2.md
+++ b/docs/release-notes/v1.2.md
@@ -47,7 +47,7 @@ NAAS now maintains persistent SSH connections to frequently-accessed devices. Su
 Connections are automatically managed with configurable timeouts and pool sizes:
 
 | Environment variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `CONNECTION_POOL_ENABLED` | `true` | Enable connection pooling |
 | `CONNECTION_POOL_MAX_SIZE` | `100` | Maximum connections per worker |
 | `CONNECTION_POOL_TTL` | `300` | Seconds before idle connection closes |

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -28,7 +28,7 @@ When a circuit is open, the job completes immediately with `status: failed` and 
 ### Configuration
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `CIRCUIT_BREAKER_ENABLED` | `true` | Disable entirely if needed |
 | `CIRCUIT_BREAKER_THRESHOLD` | `5` | Failures before circuit opens |
 | `CIRCUIT_BREAKER_TIMEOUT` | `300` | Seconds before recovery attempt |
@@ -69,7 +69,7 @@ Workers handle `SIGTERM` gracefully. When a shutdown signal is received:
 This prevents job loss during container restarts, deployments, and scaling events.
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `SHUTDOWN_TIMEOUT` | `60` | Seconds to wait for in-flight job before force-exit |
 
 ## Job TTL
@@ -77,7 +77,7 @@ This prevents job loss during container restarts, deployments, and scaling event
 Job results are retained in Redis for a configurable period to prevent unbounded memory growth:
 
 | Variable | Default | Description |
-|---|---|---|
+| --- | --- | --- |
 | `JOB_TTL_SUCCESS` | `86400` | Seconds to retain successful results (24h) |
 | `JOB_TTL_FAILED` | `604800` | Seconds to retain failed results (7 days) |
 


### PR DESCRIPTION
Fixes MD060/table-column-style violations introduced by markdownlint-cli2-action@v22 (bumped in #256).

Affected files: COVERAGE.md, environment-variables.md, development.md, kubernetes.md, observability.md, v1.1.md, v1.2.md, reliability.md