### PR TITLE
feat: add host field supporting hostnames, deprecate ip field

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ docker compose up -d
 curl -k -X POST https://localhost:8443/v1/send_command \
   -u "username:password" \
   -H "Content-Type: application/json" \
-  -d '{"ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
+  -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
 ```
 
 📖 **[Full documentation](https://naas.readthedocs.io/)** | 🚀 **[Installation guide](https://naas.readthedocs.io/en/latest/installation/)** | 📚 **[API reference](https://naas.readthedocs.io/en/latest/api-reference/)**

--- a/changes/270.feature.md
+++ b/changes/270.feature.md
@@ -1,0 +1,1 @@
+Add host field accepting IP addresses and hostnames. Deprecate ip field (still works, will be removed in v2.0).

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -6,6 +6,11 @@ Detailed examples for common NAAS API operations.
     The `delay_factor` parameter was replaced with `read_timeout` (float, seconds).
     Migrate by converting: `delay_factor=2` → `read_timeout=60.0` (approximate).
 
+!!! warning "Deprecation in v1.4: ip field"
+    The `ip` field is deprecated. Use `host` instead — it accepts IPv4, IPv6, and hostnames.
+    The `ip` field still works but will be removed in v2.0.
+    Example: `{"host": "192.168.1.1", ...}` or `{"host": "router1.example.com", ...}`
+
 ## Contents
 
 - [Authentication](#authentication)
@@ -44,7 +49,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show version", "show ip interface brief"]
   }'
@@ -57,7 +62,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "port": 2222,
     "platform": "cisco_ios",
     "commands": ["show version"]
@@ -71,7 +76,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "enable": "enable_password",
     "commands": ["show running-config"]
@@ -88,7 +93,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -H "Content-Type: application/json" \
   -H "X-Request-ID: my-custom-id-12345" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show version"]
   }'
@@ -103,7 +108,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show version"],
     "expect_string": "router.*#"
@@ -144,7 +149,7 @@ curl -k -X POST https://localhost:8443/v1/send_config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": [
       "interface GigabitEthernet0/1",
@@ -163,7 +168,7 @@ curl -k -X POST https://localhost:8443/v1/send_config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": [
       "interface GigabitEthernet0/1",
@@ -182,7 +187,7 @@ curl -k -X POST https://localhost:8443/v1/send_config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "juniper_junos",
     "commands": [
       "set interfaces ge-0/0/1 description \"Configured via NAAS\""
@@ -215,7 +220,7 @@ curl -k -X DELETE https://localhost:8443/v1/send_command/{job_id} \
 JOB_ID=$(curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
-  -d '{"ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}' \
+  -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}' \
   | jq -r '.job_id')
 
 # Cancel it
@@ -249,7 +254,7 @@ The `X-Request-ID` header in the 202 response contains the job ID:
 # Capture job ID from response header
 JOB_ID=$(curl -k -s -D - -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" -H "Content-Type: application/json" \
-  -d '{"ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}' \
+  -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}' \
   | grep -i x-request-id | awk '{print $2}' | tr -d '\r')
 ```
 
