### PR TITLE
ci: integration and k8s test speedups (#302, #303, #308)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,7 @@ jobs:
           sed 's|ghcr.io/lykinsbd/naas:.*|naas:test|g' k8s/worker/deployment.yaml \
             | kubectl apply -f -
           kubectl -n naas patch deployment naas-api \
-            -p '{"spec":{"template":{"spec":{"containers":[{"name":"naas-api","imagePullPolicy":"Never"}]}}}}'
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"naas-api","imagePullPolicy":"Never","env":[{"name":"GUNICORN_WORKERS","value":"2"}]}]}}}}'
           kubectl -n naas patch deployment naas-worker \
             -p '{"spec":{"template":{"spec":{"containers":[{"name":"naas-worker","imagePullPolicy":"Never"}]}}}}'
           kubectl apply -f k8s/cisshgo/
@@ -116,14 +116,14 @@ jobs:
       - name: Wait for rollouts
         run: |
           kubectl -n naas rollout status deployment/redis --timeout=60s
-          kubectl -n naas rollout status deployment/naas-api --timeout=180s || {
+          kubectl -n naas rollout status deployment/naas-api --timeout=90s || {
             echo "API deployment failed, debugging..."
             kubectl -n naas get pods
             kubectl -n naas describe deployment naas-api
             kubectl -n naas logs -l app=naas-api --tail=50
             exit 1
           }
-          kubectl -n naas rollout status deployment/naas-worker --timeout=180s || {
+          kubectl -n naas rollout status deployment/naas-worker --timeout=90s || {
             echo "Worker deployment failed, debugging..."
             kubectl -n naas get pods
             kubectl -n naas describe deployment naas-worker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Run integration tests
         run: uv run pytest tests/integration -v --tb=short --no-cov
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.14"]  # container always runs 3.14; multi-version adds no value
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/changes/302.testing.md
+++ b/changes/302.testing.md
@@ -1,0 +1,1 @@
+Add Docker BuildKit GHA layer caching to integration test builds, reducing rebuild time on cache hits.

--- a/changes/303.testing.md
+++ b/changes/303.testing.md
@@ -1,0 +1,1 @@
+Run integration tests on Python 3.14 only — the Docker container always uses 3.14 regardless of matrix version, so multi-version integration testing added no coverage value.

--- a/changes/308.testing.md
+++ b/changes/308.testing.md
@@ -1,0 +1,1 @@
+Reduce k8s CI test time by patching GUNICORN_WORKERS=2 on the API deployment and reducing rollout timeouts from 180s to 90s.

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -16,6 +16,10 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
     ports:
       - "18443:443"
     environment:
@@ -42,6 +46,10 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
     healthcheck:
       test: ["CMD", "sh", "-c", "kill -0 1"]
       interval: 5s
@@ -66,6 +74,10 @@ services:
     build:
       context: ../..
       dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
     healthcheck:
       test: ["CMD", "sh", "-c", "kill -0 1"]
       interval: 5s


### PR DESCRIPTION
Closes #302
Closes #303
Closes #308

### Integration tests

**Docker BuildKit GHA layer caching (#302)**
- Adds `docker/setup-buildx-action` to the integration job
- Adds `cache_from: type=gha` / `cache_to: type=gha,mode=max` to all build services
- Expected ~30-40s savings per run on cache hits

**Single Python version (#303)**
- Changes integration matrix from `[3.11, 3.12, 3.13, 3.14]` to `[3.14]` only
- Container always builds with 3.14 — multi-version was testing the HTTP client, not the app
- **75% reduction** in integration CI compute (4 jobs → 1)

### k8s tests

**GUNICORN_WORKERS=2 + reduced rollout timeouts (#308)**
- Patches `GUNICORN_WORKERS=2` on the API deployment in CI (same fix as integration tests)
- Reduces rollout timeouts from 180s to 90s

### Not included: #304 (reduce SSH timeouts)
`test_unreachable_host_fails` uses TCP connection timeout, not `read_timeout`. Requires adding `conn_timeout` as an API parameter — tracked separately.