### PR TITLE
docs: establish ADR process using MADR format

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           use-quiet-mode: 'yes'
           config-file: '.markdown-link-check.json'
+          exclude-file: 'docs/adr/template.md'
 
   check-openapi-spec:
     runs-on: ubuntu-latest

--- a/.kiro/agents/naas-dev-prompt.md
+++ b/.kiro/agents/naas-dev-prompt.md
@@ -286,6 +286,7 @@ chore(deps): upgrade netmiko to 4.6.0
 
 - `pyproject.toml` - Project config, dependencies, version
 - `CONTRIBUTING.md` - Development guidelines
+- `docs/adr/` - Architectural Decision Records (MADR format)
 - `CHANGELOG.md` - Generated from fragments
 - `changes/` - Changelog fragments directory
 - `changes/template.md.j2` - Changelog template
@@ -401,6 +402,7 @@ gh pr create --base develop --title "Title" --body "Description"
 
 1. **Pause and ask** - Don't assume, clarify with the user
 2. Check CONTRIBUTING.md for documented workflow
+3. Check `docs/adr/` for prior architectural decisions
 3. Look at recent PRs for examples
 4. Default to conservative approach (create issue, add fragment, target develop)
 5. **Explain your uncertainty** - "I'm unsure about X because Y. Should I Z?"

--- a/changes/265.doc.md
+++ b/changes/265.doc.md
@@ -1,0 +1,1 @@
+Establish ADR process using MADR format. Add docs/adr/ directory with template and first ADR for Python client library integration strategy.

