### PR TITLE
fix: use ARG PYTHON_VERSION in Dockerfile instead of hardcoded 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ########################################
 # Multi-stage build for optimized image size
-FROM python:3.11-slim AS builder
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim AS builder
 
 # Fixes encoding-related bugs
 ENV LC_ALL=C.UTF-8
@@ -19,7 +20,8 @@ RUN uv export --no-dev --no-emit-project | uv pip install --system -r /dev/stdin
 
 ########################################
 # Final runtime image
-FROM python:3.11-slim
+ARG PYTHON_VERSION=3.11
+FROM python:${PYTHON_VERSION}-slim
 
 # Fixes encoding-related bugs
 ENV LC_ALL=C.UTF-8
@@ -40,8 +42,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -r -u 1000 -s /sbin/nologin naas
 
-# Copy installed packages from builder
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+# Copy installed packages from builder using dynamic Python version path
+ARG PYTHON_VERSION=3.11
+COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages /usr/local/lib/python${PYTHON_VERSION}/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Make our working dir "/app"

--- a/changes/261.bugfix.md
+++ b/changes/261.bugfix.md
@@ -1,0 +1,1 @@
+Fix Dockerfile hardcoded python3.11 path to use ARG PYTHON_VERSION, enabling base image upgrades.


### PR DESCRIPTION
Closes #261

Replace hardcoded `python3.11` path in the multi-stage COPY with `ARG PYTHON_VERSION=3.11`, allowing dependabot to bump the base image without breaking the build.