### PR TITLE
feat: idempotency keys via X-Idempotency-Key header

### DIFF
--- a/changes/280.feature.md
+++ b/changes/280.feature.md
@@ -1,0 +1,1 @@
+Add X-Idempotency-Key header support. Repeat requests with the same key return the original job_id instead of enqueuing a new job.

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -55,6 +55,7 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 | `NAAS_CONTEXTS` | `default` | Comma-separated list of valid context names (e.g. `default,corp,oob-dc1,hk-prod`) |
 | `WORKER_CONTEXTS` | `default` | Comma-separated contexts this worker serves (e.g. `oob-dc1,oob-dc2`) |
 | `MAX_QUEUE_DEPTH` | `0` | Max queued jobs before returning 503 (0 = disabled) |
+| `IDEMPOTENCY_TTL` | `86400` | Seconds to remember idempotency keys (24h) |
 
 ## Example docker-compose.yml
 

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -54,6 +54,12 @@
             "title": "Enqueued At",
             "type": "string"
           },
+          "idempotent": {
+            "default": false,
+            "description": "True if this response reuses an existing job",
+            "title": "Idempotent",
+            "type": "boolean"
+          },
           "job_id": {
             "description": "Unique job identifier",
             "title": "Job Id",

--- a/naas/config.py
+++ b/naas/config.py
@@ -56,6 +56,9 @@ WORKER_CONTEXTS: list[str] = [c.strip() for c in os.environ.get("WORKER_CONTEXTS
 # Queue depth limit (0 = disabled)
 MAX_QUEUE_DEPTH: int = int(os.environ.get("MAX_QUEUE_DEPTH", 0))
 
+# Idempotency key TTL in seconds (24h default)
+IDEMPOTENCY_TTL: int = int(os.environ.get("IDEMPOTENCY_TTL", 86400))
+
 
 def app_configure(app):
     # Configure our environment

--- a/naas/library/idempotency.py
+++ b/naas/library/idempotency.py
@@ -1,0 +1,46 @@
+"""
+idempotency.py
+Client-controlled idempotency key support via X-Idempotency-Key header.
+"""
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from naas.config import IDEMPOTENCY_TTL
+
+if TYPE_CHECKING:
+    from redis import Redis
+
+
+def _redis_key(raw_key: str) -> str:
+    """Hash the raw key before storage to avoid leaking sensitive values."""
+    return f"naas:idempotency:{hashlib.sha256(raw_key.encode()).hexdigest()}"
+
+
+def get_idempotent_job_id(key: str, redis: "Redis") -> str | None:
+    """
+    Return the existing job_id for this idempotency key, or None if not seen before.
+
+    Args:
+        key: Raw idempotency key from X-Idempotency-Key header
+        redis: Redis connection
+
+    Returns:
+        Existing job_id string if key was seen within TTL, else None
+    """
+    stored = redis.get(_redis_key(key))
+    if stored is None:
+        return None
+    return stored.decode() if isinstance(stored, bytes) else str(stored)
+
+
+def store_idempotency_key(key: str, job_id: str, redis: "Redis") -> None:
+    """
+    Store the idempotency key → job_id mapping with TTL.
+
+    Args:
+        key: Raw idempotency key from X-Idempotency-Key header
+        job_id: Job ID to associate with this key
+        redis: Redis connection
+    """
+    redis.set(_redis_key(key), job_id, ex=IDEMPOTENCY_TTL, nx=True)

--- a/naas/models.py
+++ b/naas/models.py
@@ -262,6 +262,7 @@ class JobResponse(BaseModel):
     queue_position: int = Field(..., description="Approximate position in queue (1 = next to run)")
     enqueued_at: str = Field(..., description="ISO 8601 timestamp when job was enqueued")
     timeout: int = Field(..., description="Job timeout in seconds")
+    idempotent: bool = Field(default=False, description="True if this response reuses an existing job")
 
 
 class JobResultResponse(BaseModel):

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -2,6 +2,8 @@
 
 from flask import current_app, g, request
 from flask_restful import Resource
+from rq.exceptions import NoSuchJobError
+from rq.job import Job as RQJob
 from spectree import Response
 
 from naas import __base_response__
@@ -11,6 +13,7 @@ from naas.library.auth import device_lockout, job_locker
 from naas.library.context import get_queue_for_context
 from naas.library.decorators import valid_post
 from naas.library.errorhandlers import LockedOut
+from naas.library.idempotency import get_idempotent_job_id, store_idempotency_key
 from naas.library.netmiko_lib import netmiko_send_command
 from naas.models import JobResponse, SendCommandRequest
 from naas.spec import spec
@@ -63,6 +66,27 @@ class SendCommand(Resource):
             validated.commands,
         )
 
+        # Check idempotency key if provided
+        idempotency_key = request.headers.get("X-Idempotency-Key")
+        if idempotency_key:
+            existing_job_id = get_idempotent_job_id(idempotency_key, current_app.config["redis"])
+            if existing_job_id:
+                try:
+                    existing_job = RQJob.fetch(existing_job_id, connection=current_app.config["redis"])
+                    queue_position = 0
+                    response = JobResponse(
+                        job_id=existing_job_id,
+                        message="Job enqueued",
+                        queue_position=queue_position,
+                        enqueued_at=existing_job.enqueued_at.isoformat() if existing_job.enqueued_at else "",
+                        timeout=JOB_TIMEOUT,
+                        idempotent=True,
+                    ).model_dump()
+                    response.update(__base_response__)
+                    return response, 202, {"X-Request-ID": existing_job_id}
+                except NoSuchJobError:
+                    pass  # Key expired or job gone, proceed with new enqueue
+
         # Enqueue your job, and return the job ID
         current_app.logger.debug(
             "%s: Enqueueing job for %s@%s:%s",
@@ -96,6 +120,10 @@ class SendCommand(Resource):
         # Stash the job_id in redis, with the user/pass hash so that only that user can retrieve results
         job_locker(salted_creds=user_hash, job=job)
 
+        # Store idempotency key if provided
+        if idempotency_key:
+            store_idempotency_key(idempotency_key, job_id, current_app.config["redis"])
+
         # Store tags in job metadata if provided
         if validated.tags:
             job.meta["tags"] = validated.tags
@@ -121,6 +149,7 @@ class SendCommand(Resource):
             queue_position=queue_position,
             enqueued_at=job.enqueued_at.isoformat(),
             timeout=JOB_TIMEOUT,
+            idempotent=False,
         ).model_dump()
         response.update(__base_response__)
         return response, 202, {"X-Request-ID": job_id}

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -108,6 +108,7 @@ class SendCommandStructured(Resource):
             queue_position=queue_position,
             enqueued_at=job.enqueued_at.isoformat(),
             timeout=JOB_TIMEOUT,
+            idempotent=False,
         ).model_dump()
         response.update(__base_response__)
         return response, 202, {"X-Request-ID": job_id}

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -2,6 +2,8 @@
 
 from flask import current_app, g, request
 from flask_restful import Resource
+from rq.exceptions import NoSuchJobError
+from rq.job import Job as RQJob
 from spectree import Response
 
 from naas import __base_response__
@@ -11,6 +13,7 @@ from naas.library.auth import device_lockout, job_locker
 from naas.library.context import get_queue_for_context
 from naas.library.decorators import valid_post
 from naas.library.errorhandlers import LockedOut
+from naas.library.idempotency import get_idempotent_job_id, store_idempotency_key
 from naas.library.netmiko_lib import netmiko_send_config
 from naas.models import JobResponse, SendConfigRequest
 from naas.spec import spec
@@ -65,6 +68,27 @@ class SendConfig(Resource):
             validated.config,
         )
 