--- a/docs/adr/0001-python-client-library-integration.md
+++ b/docs/adr/0001-python-client-library-integration.md
@@ -1,0 +1,53 @@
+# Python Client Library Integration Strategy
+
+* Status: Accepted
+* Date: 2026-03-18
+
+## Context and Problem Statement
+
+NAAS needs a Python client library (`naas-client`) to simplify integration for users. The library will be developed as a separate package/repository. The question is how to integrate it with the NAAS repository for testing purposes — specifically, whether to use a git submodule or install it as a dependency at test time.
+
+## Decision Drivers
+
+* Minimize CI complexity and contributor friction
+* Enable integration tests to validate the client against NAAS
+* Maintain clean separation between NAAS and the client library
+* Follow standard Python packaging practices
+
+## Considered Options
+
+* Git submodule — embed `naas-client` repo inside NAAS repo
+* Install at test time — `pip install naas-client` (pinned version) in CI
+
+## Decision Outcome
+
+Chosen option: **Install at test time**, because it follows standard Python packaging practices, keeps CI simple, and avoids submodule complexity. The separation of concerns is clean: NAAS is the server, `naas-client` is a consumer like any other.
+
+### Consequences
+
+* Good: No submodule management (`git submodule update --init`) required for contributors
+* Good: Client failures don't block NAAS CI — pin a known-good version
+* Good: Standard pattern — any Python project can depend on `naas-client` the same way
+* Bad: Must publish `naas-client` to PyPI (or GitHub Packages) before testing new client features against unreleased NAAS changes
+* Bad: Version pin can drift — requires periodic updates when client releases
+
+## Pros and Cons of the Options
+
+### Git submodule
+
+* Good: Atomic commits across both repos
+* Good: Can test unreleased client against unreleased NAAS simultaneously
+* Good: No PyPI publish required to run tests
+* Bad: `git submodule update --init` required in CI and local dev
+* Bad: Detached HEAD confusion for contributors
+* Bad: Client breakage blocks NAAS CI even when NAAS itself is unchanged
+* Bad: Adds onboarding friction
+
+### Install at test time
+
+* Good: Zero friction — standard dependency declaration
+* Good: Clean CI — just `uv sync --extra dev`
+* Good: Client and NAAS fail independently
+* Good: Follows Python ecosystem conventions
+* Bad: Requires PyPI publish before integration testing new client versions
+* Bad: Version pin maintenance overhead

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,36 @@
+# Architectural Decision Records
+
+This directory contains Architectural Decision Records (ADRs) for NAAS, using the [MADR format](https://adr.github.io/madr/).
+
+## What is an ADR?
+
+An ADR documents a significant architectural or technical decision: what was decided, why, and what the consequences are. ADRs are immutable once accepted — if a decision changes, a new ADR supersedes the old one.
+
+## When to Write an ADR
+
+Write an ADR when:
+
+- Choosing between two or more non-trivial technical approaches
+- Making a decision that would be hard to reverse
+- Adopting a new tool, pattern, or dependency that affects the whole project
+- Deciding on a convention that all contributors must follow
+
+Do **not** write an ADR for:
+
+- Implementation details (use code comments or PR descriptions)
+- Bug fixes
+- Routine dependency updates
+
+## How to Add an ADR
+
+1. Copy `template.md` to `NNNN-short-title.md` (next sequential number)
+2. Fill in all sections
+3. Set status to `Proposed`
+4. Open a PR — discussion happens in the PR review
+5. On merge, update status to `Accepted`
+
+## Index
+
+| ADR | Title | Status |
+| --- | --- | --- |
+| [0001](0001-python-client-library-integration.md) | Python client library integration strategy | Accepted |

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,41 @@
+# ADR Template
+
+## [Short title of the decision]
+
+* Status: [Proposed | Accepted | Deprecated | Superseded by [ADR-NNNN](NNNN-title.md)]
+* Date: YYYY-MM-DD
+
+## Context and Problem Statement
+
+What is the issue or question that motivated this decision?
+
+## Decision Drivers
+
+* [driver 1]
+* [driver 2]
+
+## Considered Options
+
+* [Option 1]
+* [Option 2]
+
+## Decision Outcome
+
+Chosen option: **[option]**, because [justification].
+
+### Consequences
+
+* Good: [positive consequence]
+* Bad: [negative consequence / trade-off accepted]
+
+## Pros and Cons of the Options
+
+### [Option 1]
+
+* Good: [reason]
+* Bad: [reason]
+
+### [Option 2]
+
+* Good: [reason]
+* Bad: [reason]

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -2,7 +2,7 @@
 
 ## [Short title of the decision]
 
-* Status: [Proposed | Accepted | Deprecated | Superseded by [ADR-NNNN](NNNN-title.md)]
+* Status: [Proposed | Accepted | Deprecated | Superseded by ADR-NNNN]
 * Date: YYYY-MM-DD
 
 ## Context and Problem Statement

--- a/docs/development.md
+++ b/docs/development.md
@@ -346,3 +346,20 @@ uv add package-name           # Add runtime dependency
 uv add --dev package-name     # Add dev dependency
 # Commit both pyproject.toml and uv.lock
 ```
+
+## Architectural Decision Records (ADRs)
+
+Significant architectural decisions are documented as ADRs in `docs/adr/` using [MADR format](https://adr.github.io/madr/).
+
+**When to write an ADR:** choosing between non-trivial technical approaches, adopting a new tool or pattern, or making a hard-to-reverse decision.
+
+**How to add one:**
+
+```bash
+# Copy the template and fill it in
+cp docs/adr/template.md docs/adr/NNNN-short-title.md
+# Open a PR — discussion happens in review
+# Update docs/adr/README.md index
+```
+
+See [docs/adr/README.md](adr/README.md) for the full process.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,9 @@ nav:
       - Testing: testing.md
   - Reference:
       - API Reference: api-reference.md
+      - Architecture Decisions:
+          - ADR Index: adr/README.md
+          - "0001: Python Client Integration": adr/0001-python-client-library-integration.md
       - Changelog: changelog.md
       - Release Notes:
           - v1.3: release-notes/v1.3.md


### PR DESCRIPTION
Closes #265

- `docs/adr/README.md` — process guide
- `docs/adr/template.md` — MADR template
- `docs/adr/0001-python-client-library-integration.md` — first ADR (pip install vs submodule)
- mkdocs.yml navigation updated
- development.md ADR section added
- kiro agent config updated