### PR TITLE
feat: add CONNECTION_POOL_EXCLUDE for per-device pool exclusion

### DIFF
--- a/changes/187.feature.md
+++ b/changes/187.feature.md
@@ -1,0 +1,1 @@
+Add CONNECTION_POOL_EXCLUDE environment variable to exclude specific device IPs or platforms from connection pooling.

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -46,6 +46,7 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 | `CONNECTION_POOL_MAX_SIZE` | `10` | Maximum connections per worker |
 | `CONNECTION_POOL_TTL` | `300` | Idle timeout in seconds before closing connections |
 | `CONNECTION_POOL_KEEPALIVE` | `30` | SSH keepalive interval in seconds |
+| `CONNECTION_POOL_EXCLUDE` | `` | Comma-separated IPs or device_types to exclude from pooling (e.g. `192.168.1.1,cisco_ios_old`) |
 
 ## Example docker-compose.yml
 

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -26,3 +26,4 @@ data:
   CONNECTION_POOL_MAX_AGE: "3600"
   # Paramiko SSH keepalive interval in seconds. Prevents NAT/firewall idle drops.
   CONNECTION_POOL_KEEPALIVE: "60"
+  # CONNECTION_POOL_EXCLUDE: "192.168.1.1,cisco_ios_old"  # Comma-separated IPs or device_types to exclude

--- a/naas/config.py
+++ b/naas/config.py
@@ -43,6 +43,9 @@ CONNECTION_POOL_MAX_SIZE = int(os.environ.get("CONNECTION_POOL_MAX_SIZE", 10))
 CONNECTION_POOL_IDLE_TIMEOUT = int(os.environ.get("CONNECTION_POOL_IDLE_TIMEOUT", 300))  # 5 minutes
 CONNECTION_POOL_MAX_AGE = int(os.environ.get("CONNECTION_POOL_MAX_AGE", 3600))  # 1 hour
 CONNECTION_POOL_KEEPALIVE = int(os.environ.get("CONNECTION_POOL_KEEPALIVE", 60))  # seconds
+CONNECTION_POOL_EXCLUDE: frozenset[str] = frozenset(
+    e.strip() for e in os.environ.get("CONNECTION_POOL_EXCLUDE", "").split(",") if e.strip()
+)
 
 
 def app_configure(app):

--- a/naas/library/connection_pool.py
+++ b/naas/library/connection_pool.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from naas.config import (
+    CONNECTION_POOL_EXCLUDE,
     CONNECTION_POOL_IDLE_TIMEOUT,
     CONNECTION_POOL_MAX_AGE,
     CONNECTION_POOL_MAX_SIZE,
@@ -85,6 +86,10 @@ class ConnectionPool:
         cred_hash = self._cred_hash(username, password)
         if cred_hash is None:
             logger.debug("Pool skipping: salt not set")
+            return None
+
+        if ip in CONNECTION_POOL_EXCLUDE or platform in CONNECTION_POOL_EXCLUDE:
+            logger.debug("Pool skipping: %s (%s) is in exclusion list", ip, platform)
             return None
 
         key = (ip, port, cred_hash, platform)

--- a/tests/unit/test_connection_pool.py
+++ b/tests/unit/test_connection_pool.py
@@ -50,6 +50,20 @@ class TestConnectionPoolGet:
         """Returns None when salt not set."""
         assert pool_no_salt.get("1.2.3.4", 22, "user", "pass", "cisco_ios") is None
 
+    def test_get_excluded_ip_returns_none(self, pool, mock_conn):
+        """Returns None when IP is in exclusion list."""
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        with patch("naas.library.connection_pool.CONNECTION_POOL_EXCLUDE", frozenset({"1.2.3.4"})):
+            result = pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios")
+        assert result is None
+
+    def test_get_excluded_platform_returns_none(self, pool, mock_conn):
+        """Returns None when platform is in exclusion list."""
+        pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)
+        with patch("naas.library.connection_pool.CONNECTION_POOL_EXCLUDE", frozenset({"cisco_ios"})):
+            result = pool.get("1.2.3.4", 22, "user", "pass", "cisco_ios")
+        assert result is None
+
     def test_get_hit_returns_connection(self, pool, mock_conn):
         """Returns pooled connection on cache hit."""
         pool.release("1.2.3.4", 22, "user", "pass", "cisco_ios", mock_conn)


### PR DESCRIPTION
Closes #187

Adds `CONNECTION_POOL_EXCLUDE` env var — comma-separated IPs or device_types to skip pooling for, without disabling pooling globally.

```
CONNECTION_POOL_EXCLUDE=192.168.1.1,cisco_ios_old
```

- Checked in `pool.get()` before returning a pooled connection
- 2 new tests (IP exclusion, platform exclusion), 100% coverage maintained
- Documented in environment-variables.md and k8s/configmap.yaml