### PR TITLE
feat: add MAX_QUEUE_DEPTH queue depth limit with 503 backpressure

### DIFF
--- a/changes/279.feature.md
+++ b/changes/279.feature.md
@@ -1,0 +1,1 @@
+Add MAX_QUEUE_DEPTH config to limit queue depth and return 503 when exceeded.

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -54,6 +54,7 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 | --- | --- | --- |
 | `NAAS_CONTEXTS` | `default` | Comma-separated list of valid context names (e.g. `default,corp,oob-dc1,hk-prod`) |
 | `WORKER_CONTEXTS` | `default` | Comma-separated contexts this worker serves (e.g. `oob-dc1,oob-dc2`) |
+| `MAX_QUEUE_DEPTH` | `0` | Max queued jobs before returning 503 (0 = disabled) |
 
 ## Example docker-compose.yml
 

--- a/naas/config.py
+++ b/naas/config.py
@@ -53,6 +53,9 @@ NAAS_CONTEXTS: frozenset[str] = frozenset(
 )
 WORKER_CONTEXTS: list[str] = [c.strip() for c in os.environ.get("WORKER_CONTEXTS", "default").split(",") if c.strip()]
 
+# Queue depth limit (0 = disabled)
+MAX_QUEUE_DEPTH: int = int(os.environ.get("MAX_QUEUE_DEPTH", 0))
+
 
 def app_configure(app):
     # Configure our environment

--- a/naas/library/context.py
+++ b/naas/library/context.py
@@ -5,8 +5,8 @@ Context routing helpers for multi-segment worker environments.
 
 from rq import Queue, Worker
 
-from naas.config import NAAS_CONTEXTS
-from naas.library.errorhandlers import InvalidContext, NoWorkersForContext
+from naas.config import MAX_QUEUE_DEPTH, NAAS_CONTEXTS
+from naas.library.errorhandlers import InvalidContext, NoWorkersForContext, QueueFull
 
 
 def get_queue_for_context(context: str, redis: object) -> Queue:
@@ -34,5 +34,8 @@ def get_queue_for_context(context: str, redis: object) -> Queue:
     active_workers = [w for w in Worker.all(connection=redis) if queue_name in w.queue_names()]  # type: ignore[arg-type]
     if not active_workers:
         raise NoWorkersForContext
+
+    if MAX_QUEUE_DEPTH > 0 and len(q) >= MAX_QUEUE_DEPTH:
+        raise QueueFull
 
     return q

--- a/naas/library/errorhandlers.py
+++ b/naas/library/errorhandlers.py
@@ -35,6 +35,10 @@ class NoWorkersForContext(ServiceUnavailable):
     pass
 
 
+class QueueFull(ServiceUnavailable):
+    pass
+
+
 def api_error_generator():
     """
     API error dict generator for Flask-restful
@@ -60,6 +64,7 @@ def api_error_generator():
         },
         "InvalidIP": {"status": 422, "error": "Invalid IPv4 address in 'ip' field of payload"},
         "NoWorkersForContext": {"status": 503, "error": "No workers available for the requested context"},
+        "QueueFull": {"status": 503, "error": "Queue depth limit reached, please retry later"},
         "InternalServerError": {
             "status": 500,
             "error": (

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from naas.library.context import get_queue_for_context
-from naas.library.errorhandlers import InvalidContext, NoWorkersForContext
+from naas.library.errorhandlers import InvalidContext, NoWorkersForContext, QueueFull
 
 
 class TestGetQueueForContext:
@@ -32,3 +32,15 @@ class TestGetQueueForContext:
                     result = get_queue_for_context("default", fake_redis)
                     mock_queue_cls.assert_called_once_with("naas-default", connection=fake_redis)
                     assert result == mock_queue_cls.return_value
+
+    def test_queue_full_raises(self, fake_redis):
+        """Valid context with queue at limit raises QueueFull."""
+        mock_worker = MagicMock()
+        mock_worker.queue_names.return_value = ["naas-default"]
+        with patch("naas.library.context.NAAS_CONTEXTS", frozenset({"default"})):
+            with patch("naas.library.context.Worker.all", return_value=[mock_worker]):
+                with patch("naas.library.context.MAX_QUEUE_DEPTH", 1):
+                    with patch("naas.library.context.Queue") as mock_queue_cls:
+                        mock_queue_cls.return_value.__len__ = lambda self: 1
+                        with pytest.raises(QueueFull):
+                            get_queue_for_context("default", fake_redis)


### PR DESCRIPTION
Closes #279

When `MAX_QUEUE_DEPTH > 0` and queue depth >= limit, all enqueue endpoints return 503. Default is 0 (disabled, preserves existing behavior).

- `MAX_QUEUE_DEPTH` config added
- `QueueFull` exception added to error handlers
- Check in `get_queue_for_context` covers all three enqueue endpoints
- 1 new test, 100% coverage maintained