### PR TITLE
feat: add job tags for metadata and filtering

### DIFF
--- a/changes/276.feature.md
+++ b/changes/276.feature.md
@@ -1,0 +1,1 @@
+Add optional tags field (dict[str,str]) to all enqueue requests. Tags stored in job metadata, returned in job results and list_jobs. Filter jobs by tag with ?tag=key:value.

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -118,6 +118,19 @@
             ],
             "default": null,
             "title": "Status"
+          },
+          "tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Filter by tag in 'key:value' format",
+            "title": "Tag"
           }
         },
         "title": "ListJobsQuery",
@@ -179,6 +192,22 @@
             "minimum": 1.0,
             "title": "Read Timeout",
             "type": "number"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional key-value metadata tags (max 10, keys/values max 64 chars, alphanumeric + hyphens/underscores/colons)",
+            "title": "Tags"
           }
         },
         "required": [
@@ -231,6 +260,22 @@
             "minimum": 1.0,
             "title": "Read Timeout",
             "type": "number"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional key-value metadata tags (max 10, keys/values max 64 chars, alphanumeric + hyphens/underscores/colons)",
+            "title": "Tags"
           },
           "textfsm_template": {
             "anyOf": [
@@ -346,6 +391,22 @@
             "description": "Save configuration after applying",
             "title": "Save Config",
             "type": "boolean"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional key-value metadata tags (max 10, keys/values max 64 chars)",
+            "title": "Tags"
           }
         },
         "required": [
@@ -677,6 +738,25 @@
               ],
               "default": null,
               "title": "Status"
+            }
+          },
+          {
+            "description": "Filter by tag in 'key:value' format",
+            "in": "query",
+            "name": "tag",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Filter by tag in 'key:value' format",
+              "title": "Tag"
             }
           }
         ],

--- a/naas/models.py
+++ b/naas/models.py
@@ -10,9 +10,26 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
+_TAGS_KEY_RE = re.compile(r"^[a-zA-Z0-9_\-:]{1,64}$")
 _HOSTNAME_RE = re.compile(
     r"^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*" r"[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$"
 )
+
+
+def _validate_tags(v: dict[str, str] | None) -> dict[str, str] | None:
+    """Validate tags: max 10 entries, keys/values max 64 chars, alphanumeric + hyphens/underscores/colons."""
+    if v is None:
+        return v
+    if len(v) > 10:
+        raise ValueError("tags must contain at most 10 entries")
+    for k, val in v.items():
+        if not _TAGS_KEY_RE.match(k):
+            raise ValueError(f"tag key '{k}' must be alphanumeric with hyphens, underscores, or colons (max 64 chars)")
+        if not _TAGS_KEY_RE.match(val):
+            raise ValueError(
+                f"tag value '{val}' must be alphanumeric with hyphens, underscores, or colons (max 64 chars)"
+            )
+    return v
 
 
 def _handle_device_type(data: dict[str, Any]) -> dict[str, Any]:
@@ -72,6 +89,16 @@ class _BaseCommandRequest(BaseModel):
         default="default",
         description="Routing context for multi-segment environments (e.g. 'corp', 'oob-dc1', 'hk-prod')",
     )
+    tags: dict[str, str] | None = Field(
+        default=None,
+        description="Optional key-value metadata tags (max 10, keys/values max 64 chars, alphanumeric + hyphens/underscores/colons)",
+    )
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        """Validate tags via shared _validate_tags function."""
+        return _validate_tags(v)
 
     @model_validator(mode="before")
     @classmethod
@@ -170,6 +197,16 @@ class SendConfigRequest(BaseModel):
     save_config: bool = Field(default=False, description="Save configuration after applying")
     commit: bool = Field(default=False, description="Commit configuration (Juniper)")
     context: str = Field(default="default", description="Routing context for multi-segment environments")
+    tags: dict[str, str] | None = Field(
+        default=None,
+        description="Optional key-value metadata tags (max 10, keys/values max 64 chars)",
+    )
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, v: dict[str, str] | None) -> dict[str, str] | None:
+        """Validate tags via shared _validate_tags function."""
+        return _validate_tags(v)
 
     @model_validator(mode="before")
     @classmethod
