### PR TITLE
fix(ci): use PR instead of direct push for develop version bump (#324)

### DIFF
--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -94,6 +94,8 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Bump develop to next alpha
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Extract current version from tag
           VERSION="${GITHUB_REF_NAME#v}"
@@ -103,14 +105,21 @@ jobs:
           MINOR=$(echo $VERSION | cut -d. -f2)
           NEXT_MINOR=$((MINOR + 1))
           NEXT_VERSION="${MAJOR}.${NEXT_MINOR}.0a1"
+          BRANCH="chore/bump-develop-v${NEXT_VERSION}"
 
-          # Update pyproject.toml
+          # Create branch, bump version, and open PR
+          git checkout -b "$BRANCH"
           sed -i "s/^version = \".*\"/version = \"${NEXT_VERSION}\"/" pyproject.toml
           uv lock
 
-          # Commit and push
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml uv.lock
           git commit -m "chore: bump develop to v${NEXT_VERSION}"
-          git push
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "chore: bump develop to v${NEXT_VERSION}" \
+            --body "Automated version bump after v${VERSION} release."

--- a/changes/324.bugfix.md
+++ b/changes/324.bugfix.md
@@ -1,0 +1,1 @@
+Fix sync-release workflow failing to bump develop version due to branch protection.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.4.0"
+version = "1.5.0a1"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.4.0"
+version = "1.5.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Closes #324

The `sync-release.yml` `bump-develop` job was pushing directly to `develop`, which fails due to branch protection requiring status checks.

**Fix:** Create a PR branch and open a PR to `develop` instead, matching the pattern used by `finalize-release.yml` for `main`.

Also bumps develop to `1.5.0a1` (was stuck at `1.4.0` due to this bug).