+        # Check idempotency key if provided
+        idempotency_key = request.headers.get("X-Idempotency-Key")
+        if idempotency_key:
+            existing_job_id = get_idempotent_job_id(idempotency_key, current_app.config["redis"])
+            if existing_job_id:
+                try:
+                    existing_job = RQJob.fetch(existing_job_id, connection=current_app.config["redis"])
+                    queue_position = 0
+                    response = JobResponse(
+                        job_id=existing_job_id,
+                        message="Job enqueued",
+                        queue_position=queue_position,
+                        enqueued_at=existing_job.enqueued_at.isoformat() if existing_job.enqueued_at else "",
+                        timeout=JOB_TIMEOUT,
+                        idempotent=True,
+                    ).model_dump()
+                    response.update(__base_response__)
+                    return response, 202, {"X-Request-ID": existing_job_id}
+                except NoSuchJobError:
+                    pass  # Key expired or job gone, proceed with new enqueue
+
         # Enqueue your job, and return the job ID
         current_app.logger.debug(
             "%s: Enqueueing job for %s@%s:%s",
@@ -99,6 +123,10 @@ class SendConfig(Resource):
         # Stash the job_id in redis, with the user/pass hash so that only that user can retrieve results
         job_locker(salted_creds=user_hash, job=job)
 
+        # Store idempotency key if provided
+        if idempotency_key:
+            store_idempotency_key(idempotency_key, job_id, current_app.config["redis"])
+
         # Store tags in job metadata if provided
         if validated.tags:
             job.meta["tags"] = validated.tags
@@ -123,6 +151,7 @@ class SendConfig(Resource):
             queue_position=queue_position,
             enqueued_at=job.enqueued_at.isoformat(),
             timeout=JOB_TIMEOUT,
+            idempotent=False,
         ).model_dump()
         response.update(__base_response__)
         return response, 202, {"X-Request-ID": job_id}