@@ -235,6 +272,7 @@ class JobResultResponse(BaseModel):
     results: Any | None = None
     error: str | None = None
     detected_platform: str | None = None
+    tags: dict[str, str] | None = None
 
 
 class ListJobsQuery(BaseModel):
@@ -248,6 +286,7 @@ class ListJobsQuery(BaseModel):
     page: int = Field(default=1, ge=1)
     per_page: int = Field(default=20, ge=1, le=100)
     status: Literal["finished", "failed", "started", "queued"] | None = None
+    tag: str | None = Field(default=None, description="Filter by tag in 'key:value' format")
 
 
 class ContextInfo(BaseModel):

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -65,5 +65,10 @@ class GetResults(Resource):
         elif job_status == "failed":
             r["error"] = str(job.exc_info).strip() if job.exc_info else "Job failed"
 
+        # Include tags if present in job metadata
+        tags = getattr(job, "meta", {}).get("tags") if isinstance(getattr(job, "meta", {}), dict) else None
+        if tags:
+            r["tags"] = tags
+
         r.update(__base_response__)
         return r

--- a/naas/resources/list_jobs.py
+++ b/naas/resources/list_jobs.py
@@ -100,10 +100,18 @@ class ListJobs(Resource):
                 "status": job.get_status(),
                 "created_at": job.created_at.isoformat() if job.created_at else None,
                 "ended_at": job.ended_at.isoformat() if job.ended_at else None,
+                "tags": getattr(job, "meta", {}).get("tags") if isinstance(getattr(job, "meta", {}), dict) else None,
             }
             for job in Job.fetch_many(job_ids, connection=redis_conn)
             if job is not None
         ]
+
+        # Filter by tag if requested (key:value format)
+        if query.tag:
+            tag_parts = query.tag.split(":", 1)
+            if len(tag_parts) == 2:
+                tag_key, tag_val = tag_parts
+                jobs = [j for j in jobs if j.get("tags") and j["tags"].get(tag_key) == tag_val]
 
         # Calculate pagination
         total_pages = (total_count + query.per_page - 1) // query.per_page if total_count > 0 else 0

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -96,6 +96,11 @@ class SendCommand(Resource):
         # Stash the job_id in redis, with the user/pass hash so that only that user can retrieve results
         job_locker(salted_creds=user_hash, job=job)
 
