### PR TITLE
feat: generate Postman collection and attach to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,16 @@ jobs:
             mv .changelog-final.md .changelog-excerpt.md
           fi
 
+      - name: Generate API client collections
+        run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
+          # Generate Postman collection from OpenAPI spec
+          npx --yes openapi-to-postmanv2 \
+            -s docs/swagger/openapi.json \
+            -o "naas-v${VERSION}.postman_collection.json"
+          # Copy OpenAPI spec with versioned filename
+          cp docs/swagger/openapi.json "naas-v${VERSION}.openapi.json"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -183,3 +193,6 @@ jobs:
           body_path: .changelog-excerpt.md
           draft: false
           prerelease: ${{ needs.check-version.outputs.is_prerelease }}
+          files: |
+            naas-v${{ needs.check-version.outputs.version }}.postman_collection.json
+            naas-v${{ needs.check-version.outputs.version }}.openapi.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,11 @@ jobs:
             mv .changelog-final.md .changelog-excerpt.md
           fi
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Generate API client collections
         run: |
           VERSION="${{ needs.check-version.outputs.version }}"

--- a/changes/92.doc.md
+++ b/changes/92.doc.md
@@ -1,0 +1,1 @@
+Add Postman collection and OpenAPI spec as release artifacts. Document API client import instructions for Postman, Insomnia, and Bruno.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -574,6 +574,28 @@ def send_command_safe(ip, commands):
     return None
 ```
 
+## API Client Collections
+
+Each NAAS release includes downloadable API client collections on the [GitHub Releases page](https://github.com/lykinsbd/naas/releases):
+
+- `naas-vX.Y.Z.postman_collection.json` — Postman collection with all endpoints
+- `naas-vX.Y.Z.openapi.json` — OpenAPI spec for import into any compatible tool
+
+### Postman
+
+1. Download `naas-vX.Y.Z.postman_collection.json` from the release
+2. In Postman: **Import** → select the file
+3. Set environment variables: `base_url`, `username`, `password`
+
+### Insomnia
+
+1. Download `naas-vX.Y.Z.openapi.json` from the release
+2. In Insomnia: **Create** → **Import** → select the file
+
+### Bruno / Other Tools
+
+Import `naas-vX.Y.Z.openapi.json` — any OpenAPI 3.x compatible client works.
+
 ## Next steps
 
 - [Troubleshooting Guide](troubleshooting.md) - Common issues


### PR DESCRIPTION
Closes #92

- Auto-generate `naas-vX.Y.Z.postman_collection.json` via `openapi-to-postmanv2` in release workflow
- Attach Postman collection and `openapi.json` to each GitHub release
- Add API client import instructions to `docs/api-usage.md` (Postman, Insomnia, Bruno)