### PR TITLE
feat: add queue_position, enqueued_at, timeout to enqueue response

### DIFF
--- a/changes/271.feature.md
+++ b/changes/271.feature.md
@@ -1,0 +1,1 @@
+Enqueue response now includes queue_position, enqueued_at, and timeout fields.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -42,6 +42,22 @@ curl -k -H "Authorization: Basic $(echo -n 'username:password' | base64)" \
 
 Execute show commands on network devices.
 
+### Enqueue Response (202 Accepted)
+
+```json
+{
+  "job_id": "550e8400-e29b-41d4-a716-446655440000",
+  "message": "Job enqueued",
+  "queue_position": 1,
+  "enqueued_at": "2026-03-20T19:00:00+00:00",
+  "timeout": 60
+}
+```
+
+- `queue_position` — approximate position in queue (1 = next to run, may change as jobs complete)
+- `enqueued_at` — ISO 8601 timestamp when job was accepted
+- `timeout` — maximum seconds the job will run before being killed
+
 ### Basic Example
 
 ```bash

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -4,6 +4,11 @@
       "JobResponse.c5eb086": {
         "description": "Response model for job submission.",
         "properties": {
+          "enqueued_at": {
+            "description": "ISO 8601 timestamp when job was enqueued",
+            "title": "Enqueued At",
+            "type": "string"
+          },
           "job_id": {
             "description": "Unique job identifier",
             "title": "Job Id",
@@ -13,11 +18,24 @@
             "description": "Status message",
             "title": "Message",
             "type": "string"
+          },
+          "queue_position": {
+            "description": "Approximate position in queue (1 = next to run)",
+            "title": "Queue Position",
+            "type": "integer"
+          },
+          "timeout": {
+            "description": "Job timeout in seconds",
+            "title": "Timeout",
+            "type": "integer"
           }
         },
         "required": [
           "job_id",
-          "message"
+          "message",
+          "queue_position",
+          "enqueued_at",
+          "timeout"
         ],
         "title": "JobResponse",
         "type": "object"

--- a/naas/models.py
+++ b/naas/models.py
@@ -217,6 +217,9 @@ class JobResponse(BaseModel):
 
     job_id: str = Field(..., description="Unique job identifier")
     message: str = Field(..., description="Status message")
+    queue_position: int = Field(..., description="Approximate position in queue (1 = next to run)")
+    enqueued_at: str = Field(..., description="ISO 8601 timestamp when job was enqueued")
+    timeout: int = Field(..., description="Job timeout in seconds")
 
 
 class JobResultResponse(BaseModel):

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -106,6 +106,13 @@ class SendCommand(Resource):
         )
 
         # Return our payload containing job_id, a 202 Accepted, and the X-Request-ID header
-        response = JobResponse(job_id=job_id, message="Job enqueued").model_dump()
+        queue_position = len(current_app.config["q"].job_ids)
+        response = JobResponse(
+            job_id=job_id,
+            message="Job enqueued",
+            queue_position=queue_position,
+            enqueued_at=job.enqueued_at.isoformat(),
+            timeout=JOB_TIMEOUT,
+        ).model_dump()
         response.update(__base_response__)
         return response, 202, {"X-Request-ID": job_id}

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -99,6 +99,13 @@ class SendCommandStructured(Resource):
             request_id=job_id,
         )
 
-        response = JobResponse(job_id=job_id, message="Job enqueued").model_dump()
+        queue_position = len(current_app.config["q"].job_ids)
+        response = JobResponse(
+            job_id=job_id,
+            message="Job enqueued",
+            queue_position=queue_position,
+            enqueued_at=job.enqueued_at.isoformat(),
+            timeout=JOB_TIMEOUT,
+        ).model_dump()
         response.update(__base_response__)
         return response, 202, {"X-Request-ID": job_id}

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -109,6 +109,13 @@ class SendConfig(Resource):
         )
 
         # Return our payload containing job_id added to the base response, a 202 Accepted, and the X-Request-ID header
-        response = JobResponse(job_id=job_id, message="Job enqueued").model_dump()
+        queue_position = len(current_app.config["q"].job_ids)
+        response = JobResponse(
+            job_id=job_id,
+            message="Job enqueued",
+            queue_position=queue_position,
+            enqueued_at=job.enqueued_at.isoformat(),
+            timeout=JOB_TIMEOUT,
+        ).model_dump()
         response.update(__base_response__)
         return response, 202, {"X-Request-ID": job_id}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,9 @@ def app():
             mock_job = MagicMock()
             mock_job.id = "test-job-id"
             mock_job.meta = {}
+            mock_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
             mock_queue.return_value.enqueue.return_value = mock_job
+            mock_queue.return_value.job_ids = []
 
             # Make fetch_job return None for new job IDs (not duplicates)
             def fetch_job_side_effect(job_id):

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -44,6 +44,9 @@ class TestSendCommand:
         assert response.status_code == 202
         assert response.json["job_id"] is not None
         assert response.json["message"] == "Job enqueued"
+        assert "queue_position" in response.json
+        assert "enqueued_at" in response.json
+        assert "timeout" in response.json
         assert response.headers["X-Request-ID"] == response.json["job_id"]
 
     def test_send_command_post_no_auth(self, client):

--- a/tests/unit/test_send_command_structured.py
+++ b/tests/unit/test_send_command_structured.py
@@ -19,6 +19,7 @@ class TestSendCommandStructured:
         mock_job = MagicMock()
         mock_job.id = "test-job-id"
         mock_job.meta = {}
+        mock_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
         app.config["q"].enqueue.return_value = mock_job
 
         with patch("naas.resources.send_command_structured.device_lockout", return_value=False):
@@ -45,6 +46,7 @@ class TestSendCommandStructured:
         mock_job = MagicMock()
         mock_job.id = "test-job-id"
         mock_job.meta = {}
+        mock_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
         app.config["q"].enqueue.return_value = mock_job
 
         with patch("naas.resources.send_command_structured.device_lockout", return_value=False):
@@ -88,6 +90,7 @@ class TestSendCommandStructured:
         mock_job = MagicMock()
         mock_job.id = "test-job-id"
         mock_job.meta = {}
+        mock_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
         app.config["q"].enqueue.return_value = mock_job
 
         with patch("naas.resources.send_command_structured.device_lockout", return_value=False):


### PR DESCRIPTION
Closes #271

Non-breaking addition to all three enqueue endpoints:

- `queue_position` — approximate position in queue
- `enqueued_at` — ISO 8601 timestamp
- `timeout` — job timeout in seconds