### PR TITLE
Release v1.4.0 (rc2 — fix ruff target-version)

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -54,7 +54,7 @@ jobs:
           git checkout -b release/finalize-$FINAL_VERSION
 
           # Update pyproject.toml
-          sed -i "s/version = \".*\"/version = \"${FINAL_VERSION}\"/" pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"${FINAL_VERSION}\"/" pyproject.toml
           uv lock
 
           # Commit

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -105,7 +105,7 @@ jobs:
           NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.0a1"
 
           # Update pyproject.toml
-          sed -i "s/version = \".*\"/version = \"${NEXT_VERSION}\"/" pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"${NEXT_VERSION}\"/" pyproject.toml
           uv lock
 
           # Commit and push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-# NAAS 1.4.0rc1 (2026-04-03)
+# NAAS 1.4.0rc2 (2026-04-03)
 
 ## ✨ Features
 

--- a/changes/322.bugfix.md
+++ b/changes/322.bugfix.md
@@ -1,0 +1,1 @@
+Fix release automation overwriting ruff target-version in pyproject.toml.

--- a/k8s/api/deployment.yaml
+++ b/k8s/api/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: naas-api
-          image: ghcr.io/lykinsbd/naas:1.4.0rc1
+          image: ghcr.io/lykinsbd/naas:1.4.0rc2
           ports:
             - containerPort: 443
           envFrom:

--- a/k8s/worker/deployment.yaml
+++ b/k8s/worker/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: naas-worker
-          image: ghcr.io/lykinsbd/naas:1.4.0rc1
+          image: ghcr.io/lykinsbd/naas:1.4.0rc2
           command:
             - python
             - worker.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.4.0rc1"
+version = "1.4.0rc2"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.4.0rc1"
+version = "1.4.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Re-release of v1.4.0. The previous finalize automation (#319) had a bug where the version bump sed command also overwrote ruff's `target-version = "py311"` with `"1.4.0"`, breaking linting on main.

This PR brings rc2 from release/1.4 which has the correct `target-version = "py311"`.

Related: need to file issue for release automation sed bug.