--- a/tests/unit/test_idempotency.py
+++ b/tests/unit/test_idempotency.py
@@ -1,0 +1,30 @@
+"""Unit tests for idempotency key support."""
+
+from naas.library.idempotency import get_idempotent_job_id, store_idempotency_key
+
+
+class TestIdempotency:
+    def test_get_returns_none_when_key_not_found(self, fake_redis):
+        """Returns None when key has not been seen before."""
+        assert get_idempotent_job_id("new-key", fake_redis) is None
+
+    def test_get_returns_job_id_when_key_exists(self, fake_redis):
+        """Returns stored job_id when key exists."""
+        store_idempotency_key("my-key", "job-abc", fake_redis)
+        assert get_idempotent_job_id("my-key", fake_redis) == "job-abc"
+
+    def test_store_sets_key_with_ttl(self, fake_redis):
+        """Storing a key makes it retrievable."""
+        store_idempotency_key("key1", "job-123", fake_redis)
+        assert get_idempotent_job_id("key1", fake_redis) == "job-123"
+
+    def test_store_is_idempotent(self, fake_redis):
+        """Second store with same key does not overwrite (NX semantics)."""
+        store_idempotency_key("key1", "job-first", fake_redis)
+        store_idempotency_key("key1", "job-second", fake_redis)
+        assert get_idempotent_job_id("key1", fake_redis) == "job-first"
+
+    def test_keys_are_hashed(self, fake_redis):
+        """Raw key is not stored in Redis (hashed before storage)."""
+        store_idempotency_key("sensitive-key", "job-abc", fake_redis)
+        assert fake_redis.get("naas:idempotency:sensitive-key") is None

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -351,6 +351,64 @@ class TestSendCommand:
         assert response.status_code == 202
         # Just verify it accepted the request - the X-Request-ID handling is tested
 
