### PR TITLE
feat: add conn_timeout parameter for TCP connection timeout control

### DIFF
--- a/changes/304.feature.md
+++ b/changes/304.feature.md
@@ -1,0 +1,1 @@
+Add conn_timeout field to all job submission endpoints to control TCP connection timeout (default 10s). Useful for fast failure detection on unreachable hosts or tuning for high-latency links.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -139,6 +139,27 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 
 **Note:** This is an advanced feature. Most users should rely on automatic prompt detection.
 
+### Connection Timeout
+
+Control the TCP connection timeout with `conn_timeout` (default: `10.0` seconds):
+
+```bash
+curl -k -X POST https://localhost:8443/v1/send_command \
+  -u "admin:password" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "host": "192.168.1.1",
+    "platform": "cisco_ios",
+    "commands": ["show version"],
+    "conn_timeout": 5.0
+  }'
+```
+
+- `conn_timeout` — seconds to wait for the TCP connection to be established before failing
+- `read_timeout` — seconds to wait for a command response after connection is established (default: `30.0`)
+
+Reduce `conn_timeout` for faster failure detection on unreachable hosts. Increase it for devices on high-latency links.
+
 ### Supported Platforms
 
 NAAS supports all [Netmiko platforms](https://github.com/ktbyers/netmiko/blob/develop/PLATFORMS.md):

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -160,6 +160,13 @@
             "title": "Commands",
             "type": "array"
           },
