### PR TITLE
feat: add TTP structured output support to send_command_structured

### DIFF
--- a/changes/246.feature.md
+++ b/changes/246.feature.md
@@ -1,0 +1,1 @@
+Add TTP structured output support to /v1/send_command_structured endpoint via ttp_template parameter. Mutually exclusive with textfsm_template.

--- a/docs/structured-output.md
+++ b/docs/structured-output.md
@@ -218,3 +218,50 @@ response = requests.post(
     verify=False
 )
 ```
+
+## TTP (Template Text Parser)
+
+[TTP](https://ttp.readthedocs.io/) is an alternative parser with Jinja2-like syntax. Use it when you prefer TTP's template style or need features not available in TextFSM.
+
+Pass a `ttp_template` instead of `textfsm_template` — the two are mutually exclusive:
+
+```bash
+curl -k -u "username:password" https://localhost:8443/v1/send_command_structured \
+  -H "Content-Type: application/json" \
+  -d '{
+    "ip": "192.168.1.1",
+    "platform": "cisco_ios",
+    "commands": ["show interfaces"],
+    "ttp_template": "interface {{ interface }}\n ip address {{ ip }} {{ mask }}"
+  }'
+```
+
+### TTP Template Syntax
+
+TTP templates use `{{ variable }}` placeholders:
+
+```text
+interface {{ interface }}
+ ip address {{ ip }} {{ mask }}
+ description {{ description | ORPHRASE }}
+```
+
+See [TTP documentation](https://ttp.readthedocs.io/) for full syntax.
+
+### Community Templates
+
+The [`ttp-templates`](https://github.com/dmulyalin/ttp_templates) library provides community-maintained templates. Reference them with `ttp://` prefix:
+
+```json
+{
+  "ttp_template": "ttp://platform/cisco_ios/show_interfaces.txt"
+}
+```
+
+### When to Use TTP vs TextFSM
+
+| | TextFSM | TTP |
+| --- | --- | --- |
+| Community templates | ntc-templates (large, active) | ttp-templates (small) |
+| Template syntax | Regex-based | Jinja2-like |
+| Best for | Standard commands with ntc-templates coverage | Custom parsing, complex structures |

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -121,7 +121,7 @@
         "type": "object"
       },
       "SendCommandStructuredRequest.c5eb086": {
-        "description": "Request model for structured send_command with TextFSM parsing.\n\nReturns parsed output as list[dict] per command. Falls back to raw string\nif no template is found.",
+        "description": "Request model for structured send_command with TextFSM or TTP parsing.\n\nReturns parsed output as list[dict] per command. Falls back to raw string\nif no template is found.",
         "properties": {
           "commands": {
             "description": "Commands to execute",
@@ -171,6 +171,19 @@
             "default": null,
             "description": "Custom TextFSM template (uses ntc-templates if not provided)",
             "title": "Textfsm Template"
+          },
+          "ttp_template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "TTP template string or ttp://<path> reference (mutually exclusive with textfsm_template)",
+            "title": "Ttp Template"
           }
         },
         "required": [

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -115,6 +115,8 @@ def _netmiko_send_command_impl(
     expect_string: str | None = None,
     use_textfsm: bool = False,
     textfsm_template: str | None = None,
+    use_ttp: bool = False,
+    ttp_template: str | None = None,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -136,8 +138,8 @@ def _netmiko_send_command_impl(
         device_type = device_type_result
         detected_platform = device_type
 
-    # Skip pool for autodetect or TextFSM (template state makes pooling unreliable)
-    use_pool = CONNECTION_POOL_ENABLED and detected_platform is None and not use_textfsm
+    # Skip pool for autodetect, TextFSM, or TTP (template state makes pooling unreliable)
+    use_pool = CONNECTION_POOL_ENABLED and detected_platform is None and not use_textfsm and not use_ttp
 
     netmiko_device = {
         "device_type": device_type,
@@ -183,6 +185,10 @@ def _netmiko_send_command_impl(
                 kwargs["use_textfsm"] = True
                 if textfsm_template is not None:
                     kwargs["textfsm_template"] = textfsm_template
+            if use_ttp:
+                kwargs["use_ttp"] = True
+                if ttp_template is not None:
+                    kwargs["ttp_template"] = ttp_template
             net_output[command] = net_connect.send_command(command, **kwargs)
 
         if use_pool:
@@ -226,14 +232,18 @@ def netmiko_send_command_structured(
     port: int = 22,
     read_timeout: float = 30.0,
     textfsm_template: str | None = None,
+    ttp_template: str | None = None,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
     """
-    Send commands with TextFSM parsing for structured output.
+    Send commands with TextFSM or TTP parsing for structured output.
 
-    Thin wrapper around _netmiko_send_command_impl with use_textfsm=True.
+    Thin wrapper around _netmiko_send_command_impl. Exactly one of
+    textfsm_template/use_textfsm or ttp_template/use_ttp should be set.
     """
+    use_textfsm = ttp_template is None
+    use_ttp = ttp_template is not None
     if CIRCUIT_BREAKER_ENABLED:
         return with_circuit_breaker(  # type: ignore[no-any-return]
             ip,
@@ -246,13 +256,27 @@ def netmiko_send_command_structured(
             port,
             read_timeout,
             None,  # expect_string
-            True,  # use_textfsm
+            use_textfsm,
             textfsm_template,
+            use_ttp,
+            ttp_template,
             verbose,
             request_id,
         )
     return _netmiko_send_command_impl(
-        ip, credentials, device_type, commands, port, read_timeout, None, True, textfsm_template, verbose, request_id
+        ip,
+        credentials,
+        device_type,
+        commands,
+        port,
+        read_timeout,
+        None,
+        use_textfsm,
+        textfsm_template,
+        use_ttp,
+        ttp_template,
+        verbose,
+        request_id,
     )
 
 

--- a/naas/models.py
+++ b/naas/models.py
@@ -84,7 +84,7 @@ class SendCommandRequest(_BaseCommandRequest):
 
 
 class SendCommandStructuredRequest(_BaseCommandRequest):
-    """Request model for structured send_command with TextFSM parsing.
+    """Request model for structured send_command with TextFSM or TTP parsing.
 
     Returns parsed output as list[dict] per command. Falls back to raw string
     if no template is found.
@@ -93,6 +93,17 @@ class SendCommandStructuredRequest(_BaseCommandRequest):
     textfsm_template: str | None = Field(
         default=None, description="Custom TextFSM template (uses ntc-templates if not provided)"
     )
+    ttp_template: str | None = Field(
+        default=None,
+        description="TTP template string or ttp://<path> reference (mutually exclusive with textfsm_template)",
+    )
+
+    @model_validator(mode="after")
+    def validate_parser_exclusivity(self) -> "SendCommandStructuredRequest":
+        """Ensure textfsm_template and ttp_template are mutually exclusive."""
+        if self.textfsm_template is not None and self.ttp_template is not None:
+            raise ValueError("textfsm_template and ttp_template are mutually exclusive")
+        return self
 
 
 class SendConfigRequest(BaseModel):

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -74,6 +74,7 @@ class SendCommandStructured(Resource):
             commands=validated.commands,
             read_timeout=validated.read_timeout,
             textfsm_template=validated.textfsm_template,
+            ttp_template=validated.ttp_template,
             request_id=g.request_id,
             job_id=g.request_id,
             job_timeout=JOB_TIMEOUT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "scp>=0.13.2",
     "spectree>=2.0.1",
     "textfsm>=1.1.0",
+    "ttp>=0.10.0",
+    "ttp-templates>=0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_netmiko_lib.py
+++ b/tests/unit/test_netmiko_lib.py
@@ -246,6 +246,25 @@ class TestNetmikoSendCommandStructured:
             call_kwargs = mock_conn.send_command.call_args[1]
             assert call_kwargs["textfsm_template"] == template
 
+    def test_structured_with_ttp_template(self):
+        """Test structured command with TTP template."""
+        creds = Credentials(username="testuser", password="testpass")
+        template = "interface {{ interface }}\n ip address {{ ip }} {{ mask }}"
+
+        with patch("naas.library.netmiko_lib.netmiko.ConnectHandler") as mock_handler:
+            mock_conn = MagicMock()
+            mock_conn.send_command.return_value = [[{"interface": "Gi0/0", "ip": "10.0.0.1", "mask": "255.255.255.0"}]]
+            mock_handler.return_value = mock_conn
+
+            result, error = netmiko_send_command_structured(
+                "192.168.1.1", creds, "cisco_ios", ["show interfaces"], ttp_template=template
+            )
+
+            assert error is None
+            call_kwargs = mock_conn.send_command.call_args[1]
+            assert call_kwargs["use_ttp"] is True
+            assert call_kwargs["ttp_template"] == template
+
     def test_structured_timeout_error(self):
         """Test structured command timeout handling."""
         creds = Credentials(username="testuser", password="testpass")

--- a/tests/unit/test_send_command_structured.py
+++ b/tests/unit/test_send_command_structured.py
@@ -79,3 +79,47 @@ class TestSendCommandStructured:
             )
 
         assert response.status_code == 403
+
+    def test_post_with_ttp_template(self, app, client):
+        """Test POST with TTP template."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        mock_job = MagicMock()
+        mock_job.id = "test-job-id"
+        mock_job.meta = {}
+        app.config["q"].enqueue.return_value = mock_job
+
+        with patch("naas.resources.send_command_structured.device_lockout", return_value=False):
+            with patch("naas.resources.send_command_structured.job_locker"):
+                with patch("naas.resources.send_command_structured.emit_audit_event"):
+                    response = client.post(
+                        "/v1/send_command_structured",
+                        json={
+                            "ip": "192.168.1.1",
+                            "commands": ["show interfaces"],
+                            "ttp_template": "interface {{ interface }}",
+                        },
+                        headers={"Authorization": f"Basic {auth}"},
+                    )
+
+        assert response.status_code == 202
+        call_kwargs = app.config["q"].enqueue.call_args[1]
+        assert call_kwargs["ttp_template"] == "interface {{ interface }}"
+
+    def test_post_textfsm_and_ttp_mutually_exclusive(self, app, client):
+        """Test POST with both textfsm_template and ttp_template returns 422."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        response = client.post(
+            "/v1/send_command_structured",
+            json={
+                "ip": "192.168.1.1",
+                "commands": ["show version"],
+                "textfsm_template": "Value TEST (\\S+)",
+                "ttp_template": "interface {{ interface }}",
+            },
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 422

--- a/uv.lock
+++ b/uv.lock
@@ -1104,6 +1104,8 @@ dependencies = [
     { name = "scp" },
     { name = "spectree" },
     { name = "textfsm" },
+    { name = "ttp" },
+    { name = "ttp-templates" },
 ]
 
 [package.optional-dependencies]
@@ -1162,6 +1164,8 @@ requires-dist = [
     { name = "spectree", specifier = ">=2.0.1" },
     { name = "textfsm", specifier = ">=1.1.0" },
     { name = "towncrier", marker = "extra == 'dev'", specifier = ">=23.11.0" },
+    { name = "ttp", specifier = ">=0.10.0" },
+    { name = "ttp-templates", specifier = ">=0.4.0" },
 ]
 provides-extras = ["dev"]
 
@@ -1938,6 +1942,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ttp"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/e6/9169d35574be82df2a0cdd2546f4f83d0d30964cf0043fc9784df855b024/ttp-0.10.0.tar.gz", hash = "sha256:40f1ca61ee1431f5b1ab5326fb55f852a04749e9574792d45455b62c5e7ac97b", size = 64665, upload-time = "2025-11-02T08:47:50.329Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/c3/60abb45bd8eb973997f133eb76949523478d35dfc551a0dbd8906b6a8075/ttp-0.10.0-py3-none-any.whl", hash = "sha256:9985e0ca414e85d41493a6291a924624b9a08c48c78d2d01477cc60ba2a347c1", size = 84287, upload-time = "2025-11-02T08:47:48.656Z" },
+]
+
+[[package]]
+name = "ttp-templates"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/0e/2649128b69cb4b4b6db4029a42dff45f1becab9f1e86856febb5f8974a77/ttp_templates-0.4.0.tar.gz", hash = "sha256:607cfd1d111e24dbfd9c871d79d83ee7c55e61c32feb9296ca01674b010f9994", size = 43863, upload-time = "2026-03-15T12:06:17.758Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/97/c27b9cfef1a5bfd869b69cfc322d360749dff0d679fe052fe8be99eee946/ttp_templates-0.4.0-py3-none-any.whl", hash = "sha256:c61364d7e6e256adf0d753b11b117965fda6aa556f6a7addc6a1646007517b08", size = 81988, upload-time = "2026-03-15T12:06:16.338Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #246

Adds TTP (Template Text Parser) support to `/v1/send_command_structured`:

- New `ttp_template` field on request (mutually exclusive with `textfsm_template`)
- Supports inline templates and `ttp://` references to `ttp-templates` community library
- Skips connection pool when using TTP (same behavior as TextFSM)
- 3 new tests, 100% coverage maintained