+    def test_idempotency_key_returns_existing_job(self, app, client):
+        """POST with X-Idempotency-Key returns existing job_id on repeat."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        existing_job = MagicMock()
+        existing_job.id = "existing-job-id"
+        existing_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
+
+        with patch("naas.resources.send_command.get_idempotent_job_id", return_value="existing-job-id"):
+            with patch("naas.resources.send_command.RQJob.fetch", return_value=existing_job):
+                response = client.post(
+                    "/v1/send_command",
+                    json={"host": "192.0.2.1", "commands": ["show version"]},
+                    headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "my-key"},
+                )
+
+        assert response.status_code == 202
+        assert response.json["job_id"] == "existing-job-id"
+        assert response.json["idempotent"] is True
+        # Should NOT have enqueued a new job
+        app.config["q"].enqueue.assert_not_called()
+
+    def test_idempotency_key_enqueues_new_job_first_time(self, app, client):
+        """POST with X-Idempotency-Key enqueues normally on first call."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.resources.send_command.get_idempotent_job_id", return_value=None):
+            with patch("naas.resources.send_command.store_idempotency_key") as mock_store:
+                response = client.post(
+                    "/v1/send_command",
+                    json={"host": "192.0.2.1", "commands": ["show version"]},
+                    headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "new-key"},
+                )
+
+        assert response.status_code == 202
+        assert response.json["idempotent"] is False
+        mock_store.assert_called_once()
+
+    def test_idempotency_key_enqueues_new_when_job_gone(self, app, client):
+        """POST with X-Idempotency-Key enqueues new job if stored job no longer exists."""
+        from rq.exceptions import NoSuchJobError
+
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.resources.send_command.get_idempotent_job_id", return_value="gone-job-id"):
+            with patch("naas.resources.send_command.RQJob.fetch", side_effect=NoSuchJobError):
+                response = client.post(
+                    "/v1/send_command",
+                    json={"host": "192.0.2.1", "commands": ["show version"]},
+                    headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "stale-key"},
+                )
+
+        assert response.status_code == 202
+        assert response.json["idempotent"] is False  # New job was enqueued
+
 
 class TestSendConfig:
     """Test send_config resource."""
@@ -498,6 +556,63 @@ class TestSendConfig:
         )
 
         assert response.status_code == 422
+
+    def test_send_config_idempotency_key_returns_existing_job(self, app, client):
+        """POST with X-Idempotency-Key returns existing job_id on repeat."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        existing_job = MagicMock()
+        existing_job.id = "existing-config-job"
+        existing_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
+
+        with patch("naas.resources.send_config.get_idempotent_job_id", return_value="existing-config-job"):
+            with patch("naas.resources.send_config.RQJob.fetch", return_value=existing_job):
+                response = client.post(
+                    "/v1/send_config",
+                    json={"host": "192.0.2.1", "commands": ["interface Gi0/1"]},
+                    headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "config-key"},
+                )
+
+        assert response.status_code == 202
+        assert response.json["job_id"] == "existing-config-job"
+        assert response.json["idempotent"] is True
+        app.config["q"].enqueue.assert_not_called()
+
+    def test_send_config_idempotency_key_enqueues_new_job(self, app, client):
+        """POST with X-Idempotency-Key enqueues normally on first call."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.resources.send_config.get_idempotent_job_id", return_value=None):
+            with patch("naas.resources.send_config.store_idempotency_key") as mock_store:
+                response = client.post(
+                    "/v1/send_config",
+                    json={"host": "192.0.2.1", "commands": ["interface Gi0/1"]},
+                    headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "new-config-key"},
+                )
+
+        assert response.status_code == 202
+        assert response.json["idempotent"] is False
+        mock_store.assert_called_once()
+
+    def test_send_config_idempotency_key_enqueues_new_when_job_gone(self, app, client):
+        """POST with X-Idempotency-Key enqueues new job if stored job no longer exists."""
+        from rq.exceptions import NoSuchJobError
+
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        with patch("naas.resources.send_config.get_idempotent_job_id", return_value="gone-job-id"):
+            with patch("naas.resources.send_config.RQJob.fetch", side_effect=NoSuchJobError):
+                response = client.post(
+                    "/v1/send_config",
+                    json={"host": "192.0.2.1", "commands": ["interface Gi0/1"]},
+                    headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "stale-config-key"},
+                )
+
+        assert response.status_code == 202
+        assert response.json["idempotent"] is False
 
     def test_send_config_invalid_platform(self, app, client):
         """Test POST with invalid platform returns 422."""


### PR DESCRIPTION
Closes #280

Clients can pass `X-Idempotency-Key: <key>` on any enqueue request. Repeat requests with the same key within the TTL window return the original `job_id` instead of enqueuing a new job.

- Keys hashed (SHA256) before Redis storage
- `IDEMPOTENCY_TTL` config (default 24h)
- `idempotent: bool` field added to `JobResponse`
- All three enqueue endpoints support the header
- 11 new tests, 100% coverage