### PR TITLE
feat: graceful 503 degradation when Redis is unavailable

### DIFF
--- a/changes/283.feature.md
+++ b/changes/283.feature.md
@@ -1,0 +1,1 @@
+Add global Redis error handler returning 503 with Retry-After header instead of unhandled 500.

--- a/naas/app.py
+++ b/naas/app.py
@@ -10,12 +10,14 @@ Description: Main app setup/config
 import logging
 import os
 
-from flask import Flask, request
+from flask import Flask, jsonify, request
 from flask_restful import Api
 from prometheus_client import Gauge
 from prometheus_flask_exporter import PrometheusMetrics
 from pythonjsonlogger.json import JsonFormatter
+from redis.exceptions import RedisError
 
+from naas import __base_response__
 from naas.config import app_configure
 from naas.library.errorhandlers import api_error_generator
 from naas.library.worker_cache import get_cached_workers
@@ -32,6 +34,17 @@ from naas.spec import spec
 app = Flask(__name__)
 
 app_configure(app)
+
+
+@app.errorhandler(RedisError)
+def handle_redis_error(e: RedisError):
+    """Return 503 for any Redis connectivity failure without leaking internal details."""
+    app.logger.error("Redis error: %s", type(e).__name__)
+    response = jsonify({"error": "Queue backend unavailable", "status": 503, **__base_response__})
+    response.status_code = 503
+    response.headers["Retry-After"] = "10"
+    return response
+
 
 # Prometheus metrics — request counts/latency via exporter, NAAS-specific gauges manually updated
 metrics = PrometheusMetrics(app, path="/metrics", default_labels={"app": "naas"})

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -81,3 +81,18 @@ class TestHealthCheck:
         data = response.get_json()
         assert data["status"] == "degraded"
         assert data["components"]["redis"]["status"] == "unhealthy"
+
+
+class TestRedisErrorHandler:
+    """Tests for global Redis error handler."""
+
+    def test_redis_error_returns_503(self, client):
+        """RedisError on any endpoint returns 503 with Retry-After header."""
+        from redis.exceptions import RedisError
+
+        with patch("naas.resources.healthcheck.get_cached_workers", side_effect=RedisError("connection lost")):
+            response = client.get("/healthcheck")
+
+        assert response.status_code == 503
+        assert response.headers.get("Retry-After") == "10"
+        assert response.get_json()["error"] == "Queue backend unavailable"


### PR DESCRIPTION
Closes #283

Global Flask `@app.errorhandler(RedisError)` catches any Redis connectivity failure and returns 503 with `Retry-After: 10` header. Does not expose internal Redis error details to clients.