### PR TITLE
ci: add Python 3.12/3.13/3.14 to test matrix, bump Docker to 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        run: uv python install 3.14
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
 
@@ -18,7 +22,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -32,12 +36,16 @@ jobs:
         with:
           files: ./coverage.xml
           flags: unit
-          name: unit-tests
+          name: unit-tests-${{ matrix.python-version }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
 
@@ -47,7 +55,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -61,6 +69,10 @@ jobs:
 
   contract-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v6
 
@@ -70,7 +82,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ########################################
 # Multi-stage build for optimized image size
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-slim AS builder
 
 # Fixes encoding-related bugs
@@ -20,7 +20,7 @@ RUN uv export --no-dev --no-emit-project | uv pip install --system -r /dev/stdin
 
 ########################################
 # Final runtime image
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.14
 FROM python:${PYTHON_VERSION}-slim
 
 # Fixes encoding-related bugs

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
     useradd -r -u 1000 -s /sbin/nologin naas
 
 # Copy installed packages from builder using dynamic Python version path
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.14
 COPY --from=builder /usr/local/lib/python${PYTHON_VERSION}/site-packages /usr/local/lib/python${PYTHON_VERSION}/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 

--- a/changes/263.testing.md
+++ b/changes/263.testing.md
@@ -1,0 +1,1 @@
+Add Python 3.12, 3.13, and 3.14 to CI test matrix. Bump Docker default base image to python:3.14-slim.


### PR DESCRIPTION
Closes #263

- Add matrix `["3.11", "3.12", "3.13", "3.14"]` to unit, integration, and contract test jobs
- `fail-fast: false` so all versions run even if one fails
- Bump Dockerfile default from `python:3.11-slim` to `python:3.14-slim`