+        # Store tags in job metadata if provided
+        if validated.tags:
+            job.meta["tags"] = validated.tags
+            job.save_meta()
+
         # Emit audit event
         emit_audit_event(
             "job.submitted",

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -99,6 +99,11 @@ class SendConfig(Resource):
         # Stash the job_id in redis, with the user/pass hash so that only that user can retrieve results
         job_locker(salted_creds=user_hash, job=job)
 
+        # Store tags in job metadata if provided
+        if validated.tags:
+            job.meta["tags"] = validated.tags
+            job.save_meta()
+
         # Emit audit event
         emit_audit_event(
             "job.submitted",

--- a/tests/unit/test_list_jobs.py
+++ b/tests/unit/test_list_jobs.py
@@ -312,3 +312,40 @@ class TestListJobs:
         assert data["jobs"][0]["job_id"] == "job2"
         # Verify queue was called (is_queue branch) and finished registry was skipped
         app.config["q"].get_job_ids.assert_called_once_with(offset=0, length=1)
+
+    def test_list_jobs_tag_filter(self, app, client):
+        """Test GET with tag filter returns only matching jobs."""
+        from rq.job import Job
+
+        auth = b64encode(b"testuser:testpass").decode()
+
+        job_with_tag = MagicMock(spec=Job)
+        job_with_tag.id = "tagged-job"
+        job_with_tag.get_status = lambda: "finished"
+        job_with_tag.created_at = None
+        job_with_tag.ended_at = None
+        job_with_tag.meta = {"tags": {"change": "CHG001"}}
+
+        job_without_tag = MagicMock(spec=Job)
+        job_without_tag.id = "untagged-job"
+        job_without_tag.get_status = lambda: "finished"
+        job_without_tag.created_at = None
+        job_without_tag.ended_at = None
+        job_without_tag.meta = {}
+
+        with patch("naas.resources.list_jobs.Job.fetch_many", return_value=[job_with_tag, job_without_tag]):
+            with patch("naas.resources.list_jobs.FinishedJobRegistry") as mock_reg:
+                mock_reg_instance = MagicMock()
+                mock_reg_instance.get_job_ids.return_value = ["tagged-job", "untagged-job"]
+                mock_reg_instance.count = 2
+                mock_reg.return_value = mock_reg_instance
+                response = client.get(
+                    "/v1/jobs?status=finished&tag=change:CHG001",
+                    headers={"Authorization": f"Basic {auth}"},
+                )
+
+        assert response.status_code == 200
+        data = response.json
+        assert len(data["jobs"]) == 1
+        assert data["jobs"][0]["job_id"] == "tagged-job"
+        assert data["jobs"][0]["tags"] == {"change": "CHG001"}

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,71 @@
+"""Unit tests for Pydantic model validation."""
+
+import pytest
+from pydantic import ValidationError
+
+from naas.models import SendCommandRequest, SendConfigRequest
+
+
+class TestTagsValidation:
+    """Direct model validation tests for the tags field."""
+
+    def _base(self):
+        return {"host": "192.0.2.1", "commands": ["show version"]}
+
+    def test_valid_tags_accepted(self):
+        """Tags with valid keys/values are accepted."""
+        r = SendCommandRequest(**self._base(), tags={"change": "CHG001", "site": "nyc-dc1"})
+        assert r.tags == {"change": "CHG001", "site": "nyc-dc1"}
+
+    def test_none_tags_accepted(self):
+        """None tags (omitted) is valid."""
+        r = SendCommandRequest(**self._base())
+        assert r.tags is None
+
+    def test_validate_tags_none_directly(self):
+        """_validate_tags returns None when called directly with None."""
+        from naas.models import _validate_tags
+
+        assert _validate_tags(None) is None
+
+    def test_too_many_tags_rejected(self):
+        """More than 10 tags raises ValidationError."""
+        with pytest.raises(ValidationError, match="at most 10"):
+            SendCommandRequest(**self._base(), tags={f"key{i}": f"val{i}" for i in range(11)})
+
+    def test_invalid_tag_key_rejected(self):
+        """Tag key with spaces raises ValidationError."""
+        with pytest.raises(ValidationError, match="tag key"):
+            SendCommandRequest(**self._base(), tags={"invalid key!": "value"})
+
+    def test_invalid_tag_value_rejected(self):
+        """Tag value with special chars raises ValidationError."""
+        with pytest.raises(ValidationError, match="tag value"):
+            SendCommandRequest(**self._base(), tags={"key": "invalid value!"})
+
+    def test_send_config_too_many_tags_rejected(self):
+        """SendConfigRequest also enforces max 10 tags."""
+        with pytest.raises(ValidationError, match="at most 10"):
+            SendConfigRequest(
+                host="192.0.2.1",
+                commands=["interface Gi0/1"],
+                tags={f"key{i}": f"val{i}" for i in range(11)},
+            )
+
+    def test_send_config_invalid_tag_key_rejected(self):
+        """SendConfigRequest rejects invalid tag keys."""
+        with pytest.raises(ValidationError, match="tag key"):
+            SendConfigRequest(
+                host="192.0.2.1",
+                commands=["interface Gi0/1"],
+                tags={"bad key!": "value"},
+            )
+
+    def test_send_config_invalid_tag_value_rejected(self):
+        """SendConfigRequest rejects invalid tag values."""
+        with pytest.raises(ValidationError, match="tag value"):
+            SendConfigRequest(
+                host="192.0.2.1",
+                commands=["interface Gi0/1"],
+                tags={"key": "bad value!"},
+            )

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -257,6 +257,75 @@ class TestSendCommand:
 
         assert response.status_code == 202
 
+    def test_send_command_with_tags(self, app, client):
+        """Test POST with tags stores them in job meta."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={
+                    "host": "192.0.2.1",
+                    "commands": ["show version"],
+                    "tags": {"change": "CHG001", "site": "nyc-dc1"},
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+        # Verify tags were saved to job meta
+        mock_job = app.config["q"].enqueue.return_value
+        assert mock_job.meta["tags"] == {"change": "CHG001", "site": "nyc-dc1"}
+
+    def test_send_command_invalid_tags_too_many(self, app, client):
+        """Test POST with more than 10 tags returns 422."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.0.2.1",
+                "commands": ["show version"],
+                "tags": {f"key{i}": f"val{i}" for i in range(11)},
+            },
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 422
+
+    def test_send_command_invalid_tags_bad_key(self, app, client):
+        """Test POST with invalid tag key (spaces) returns 422."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.0.2.1",
+                "commands": ["show version"],
+                "tags": {"invalid key!": "value"},
+            },
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 422
+
+    def test_send_command_invalid_tags_bad_value(self, app, client):
+        """Test POST with invalid tag value (spaces) returns 422."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.0.2.1",
+                "commands": ["show version"],
+                "tags": {"key": "invalid value!"},
+            },
+            headers={"Authorization": f"Basic {auth}"},
+        )
+
+        assert response.status_code == 422
+
     def test_send_command_with_request_id(self, app, client):
         """Test POST with custom X-Request-ID uses that ID."""
         auth = b64encode(b"testuser:testpass").decode()