+          "conn_timeout": {
+            "default": 10.0,
+            "description": "TCP connection timeout in seconds",
+            "minimum": 1.0,
+            "title": "Conn Timeout",
+            "type": "number"
+          },
           "context": {
             "default": "default",
             "description": "Routing context for multi-segment environments (e.g. 'corp', 'oob-dc1', 'hk-prod')",
@@ -253,6 +260,13 @@
             "minItems": 1,
             "title": "Commands",
             "type": "array"
+          },
+          "conn_timeout": {
+            "default": 10.0,
+            "description": "TCP connection timeout in seconds",
+            "minimum": 1.0,
+            "title": "Conn Timeout",
+            "type": "number"
           },
           "context": {
             "default": "default",
@@ -391,6 +405,13 @@
             "default": null,
             "description": "Configuration commands",
             "title": "Config"
+          },
+          "conn_timeout": {
+            "default": 10.0,
+            "description": "TCP connection timeout in seconds",
+            "minimum": 1.0,
+            "title": "Conn Timeout",
+            "type": "number"
           },
           "context": {
             "default": "default",

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -65,6 +65,7 @@ def netmiko_send_command(
     commands: "Sequence[str]",
     port: int = 22,
     read_timeout: float = 30.0,
+    conn_timeout: float = 10.0,
     expect_string: str | None = None,
     verbose: bool = False,
     request_id: str = "",
@@ -94,6 +95,7 @@ def netmiko_send_command(
             commands,
             port,
             read_timeout,
+            conn_timeout,
             expect_string,
             False,  # use_textfsm
             None,  # textfsm_template
@@ -101,7 +103,18 @@ def netmiko_send_command(
             request_id,
         )
     return _netmiko_send_command_impl(
-        ip, credentials, device_type, commands, port, read_timeout, expect_string, False, None, verbose, request_id
+        ip,
+        credentials,
+        device_type,
+        commands,
+        port,
+        read_timeout,
+        conn_timeout,
+        expect_string,
+        False,
+        None,
+        verbose,
+        request_id,
     )
 
 
@@ -112,6 +125,7 @@ def _netmiko_send_command_impl(
     commands: "Sequence[str]",
     port: int = 22,
     read_timeout: float = 30.0,
+    conn_timeout: float = 10.0,
     expect_string: str | None = None,
     use_textfsm: bool = False,
     textfsm_template: str | None = None,
@@ -153,6 +167,7 @@ def _netmiko_send_command_impl(
         "use_keys": False,
         "fast_cli": True,
         "verbose": verbose,
+        "conn_timeout": conn_timeout,
     }
 
     try:
@@ -231,6 +246,7 @@ def netmiko_send_command_structured(
     commands: "Sequence[str]",
     port: int = 22,
     read_timeout: float = 30.0,
+    conn_timeout: float = 10.0,
     textfsm_template: str | None = None,
     ttp_template: str | None = None,
     verbose: bool = False,
@@ -255,6 +271,7 @@ def netmiko_send_command_structured(
             commands,
             port,
             read_timeout,
+            conn_timeout,
             None,  # expect_string
             use_textfsm,
             textfsm_template,
@@ -270,6 +287,7 @@ def netmiko_send_command_structured(
         commands,
         port,
         read_timeout,
+        conn_timeout,
         None,
         use_textfsm,
         textfsm_template,
@@ -289,6 +307,7 @@ def netmiko_send_config(
     save_config: bool = False,
     commit: bool = False,
     read_timeout: float = 30.0,
+    conn_timeout: float = 10.0,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -320,11 +339,22 @@ def netmiko_send_config(
             save_config,
             commit,
             read_timeout,
+            conn_timeout,
             verbose,
             request_id,
         )
     return _netmiko_send_config_impl(
-        ip, credentials, device_type, commands, port, save_config, commit, read_timeout, verbose, request_id
+        ip,
+        credentials,
+        device_type,
+        commands,
+        port,
+        save_config,
+        commit,
+        read_timeout,
+        conn_timeout,
+        verbose,
+        request_id,
     )
 
 
@@ -337,6 +367,7 @@ def _netmiko_send_config_impl(
     save_config: bool = False,
     commit: bool = False,
     read_timeout: float = 30.0,
+    conn_timeout: float = 10.0,
     verbose: bool = False,
     request_id: str = "",
 ) -> "tuple[dict | None, str | None]":
@@ -353,6 +384,7 @@ def _netmiko_send_config_impl(
         "use_keys": False,
         "fast_cli": True,
         "verbose": verbose,
+        "conn_timeout": conn_timeout,
     }
 
     try:

--- a/naas/models.py
+++ b/naas/models.py
@@ -106,6 +106,7 @@ class _BaseCommandRequest(BaseModel):
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
+    conn_timeout: float = Field(default=10.0, ge=1.0, description="TCP connection timeout in seconds")
     context: str = Field(
         default="default",
         description="Routing context for multi-segment environments (e.g. 'corp', 'oob-dc1', 'hk-prod')",
@@ -225,6 +226,7 @@ class SendConfigRequest(BaseModel):
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
+    conn_timeout: float = Field(default=10.0, ge=1.0, description="TCP connection timeout in seconds")
     save_config: bool = Field(default=False, description="Save configuration after applying")
     commit: bool = Field(default=False, description="Commit configuration (Juniper)")
     context: str = Field(default="default", description="Routing context for multi-segment environments")

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -134,6 +134,7 @@ class SendCommand(Resource):
             credentials=g.credentials,
             commands=validated.commands,
             read_timeout=validated.read_timeout,
+            conn_timeout=validated.conn_timeout,
             expect_string=validated.expect_string,
             request_id=g.request_id,
             job_id=g.request_id,

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -126,6 +126,7 @@ class SendCommandStructured(Resource):
             credentials=g.credentials,
             commands=validated.commands,
             read_timeout=validated.read_timeout,
+            conn_timeout=validated.conn_timeout,
             textfsm_template=validated.textfsm_template,
             ttp_template=validated.ttp_template,
             request_id=g.request_id,

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -138,6 +138,7 @@ class SendConfig(Resource):
             save_config=validated.save_config,
             commit=validated.commit,
             read_timeout=validated.read_timeout,
+            conn_timeout=validated.conn_timeout,
             request_id=g.request_id,
             job_id=g.request_id,
             job_timeout=JOB_TIMEOUT,

--- a/tests/integration/test_ssh_device.py
+++ b/tests/integration/test_ssh_device.py
@@ -299,8 +299,9 @@ class TestErrorHandling:
             "platform": CISSHGO_PLATFORM,
             "port": CISSHGO_PORT,
             "commands": ["show version"],
+            "conn_timeout": 3.0,  # fail fast — we just need it to fail, not wait 10s
         }
-        result = _submit_and_poll(api_url, payload, timeout=60)
+        result = _submit_and_poll(api_url, payload, timeout=30)
         # Worker catches the connection exception and returns it as an error;
         # job status is "finished" (worker ran to completion) but results is None
         assert result["results"] is None


### PR DESCRIPTION
Closes #304

Adds `conn_timeout` (float, default `10.0`) to all job submission endpoints to control the TCP connection establishment timeout.

### Why

Previously, jobs targeting unreachable hosts would wait for the OS TCP timeout (~25s) before failing. There was no way to tune this. Integration test `test_unreachable_host_fails` now uses `conn_timeout=3`, saving ~20s off the suite.

### Changes

- `conn_timeout` field on `_BaseCommandRequest` and `SendConfigRequest` (default `10.0`)
- Passed through to `netmiko.ConnectHandler(conn_timeout=...)`
- Documented in `docs/api-usage.md`