### PR TITLE
chore: bump develop to v2.0.0a1

### DIFF
--- a/changes/+bump-2.0.internal.md
+++ b/changes/+bump-2.0.internal.md
@@ -1,0 +1,1 @@
+Bump develop to v2.0.0a1 development cycle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "1.5.0a1"
+version = "2.0.0a1"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "1.5.0a1"
+version = "2.0.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Bump develop to v2.0.0a1 — starting the v2.0 development cycle.