@@ -378,6 +447,42 @@ class TestSendConfig:
             )
 
         assert response.status_code == 202
+
+    def test_send_config_with_tags(self, app, client):
+        """Test POST with tags stores them in job meta."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_config",
+                json={
+                    "host": "192.0.2.1",
+                    "commands": ["interface Gi0/1"],
+                    "tags": {"change": "CHG002"},
+                },
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 202
+        mock_job = app.config["q"].enqueue.return_value
+        assert mock_job.meta["tags"] == {"change": "CHG002"}
+
+    def test_send_config_invalid_tags(self, app, client):
+        """Test POST with invalid tags returns 422."""
+        auth = b64encode(b"testuser:testpass").decode()
+
+        for bad_tags in [
+            {f"key{i}": f"val{i}" for i in range(11)},  # too many
+            {"invalid key!": "value"},  # bad key
+            {"key": "invalid value!"},  # bad value
+        ]:
+            response = client.post(
+                "/v1/send_config",
+                json={"host": "192.0.2.1", "commands": ["interface Gi0/1"], "tags": bad_tags},
+                headers={"Authorization": f"Basic {auth}"},
+            )
+            assert response.status_code == 422
 
     def test_send_config_invalid_host(self, app, client):
         """Test POST with invalid host returns 422."""
@@ -559,6 +664,31 @@ class TestGetResults:
         assert response.status_code == 200
         assert response.json["detected_platform"] == "cisco_nxos"
         assert "_detected_platform" not in response.json["results"]
+
+    def test_get_results_with_tags(self, app, client):
+        """Test GET returns tags from job metadata."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        job_id = "55555555-5555-5555-5555-555555555555"
+        job = MagicMock()
+        job.get_status = lambda: "finished"
+        job.result = ({"show version": "output"}, None)
+        job.meta = {"tags": {"change": "CHG001", "site": "nyc"}}
+
+        def fetch_side_effect(job_id_param):
+            return job if job_id_param == job_id else None
+
+        app.config["q"].fetch_job.side_effect = fetch_side_effect
+
+        with patch("naas.resources.get_results.job_unlocker", return_value=True):
+            response = client.get(
+                f"/v1/send_command/{job_id}",
+                headers={"Authorization": f"Basic {auth}"},
+            )
+
+        assert response.status_code == 200
+        assert response.json["tags"] == {"change": "CHG001", "site": "nyc"}
 
     def test_get_results_no_auth(self, client):
         """Test GET without auth returns 401."""


### PR DESCRIPTION
Closes #276

- `tags: dict[str, str] | None` on all enqueue requests (max 10, alphanumeric keys/values max 64 chars)
- Shared `_validate_tags` function (no duplication)
- Tags stored in `job.meta['tags']` after enqueue
- Returned in `get_results` and `list_jobs` responses
- Filter `list_jobs` with `?tag=key:value`
- 17 new tests, 100% coverage, no pragmas