@@ -404,7 +409,7 @@ response = requests.post(
     auth=AUTH,
     verify=False,
     json={
-        "ip": "192.168.1.1",
+        "host": "192.168.1.1",
         "platform": "cisco_ios",
         "commands": ["show version"]
     }
@@ -446,7 +451,7 @@ async def send_command(session, device_ip, commands):
     async with session.post(
         "https://localhost:8443/v1/send_command",
         json={
-            "ip": device_ip,
+            "host": device_ip,
             "platform": "cisco_ios",
             "commands": commands
         },
@@ -552,7 +557,7 @@ def send_command_safe(ip, commands):
             auth=HTTPBasicAuth("admin", "password"),
             verify=False,
             json={
-                "ip": ip,
+                "host": ip,
                 "platform": "cisco_ios",
                 "commands": commands
             },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,190 @@
-../CHANGELOG.md
+# Changelog
+
+All notable changes to NAAS will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- towncrier release notes start -->
+
+# NAAS 1.3.1 (2026-03-06)
+
+## 📚 Documentation
+
+- Standardize bash syntax highlighting in kubernetes.md code blocks. ([#201](https://github.com/lykinsbd/naas/issues/201))
+- Clarify worker concurrency vs connection pooling in kubernetes.md. ([#202](https://github.com/lykinsbd/naas/issues/202))
+- Add response schema documentation to HealthCheck.get() docstring. ([#203](https://github.com/lykinsbd/naas/issues/203))
+- Add v1.2 and v1.3 release notes and fix v1.0.0 changelog entry.
+
+# NAAS 1.3.0rc2 (2026-03-04)
+
+## 💥 Breaking Changes
+
+- Replace delay_factor parameter with read_timeout (float, seconds) in send_command and send_config endpoints ([#216](https://github.com/lykinsbd/naas/issues/216))
+
+## 🔒 Security
+
+- Run API and worker containers as non-root user (UID 1000) with NET_BIND_SERVICE capability for port 443 ([#198](https://github.com/lykinsbd/naas/issues/198))
+- Set readOnlyRootFilesystem on API and worker containers; pre-compile Python bytecode in Dockerfile ([#206](https://github.com/lykinsbd/naas/issues/206))
+
+## ✨ Features
+
+- Add /v1/send_command_structured endpoint with TextFSM parsing via ntc-templates or custom templates ([#219](https://github.com/lykinsbd/naas/issues/219))
+- Add optional expect_string parameter to send_command for custom prompt matching ([#220](https://github.com/lykinsbd/naas/issues/220))
+- Add platform autodetect via SSHDetect for discovery workflows and heterogeneous environments ([#222](https://github.com/lykinsbd/naas/issues/222))
+
+## 🐛 Bug Fixes
+
+- Detect config errors via `error_pattern` in `send_config_set`, returning error string instead of succeeding silently ([#217](https://github.com/lykinsbd/naas/issues/217))
+- Call find_prompt() after connection pool hit to verify clean CLI state before issuing commands ([#218](https://github.com/lykinsbd/naas/issues/218))
+- Use `setnx` for `naas_cred_salt` so API restarts do not invalidate existing connection pool keys and in-flight job auth ([#223](https://github.com/lykinsbd/naas/issues/223))
+- Pass Redis connection explicitly to `tacacs_auth_lockout` and `device_lockout`, eliminating per-request TCP connection overhead ([#224](https://github.com/lykinsbd/naas/issues/224))
+- Set explicit `job_timeout` on enqueue to prevent hung workers holding for RQ's 180s default ([#226](https://github.com/lykinsbd/naas/issues/226))
+- Call `redis.ping()` at startup to fail fast if Redis is unavailable ([#227](https://github.com/lykinsbd/naas/issues/227))
+
+## 📚 Documentation
+
+- Add comprehensive documentation for v1.3.0 features: job cancellation, connection pooling, Prometheus metrics, audit events, expect_string parameter, and troubleshooting guides
+
+## 🔧 Internal Changes
+
+- Explicitly set fast_cli=True on ConnectHandler for consistent throughput across all platforms ([#221](https://github.com/lykinsbd/naas/issues/221))
+- Use Job.fetch_many() in ListJobs to batch-fetch job details in a single Redis pipeline call ([#225](https://github.com/lykinsbd/naas/issues/225))
+- Pass Job object directly to `job_locker` to avoid redundant Redis fetch after enqueue ([#228](https://github.com/lykinsbd/naas/issues/228))
+- Add comment to `worker_cache` documenting per-process global state assumption ([#229](https://github.com/lykinsbd/naas/issues/229))
+- Ignore codecov.io badge URLs in link-check to prevent flaky CI failures ([#234](https://github.com/lykinsbd/naas/issues/234))
+- Share Docker image between build.yml and k8s-tests via artifact to eliminate duplicate builds ([#240](https://github.com/lykinsbd/naas/issues/240))
+- Automate release workflow: auto-create PR from main to develop, auto-bump develop to next alpha version after release
+- Improve code quality: add docstrings, avoid mutable dict mutations, replace bare except with specific exceptions, eliminate type ignore comments
+- Replace shell scripts with Python for changelog cleanup, add comprehensive unit tests, fix bugs in cleanup_released_fragments and cleanup_changelog scripts
+
+# NAAS 1.2.0 (2026-03-02)
+
+## ✨ Features
+
+- Add connection pooling for persistent SSH device connections, reducing VTY session overhead on network devices ([#57](https://github.com/lykinsbd/naas/issues/57))
+- Add Prometheus metrics endpoint at `/metrics` exposing request counts, latency, queue depth, worker count, and job totals ([#78](https://github.com/lykinsbd/naas/issues/78))
+- Add DELETE endpoint for job cancellation ([#178](https://github.com/lykinsbd/naas/issues/178))
+- Healthcheck endpoint now reports worker count, active jobs, and a `no_workers` status when no RQ workers are available ([#179](https://github.com/lykinsbd/naas/issues/179))
+- Add structured audit events for job lifecycle and device failures ([#180](https://github.com/lykinsbd/naas/issues/180))
+
+## 🐛 Bug Fixes
+
+- Fix connection pool key to include password hash, preventing credential sharing between users with the same username ([#196](https://github.com/lykinsbd/naas/issues/196))
+
+## 📚 Documentation
+
+- Add Kubernetes deployment manifests and documentation for k3d/k8s deployment ([#28](https://github.com/lykinsbd/naas/issues/28))
+- Document connection pool configuration variables in kubernetes.md and k8s/configmap.yaml ([#191](https://github.com/lykinsbd/naas/issues/191))
+- Document TLS certificate encoding requirements for NAAS_CERT/NAAS_KEY/NAAS_CA_BUNDLE in kubernetes.md ([#192](https://github.com/lykinsbd/naas/issues/192))
+- Add 400 status code to CancelJob.delete() docstring ([#193](https://github.com/lykinsbd/naas/issues/193))
+- Document required fields per event type in emit_audit_event docstring ([#194](https://github.com/lykinsbd/naas/issues/194))
+- Add exposed metrics list to Monitoring section in kubernetes.md ([#195](https://github.com/lykinsbd/naas/issues/195))
+
+## 🧪 Testing & CI/CD
+
+- Add end-to-end job test to k8s CI: deploys Cisshgo into k3d cluster and validates full API → Redis → worker → SSH device job flow ([#189](https://github.com/lykinsbd/naas/issues/189))
+- Justify pragma: no cover on cancel_job.py auth guard with inline explanation ([#205](https://github.com/lykinsbd/naas/issues/205))
+- Fix contract test to accept no_workers healthcheck status
+
+## 🔧 Internal Changes
+
+- Release workflow now pins k8s manifest image tags to the release version ([#197](https://github.com/lykinsbd/naas/issues/197))
+- Cache Worker.all() result with 10s TTL to avoid repeated Redis scans on every request ([#199](https://github.com/lykinsbd/naas/issues/199))
+- Add file-based heartbeat to worker process and liveness probe to k8s worker deployment ([#200](https://github.com/lykinsbd/naas/issues/200))
+
+# NAAS 1.1.0 (2026-02-26)
+
+## ✨ Features
+
+- Device IP lockout: after 10 connection failures within 10 minutes, all access to that device is blocked for 10 minutes, preventing credential-spray abuse across multiple users. Also refactors the user lockout to use the same Redis sorted-set sliding-window implementation. ([#2](https://github.com/lykinsbd/naas/issues/2))
+- All log output is now structured JSON, making logs parseable by ELK, Splunk, CloudWatch, and other log aggregation tools. Each log line includes `timestamp`, `level`, `logger`, and `message` fields. ([#79](https://github.com/lykinsbd/naas/issues/79))
+- Correlation ID (request_id/job_id) now flows from API request through to worker log messages, enabling end-to-end log tracing across API and worker. ([#80](https://github.com/lykinsbd/naas/issues/80))
+- Health check endpoint now returns detailed component status including Redis connectivity, queue depth, version, and uptime. Returns `status: degraded` when Redis is unreachable. ([#81](https://github.com/lykinsbd/naas/issues/81))
+- OpenAPI spec now includes Basic Auth security scheme, enabling 'Try it out' authentication in Swagger UI at /apidoc. ([#83](https://github.com/lykinsbd/naas/issues/83))
+- All API endpoints are now available under the `/v1/` prefix. Legacy unversioned routes (`/send_command`, `/send_config`) remain functional but return `X-API-Deprecated: true` and `X-API-Sunset: 2027-01-01` headers. All responses include `X-API-Version: v1`. ([#84](https://github.com/lykinsbd/naas/issues/84))
+- Add structured request validation using Pydantic: IP address format, platform against all supported Netmiko device types, and non-empty command lists. Invalid requests now return 422 with a structured `errors` array instead of a generic 400. ([#85](https://github.com/lykinsbd/naas/issues/85))
+- Add pagination for job history with GET /v1/jobs endpoint ([#87](https://github.com/lykinsbd/naas/issues/87))
+- Workers now handle SIGTERM gracefully, finishing in-flight jobs before shutdown with configurable timeout ([#94](https://github.com/lykinsbd/naas/issues/94))
+- Job result TTLs are now configurable via environment variables: `JOB_TTL_SUCCESS` (default 24h) and `JOB_TTL_FAILED` (default 7 days). Previously both were hardcoded at ~24h. ([#95](https://github.com/lykinsbd/naas/issues/95))
+- Circuit breaker pattern prevents repeated connection attempts to failing devices with configurable thresholds and automatic recovery ([#96](https://github.com/lykinsbd/naas/issues/96))
+- Add dynamic OpenAPI spec generation via spectree. The spec is served at `/apidoc/openapi.json` and Swagger UI at `/apidoc`, generated automatically from existing Pydantic request/response models. ([#120](https://github.com/lykinsbd/naas/issues/120))
+- Add Pydantic validation for `/v1/jobs` query parameters (`page`, `per_page`, `status`). Invalid values now return 422 instead of being silently clamped. ([#122](https://github.com/lykinsbd/naas/issues/122))
+
+## 🐛 Bug Fixes
+
+- Fix auth guard in get_results.py to use explicit raise instead of assert (assert is stripped by python -O) ([#159](https://github.com/lykinsbd/naas/issues/159))
+- Fix list_jobs unfiltered path to paginate per-registry instead of fetching all job IDs into memory; fix total_count to use registry.count rather than len of fetched IDs ([#160](https://github.com/lykinsbd/naas/issues/160))
+- Fix bare except Exception in healthcheck.py to catch redis.exceptions.RedisError specifically ([#163](https://github.com/lykinsbd/naas/issues/163))
+- Fix module-level Redis client in netmiko_lib.py initialised at import time; now lazily initialised on first use in circuit_breaker.py ([#164](https://github.com/lykinsbd/naas/issues/164))
+- Failed jobs now include error detail in the API response. Previously `GET /v1/send_command/{job_id}` returned no error information when a job had status `failed`.
+- Fix job.get_id() → job.id (rq removed get_id() in a recent release); was causing 500 errors on all job submissions.
+
+## 📚 Documentation
+
+- Add MkDocs documentation site with Material theme and Read the Docs configuration ([#76](https://github.com/lykinsbd/naas/issues/76))
+- Fix command examples in CONTRIBUTING.md, docs/testing.md, and docs/COVERAGE.md to use `uv run` prefix for plug-and-play usage without virtualenv activation ([#124](https://github.com/lykinsbd/naas/issues/124))
+- Add v1.1 release notes with migration guide. Update API usage docs with GET /v1/jobs, X-Request-ID tracing, device_type deprecation notice, and 422 error shapes. Fix stale healthcheck response examples. Add Observability, Reliability, and Environment Variables reference pages. ([#135](https://github.com/lykinsbd/naas/issues/135))
+- Fix security.md to remove phantom TLS_MIN_VERSION and TLS_CIPHERS environment variables. Document actual TLS behavior: hardcoded secure defaults (TLS 1.2+, HIGH cipher suite) configured in Gunicorn. ([#145](https://github.com/lykinsbd/naas/issues/145))
+- Add architecture overview page with Mermaid diagrams covering system components, request lifecycle, async model rationale, and horizontal scaling. ([#146](https://github.com/lykinsbd/naas/issues/146))
+- Split CONTRIBUTING.md into a short contributor entry point and a full Development Guide reference page. ([#147](https://github.com/lykinsbd/naas/issues/147))
+- Configure Read the Docs to build the develop branch, making bleeding-edge documentation available at naas.readthedocs.io/en/develop/. ([#150](https://github.com/lykinsbd/naas/issues/150))
+- Document requirement that all merges to main must go through pull requests
+- Fix license section to reference existing MIT license file
+- Streamline README for clarity and conciseness
+- Update README with Read the Docs links
+
+## 🧪 Testing & CI/CD
+
+- Add cisshgo mock SSH device container to integration test suite. Tests now cover full API→worker→SSH→device path including happy path, auth failure, device lockout, circuit breaker, and error handling scenarios. ([#74](https://github.com/lykinsbd/naas/issues/74))
+
+## 🔧 Internal Changes
+
+- Automate cleanup of released changelog fragments from develop ([#107](https://github.com/lykinsbd/naas/issues/107))
+- Add invoke export-spec task and CI check to keep docs/swagger/openapi.json in sync with code; remove stale docs/swagger/naas.yaml ([#128](https://github.com/lykinsbd/naas/issues/128))
+- Audit and fix all lint/type-checking exemptions: add types-paramiko stubs, fix hset int->str args, remove dead auth guard in get_results, add inline justification for all remaining ignores. ([#154](https://github.com/lykinsbd/naas/issues/154))
+- Extract circuit breaker infrastructure into naas/library/circuit_breaker.py; deduplicate circuit breaker wrapper in netmiko_lib.py; lazy-init Redis client to prevent import-time failure when Redis is unavailable ([#161](https://github.com/lykinsbd/naas/issues/161))
+- Remove dead validation methods from Validate class (has_port, is_ip_addr, save_config, commit, is_command_set, has_platform, has_delay_factor) — Pydantic models in models.py handle all request validation now ([#162](https://github.com/lykinsbd/naas/issues/162))
+- Move mypy into the enforced lint job so type errors block CI. Previously mypy ran with continue-on-error=true in a separate job and failures were silently ignored.
+
+# NAAS 1.0.1 (2026-02-24)
+
+## ✨ Features
+
+- Add non-blocking Vale prose linting for changelog fragments. ([#73](https://github.com/lykinsbd/naas/issues/73))
+
+## 🐛 Bug Fixes
+
+- Fix changelog cleanup to remove old pre-releases. ([#72](https://github.com/lykinsbd/naas/issues/72))
+
+## 📚 Documentation
+
+- Restructure README for user-first information architecture with deployment instructions prioritized over development content ([#104](https://github.com/lykinsbd/naas/issues/104))
+- Restructure README for user-first information architecture ([#106](https://github.com/lykinsbd/naas/pull/106))
+
+## 🔧 Internal Changes
+
+- [#70](https://github.com/lykinsbd/naas/issues/70), [#71](https://github.com/lykinsbd/naas/issues/71)
+
+# NAAS 1.0.0 (2026-02-23)
+
+## ⚠️ Deprecations
+
+- Rename `device_type` parameter to `platform` to match Netmiko naming convention (backward compatibility maintained in v1.x) ([#25](https://github.com/lykinsbd/naas/issues/25))
+
+## ✨ Features
+
+- Migrate from Docker Swarm to Docker Compose for simpler deployment and better developer experience ([#29](https://github.com/lykinsbd/naas/issues/29))
+
+## 📚 Documentation
+
+- Add comprehensive user documentation including quick start guide, API usage examples, troubleshooting guide, and security best practices ([#3](https://github.com/lykinsbd/naas/issues/3))
+
+## 🧪 Testing & CI/CD
+
+- Implement comprehensive CI/CD pipeline with GitHub Actions including automated testing, linting, and Docker builds ([#34](https://github.com/lykinsbd/naas/issues/34))
+- Achieve 100% test coverage with comprehensive unit, integration, and contract tests ([#47](https://github.com/lykinsbd/naas/issues/47))
+
+## 🔧 Internal Changes
+
+- [#27](https://github.com/lykinsbd/naas/issues/27), [#60](https://github.com/lykinsbd/naas/issues/60), [#65](https://github.com/lykinsbd/naas/issues/65), [#68](https://github.com/lykinsbd/naas/issues/68), [#70](https://github.com/lykinsbd/naas/issues/70), [#71](https://github.com/lykinsbd/naas/issues/71)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,1 +1,52 @@
-../CONTRIBUTING.md
+# Contributing to NAAS
+
+Thank you for your interest in contributing to NAAS!
+
+## Getting started
+
+1. Install [uv](https://github.com/astral-sh/uv):
+
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. Clone and set up:
+
+   ```bash
+   git clone https://github.com/lykinsbd/naas.git
+   cd naas
+   uv sync --extra dev
+   pre-commit install
+   ```
+
+3. Run checks and tests:
+
+   ```bash
+   uv run invoke check
+   uv run invoke test
+   ```
+
+## Submitting a pull request
+
+1. Create a feature branch from `develop`
+2. Make changes with [conventional commits](https://www.conventionalcommits.org/)
+3. Add a changelog fragment: `uv run towncrier create <issue#>.<type>.md --content "..."`
+4. Ensure `uv run invoke check` and `uv run invoke test` pass
+5. Open a PR targeting `develop` and reference the related issue
+
+PRs are merged via squash or rebase — no merge commits.
+
+## Full development reference
+
+See the [Development Guide](https://naas.readthedocs.io/en/develop/development/) for:
+
+- Branching strategy and hotfix workflow
+- Commit message conventions
+- Code style standards
+- Testing requirements
+- Changelog fragment types
+- Release process
+
+## Questions
+
+Open an issue or start a [discussion](https://github.com/lykinsbd/naas/discussions).

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ curl -X POST https://naas.example.com/v1/send_command \
   -u admin:password \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show version", "show interfaces"]
   }'

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -55,7 +55,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -H "X-Request-ID: 550e8400-e29b-41d4-a716-446655440000" \
-  -d '{"ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
+  -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
 ```
 
 If omitted, NAAS generates one automatically.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -45,7 +45,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
   -u "device_username:device_password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show version"]
   }'
@@ -92,7 +92,7 @@ curl -k -X POST https://localhost:8443/v1/send_config \
   -u "device_username:device_password" \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": [
       "interface GigabitEthernet0/1",

--- a/docs/release-notes/v1.1.md
+++ b/docs/release-notes/v1.1.md
@@ -18,10 +18,10 @@ None. All v1.0 API calls continue to work unchanged.
 
 ```json
 // Before (still works, but deprecated)
-{ "ip": "192.168.1.1", "device_type": "cisco_ios", "commands": ["show version"] }
+{ "host": "192.168.1.1", "device_type": "cisco_ios", "commands": ["show version"] }
 
 // After
-{ "ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"] }
+{ "host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"] }
 ```
 
 ### Response shape changes

--- a/docs/release-notes/v1.3.md
+++ b/docs/release-notes/v1.3.md
@@ -14,10 +14,10 @@ v1.3 adds **structured output parsing**, **platform autodetection**, and **enhan
 
 ```json
 // v1.2 (no longer works)
-{ "ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"], "delay_factor": 2 }
+{ "host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"], "delay_factor": 2 }
 
 // v1.3
-{ "ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"], "read_timeout": 30.0 }
+{ "host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"], "read_timeout": 30.0 }
 ```
 
 `read_timeout` is the total time to wait for command output. Default is 10 seconds.
@@ -43,7 +43,7 @@ v1.3 adds **structured output parsing**, **platform autodetection**, and **enhan
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "commands": ["show ip interface brief"]
 }
@@ -66,7 +66,7 @@ Supports 300+ commands across 50+ platforms. Bring your own TextFSM templates:
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "commands": ["show custom-command"],
   "textfsm_template": "Value FIELD1 (\\S+)\\nValue FIELD2 (\\S+)\\n\\nStart\\n  ^${FIELD1}\\s+${FIELD2} -> Record"
@@ -81,7 +81,7 @@ Set `platform: "autodetect"` and NAAS probes the device to determine its type:
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "autodetect",
   "commands": ["show version"]
 }
@@ -101,7 +101,7 @@ Useful for:
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "commands": ["show version"],
   "expect_string": "CustomPrompt#"

--- a/docs/security.md
+++ b/docs/security.md
@@ -81,7 +81,7 @@ For devices requiring enable mode:
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "enable": "enable_password",
   "commands": ["show running-config"]

--- a/docs/structured-output.md
+++ b/docs/structured-output.md
@@ -11,7 +11,7 @@ Use the `/v1/send_command_structured` endpoint:
 curl -k -u "username:password" https://localhost:8443/v1/send_command_structured \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show version", "show ip interface brief"]
   }'
@@ -68,7 +68,7 @@ Supply your own TextFSM template for commands not covered by ntc-templates:
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "commands": ["show custom output"],
   "textfsm_template": "Value FIELD1 (\\S+)\\nValue FIELD2 (\\S+)\\n\\nStart\\n  ^${FIELD1}\\s+${FIELD2} -> Record"
@@ -102,7 +102,7 @@ Use `platform: "autodetect"` to fingerprint unknown devices:
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "autodetect",
   "commands": ["show version"]
 }
@@ -154,7 +154,7 @@ response = requests.post(
     "https://naas.local/v1/send_command_structured",
     auth=("user", "pass"),
     json={
-        "ip": "192.168.1.1",
+        "host": "192.168.1.1",
         "platform": "cisco_ios",
         "commands": ["show version", "show inventory"]
     },
@@ -181,7 +181,7 @@ response = requests.post(
     "https://naas.local/v1/send_command_structured",
     auth=("user", "pass"),
     json={
-        "ip": "192.168.1.1",
+        "host": "192.168.1.1",
         "platform": "autodetect",
         "commands": ["show version"]
     },
@@ -210,7 +210,7 @@ response = requests.post(
     "https://naas.local/v1/send_command_structured",
     auth=("user", "pass"),
     json={
-        "ip": "192.168.1.1",
+        "host": "192.168.1.1",
         "platform": "cisco_ios",
         "commands": ["show vlan brief"],
         "textfsm_template": template
@@ -229,7 +229,7 @@ Pass a `ttp_template` instead of `textfsm_template` — the two are mutually exc
 curl -k -u "username:password" https://localhost:8443/v1/send_command_structured \
   -H "Content-Type: application/json" \
   -d '{
-    "ip": "192.168.1.1",
+    "host": "192.168.1.1",
     "platform": "cisco_ios",
     "commands": ["show interfaces"],
     "ttp_template": "interface {{ interface }}\n ip address {{ ip }} {{ mask }}"

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -85,10 +85,9 @@
             "description": "Regex pattern to match in device output (overrides prompt detection)",
             "title": "Expect String"
           },
-          "ip": {
-            "description": "Device IP address",
-            "format": "ipvanyaddress",
-            "title": "Ip",
+          "host": {
+            "description": "Device IP address or hostname",
+            "title": "Host",
             "type": "string"
           },
           "platform": {
@@ -114,7 +113,7 @@
           }
         },
         "required": [
-          "ip",
+          "host",
           "commands"
         ],
         "title": "SendCommandRequest",
@@ -132,10 +131,9 @@
             "title": "Commands",
             "type": "array"
           },
-          "ip": {
-            "description": "Device IP address",
-            "format": "ipvanyaddress",
-            "title": "Ip",
+          "host": {
+            "description": "Device IP address or hostname",
+            "title": "Host",
             "type": "string"
           },
           "platform": {
@@ -187,7 +185,7 @@
           }
         },
         "required": [
-          "ip",
+          "host",
           "commands"
         ],
         "title": "SendCommandStructuredRequest",
@@ -236,10 +234,9 @@
             "description": "Configuration commands",
             "title": "Config"
           },
-          "ip": {
-            "description": "Device IP address",
-            "format": "ipvanyaddress",
-            "title": "Ip",
+          "host": {
+            "description": "Device IP address or hostname",
+            "title": "Host",
             "type": "string"
           },
           "platform": {
@@ -271,7 +268,7 @@
           }
         },
         "required": [
-          "ip"
+          "host"
         ],
         "title": "SendConfigRequest",
         "type": "object"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -122,7 +122,7 @@ Common issues and solutions for NAAS deployment and operation.
 
    ```json
    {
-     "ip": "192.168.1.1",
+     "host": "192.168.1.1",
      "platform": "cisco_ios",
      "enable": "enable_password",
      "commands": ["show version"]
@@ -319,7 +319,7 @@ Common issues and solutions for NAAS deployment and operation.
 
    ```json
    {
-     "ip": "192.168.1.1",
+     "host": "192.168.1.1",
      "platform": "cisco_ios",
      "read_timeout": 60.0,
      "commands": ["show version"]
@@ -337,7 +337,7 @@ Common issues and solutions for NAAS deployment and operation.
 
    ```json
    {
-     "ip": "192.168.1.1",
+     "host": "192.168.1.1",
      "platform": "cisco_ios",
      "expect_string": "Success rate",
      "commands": ["ping 8.8.8.8"]
@@ -355,7 +355,7 @@ Common issues and solutions for NAAS deployment and operation.
 
    ```json
    {
-     "ip": "192.168.1.1",
+     "host": "192.168.1.1",
      "platform": "autodetect",
      "commands": ["show version"]
    }
@@ -449,7 +449,7 @@ curl -k https://localhost:8443/healthcheck
 curl -k -v -X POST https://localhost:8443/v1/send_command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
-  -d '{"ip": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
+  -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
 ```
 
 ### Container Shell Access
@@ -531,7 +531,7 @@ CONNECTION_POOL_MAX_SIZE: "5"  # Default is 10
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "commands": ["show custom"],
   "textfsm_template": "Value FIELD (\\S+)\\n\\nStart\\n  ^${FIELD} -> Record"
@@ -560,7 +560,7 @@ Or check [ntc-templates](https://github.com/networktocode/ntc-templates/tree/mas
 
 ```json
 {
-  "ip": "192.168.1.1",
+  "host": "192.168.1.1",
   "platform": "cisco_ios",
   "commands": ["show version"]
 }

--- a/naas/models.py
+++ b/naas/models.py
@@ -1,12 +1,18 @@
 """Pydantic models for request/response validation."""
 
 import logging
+import re
+from ipaddress import ip_address
 from typing import Any, Literal
 
 from netmiko import platforms as netmiko_platforms
-from pydantic import BaseModel, Field, IPvAnyAddress, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
+
+_HOSTNAME_RE = re.compile(
+    r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*" r"[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$"
+)
 
 
 def _handle_device_type(data: dict[str, Any]) -> dict[str, Any]:
@@ -32,12 +38,32 @@ def _handle_device_type(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def _handle_ip(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Map deprecated ip parameter to host with warning.
+
+    Args:
+        data: Request data dictionary that may contain ip
+
+    Returns:
+        Modified data dictionary with ip mapped to host
+    """
+    data = data.copy()
+    if "ip" in data:
+        logger.warning("Parameter 'ip' is deprecated, use 'host' instead. " "Support for 'ip' will be removed in v2.0")
+        if "host" not in data:
+            data["host"] = data.pop("ip")
+        else:
+            data.pop("ip")
+    return data
+
+
 class _BaseCommandRequest(BaseModel):
     """Base model for command request endpoints with common fields and validators."""
 
     model_config = {"strict": True}
 
-    ip: IPvAnyAddress = Field(..., description="Device IP address")
+    host: str = Field(..., description="Device IP address or hostname")
     commands: list[str] = Field(..., min_length=1, description="Commands to execute")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
@@ -45,9 +71,25 @@ class _BaseCommandRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def handle_device_type(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Support deprecated device_type parameter."""
-        return _handle_device_type(data)
+    def handle_deprecated_params(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Support deprecated device_type and ip parameters."""
+        data = _handle_device_type(data)
+        return _handle_ip(data)
+
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Validate host is a valid IP address or hostname."""
+        # Try IP first
+        try:
+            ip_address(v)
+            return v
+        except Exception:
+            pass
+        # Try hostname
+        if len(v) <= 253 and _HOSTNAME_RE.match(v):
+            return v
+        raise ValueError(f"'{v}' is not a valid IP address or hostname")
 
     @field_validator("commands")
     @classmethod
@@ -115,7 +157,7 @@ class SendConfigRequest(BaseModel):
 
     model_config = {"strict": True}
 
-    ip: IPvAnyAddress = Field(..., description="Device IP address")
+    host: str = Field(..., description="Device IP address or hostname")
     config: list[str] | None = Field(default=None, min_length=1, description="Configuration commands")
     commands: list[str] | None = Field(default=None, min_length=1, description="Configuration commands (alias)")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
@@ -126,9 +168,23 @@ class SendConfigRequest(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def handle_device_type(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Support deprecated device_type parameter."""
-        return _handle_device_type(data)
+    def handle_deprecated_params(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Support deprecated device_type and ip parameters."""
+        data = _handle_device_type(data)
+        return _handle_ip(data)
+
+    @field_validator("host")
+    @classmethod
+    def validate_host(cls, v: str) -> str:
+        """Validate host is a valid IP address or hostname."""
+        try:
+            ip_address(v)
+            return v
+        except Exception:
+            pass
+        if len(v) <= 253 and _HOSTNAME_RE.match(v):
+            return v
+        raise ValueError(f"'{v}' is not a valid IP address or hostname")
 
     @field_validator("config", "commands")
     @classmethod

--- a/naas/models.py
+++ b/naas/models.py
@@ -50,7 +50,7 @@ def _handle_ip(data: dict[str, Any]) -> dict[str, Any]:
     """
     data = data.copy()
     if "ip" in data:
-        logger.warning("Parameter 'ip' is deprecated, use 'host' instead. " "Support for 'ip' will be removed in v2.0")
+        logger.warning("Parameter 'ip' is deprecated, use 'host' instead. Support for 'ip' will be removed in v2.0")
         if "host" not in data:
             data["host"] = data.pop("ip")
         else:

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -38,7 +38,7 @@ class SendCommand(Resource):
         :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header
         """
         validated: SendCommandRequest = request.context.json
-        ip_str = str(validated.ip)
+        ip_str = validated.host
 
         if device_lockout(ip=ip_str, redis=current_app.config["redis"]):
             current_app.logger.error("%s: Device %s is locked out", g.request_id, ip_str)

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -42,7 +42,7 @@ class SendCommandStructured(Resource):
         :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header
         """
         validated: SendCommandStructuredRequest = request.context.json
-        ip_str = str(validated.ip)
+        ip_str = validated.host
 
         if device_lockout(ip=ip_str, redis=current_app.config["redis"]):
             current_app.logger.error("%s: Device %s is locked out", g.request_id, ip_str)

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -40,7 +40,7 @@ class SendConfig(Resource):
         :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header
         """
         validated: SendConfigRequest = request.context.json
-        ip_str = str(validated.ip)
+        ip_str = validated.host
 
         if device_lockout(ip=ip_str, redis=current_app.config["redis"]):
             current_app.logger.error("%s: Device %s is locked out", g.request_id, ip_str)

--- a/tests/contract/test_api_endpoints.py
+++ b/tests/contract/test_api_endpoints.py
@@ -94,9 +94,9 @@ class TestSendCommand:
         assert response.status_code == 422
 
     def test_post_requires_valid_ip(self, client, auth_headers):
-        """POST /send_command with invalid ip should return 422."""
+        """POST /send_command with invalid host should return 422."""
         payload = {
-            "ip": "not-an-ip",
+            "host": "not a valid host!",
             "commands": ["show version"],
         }
         response = client.post("/send_command", json=payload, headers=auth_headers)

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -74,7 +74,7 @@ class TestSendCommand:
         assert response.status_code == 403
 
     def test_send_command_invalid_ip(self, app, client):
-        """Test POST with invalid IP returns 422."""
+        """Test POST with invalid host returns 422."""
         auth = b64encode(b"testuser:testpass").decode()
         app.config["redis"].set("naas_cred_salt", b"test-salt")
 
@@ -82,7 +82,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "not-an-ip",
+                    "host": "not a valid host!",
                     "commands": ["show version"],
                 },
                 headers={"Authorization": f"Basic {auth}"},
@@ -177,6 +177,58 @@ class TestSendCommand:
                     "ip": "192.0.2.1",
                     "commands": ["show version"],
                     "device_type": "arista_eos",
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+
+    def test_send_command_ip_backward_compat(self, app, client):
+        """Test POST with deprecated ip field maps to host."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={
+                    "ip": "192.0.2.1",
+                    "commands": ["show version"],
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+
+    def test_send_command_ip_ignored_when_host_present(self, app, client):
+        """Test POST with both ip and host uses host."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={
+                    "host": "192.0.2.1",
+                    "ip": "10.0.0.1",
+                    "commands": ["show version"],
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+
+    def test_send_command_hostname(self, app, client):
+        """Test POST with hostname instead of IP."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={
+                    "host": "router1.example.com",
+                    "commands": ["show version"],
                 },
                 headers={"Authorization": f"Basic {auth}"},
             )
@@ -306,6 +358,38 @@ class TestSendConfig:
 
         assert response.status_code == 422
         assert isinstance(response.json, list)
+
+    def test_send_config_hostname(self, app, client):
+        """Test POST with hostname instead of IP."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_config",
+                json={
+                    "host": "switch1.example.com",
+                    "commands": ["interface Gi0/1", "no shutdown"],
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+
+    def test_send_config_invalid_host(self, app, client):
+        """Test POST with invalid host returns 422."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        response = client.post(
+            "/v1/send_config",
+            json={
+                "host": "not a valid host!",
+                "commands": ["interface Gi0/1"],
+            },
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 422
 
     def test_send_config_invalid_platform(self, app, client):
         """Test POST with invalid platform returns 422."""


### PR DESCRIPTION
Closes #270

- New `host` field accepts IPv4, IPv6, or RFC 1123 hostnames
- Deprecated `ip` field still works (logs warning, maps to `host`)
- `ip` removal tracked in #272 (v2.0)
- 5 new tests, 100% coverage maintained