### PR TITLE
docs: add user documentation for job tags and queue backpressure

### DIFF
--- a/changes/316.doc.md
+++ b/changes/316.doc.md
@@ -1,0 +1,1 @@
+Add user documentation for job tags and queue backpressure.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -504,6 +504,57 @@ Response:
 }
 ```
 
+## Job Tags
+
+Attach key-value metadata to any job for filtering and auditing. Tags are stored in job metadata and returned in job results and list responses.
+
+### Submitting Tags
+
+```bash
+curl -k -X POST https://localhost:8443/v1/send_command \
+  -u "admin:password" \
+  -d '{
+    "host": "192.168.1.1",
+    "platform": "cisco_ios",
+    "commands": ["show version"],
+    "tags": {"team": "network-ops", "env": "prod", "ticket": "CHG-12345"}
+  }'
+```
+
+### Constraints
+
+- Maximum 10 tags per job
+- Keys and values: alphanumeric, hyphens, underscores, colons (max 64 characters each)
+- Tags are optional — omit the field entirely if not needed
+
+### Filtering by Tag
+
+Use `?tag=key:value` on the list jobs endpoint:
+
+```bash
+# All jobs tagged team:network-ops
+curl -k -u "admin:password" "https://localhost:8443/v1/jobs?tag=team:network-ops"
+
+# Combine with status and pagination
+curl -k -u "admin:password" "https://localhost:8443/v1/jobs?tag=env:prod&status=failed&per_page=50"
+```
+
+Tags are included in each job object in the response:
+
+```json
+{
+  "jobs": [
+    {
+      "job_id": "550e8400-e29b-41d4-a716-446655440000",
+      "status": "finished",
+      "created_at": "2026-02-22T19:00:00+00:00",
+      "ended_at": "2026-02-22T19:00:05+00:00",
+      "tags": {"team": "network-ops", "env": "prod", "ticket": "CHG-12345"}
+    }
+  ]
+}
+```
+
 ## Connection Pooling
 
 NAAS automatically reuses SSH connections to improve performance and reduce load on network devices.

--- a/docs/reliability.md
+++ b/docs/reliability.md
@@ -82,3 +82,45 @@ Job results are retained in Redis for a configurable period to prevent unbounded
 | `JOB_TTL_FAILED` | `604800` | Seconds to retain failed results (7 days) |
 
 Failed jobs are retained longer by default to aid post-incident investigation.
+
+## Queue Backpressure
+
+When `MAX_QUEUE_DEPTH` is set, NAAS rejects new jobs with `503 Service Unavailable` once the queue reaches the configured limit. This prevents unbounded queue growth during traffic spikes or worker outages.
+
+### How it works
+
+1. Before enqueuing a job, NAAS checks the current queue depth
+2. If the queue has reached `MAX_QUEUE_DEPTH`, the request is rejected immediately
+3. The check runs before deduplication, so duplicate detection does not bypass the limit
+
+### What the caller sees
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+
+{"error": "Queue depth limit reached, please retry later", "status": 503}
+```
+
+NAAS also returns `503` with a `Retry-After: 10` header when Redis itself is unavailable:
+
+```http
+HTTP/1.1 503 Service Unavailable
+Retry-After: 10
+Content-Type: application/json
+
+{"error": "Queue backend unavailable", "status": 503}
+```
+
+### Client retry guidance
+
+- Implement exponential backoff starting at 1–2 seconds
+- Respect the `Retry-After` header when present
+- Set a maximum retry count to avoid infinite loops
+- Monitor for sustained 503s — they may indicate a capacity or worker health issue
+
+### Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `MAX_QUEUE_DEPTH` | `0` (unlimited) | Maximum jobs allowed in queue before 503 |


### PR DESCRIPTION
Closes #316

Adds user-facing documentation for two v1.4 features that were only covered in release notes:

- **Job tags** (api-usage.md) — submitting tags, validation constraints, filtering with `?tag=key:value`
- **Queue backpressure** (reliability.md) — `MAX_QUEUE_DEPTH` behavior, 503 responses, client retry guidance

Blocking v1.4.0rc1.