### PR TITLE
feat!: remove deprecated ip field from all endpoints (#272)

### DIFF
--- a/changes/272.breaking.md
+++ b/changes/272.breaking.md
@@ -1,0 +1,1 @@
+Remove deprecated `ip` field from all endpoints. Use `host` instead.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -6,11 +6,6 @@ Detailed examples for common NAAS API operations.
     The `delay_factor` parameter was replaced with `read_timeout` (float, seconds).
     Migrate by converting: `delay_factor=2` → `read_timeout=60.0` (approximate).
 
-!!! warning "Deprecation in v1.4: ip field"
-    The `ip` field is deprecated. Use `host` instead — it accepts IPv4, IPv6, and hostnames.
-    The `ip` field still works but will be removed in v2.0.
-    Example: `{"host": "192.168.1.1", ...}` or `{"host": "router1.example.com", ...}`
-
 ## Contents
 
 - [Authentication](#authentication)
@@ -732,8 +727,8 @@ if __name__ == "__main__":
   "validation_error": {
     "json": [
       {
-        "loc": ["ip"],
-        "msg": "value is not a valid IPv4 address",
+        "loc": ["host"],
+        "msg": "value is not a valid IP address or hostname",
         "type": "value_error"
       }
     ]

--- a/naas/library/audit.py
+++ b/naas/library/audit.py
@@ -5,13 +5,13 @@ import logging
 logger = logging.getLogger("NAAS")
 
 _EVENT_SCHEMAS = {
-    "job.submitted": {"ip", "platform", "port", "command_count", "user_hash", "request_id"},
+    "job.submitted": {"host", "platform", "port", "command_count", "user_hash", "request_id"},
     "job.completed": {"request_id", "status", "duration_ms"},
     "job.cancelled": {"request_id", "cancelled_by_hash"},
     "job.orphaned": {"request_id", "worker_name"},
-    "device.locked_out": {"ip", "failure_count"},
-    "circuit.opened": {"ip"},
-    "circuit.closed": {"ip"},
+    "device.locked_out": {"host", "failure_count"},
+    "circuit.opened": {"host"},
+    "circuit.closed": {"host"},
 }
 
 

--- a/naas/library/auth.py
+++ b/naas/library/auth.py
@@ -69,7 +69,7 @@ def _is_locked_out(redis_key: str, redis: Redis, report_failure: bool = False) -
 
     if is_locked and redis_key.startswith("naas_failures_device_"):
         ip = redis_key.replace("naas_failures_device_", "")
-        emit_audit_event("device.locked_out", ip=ip, failure_count=failure_count)
+        emit_audit_event("device.locked_out", host=ip, failure_count=failure_count)
 
     return is_locked
 

--- a/naas/library/circuit_breaker.py
+++ b/naas/library/circuit_breaker.py
@@ -113,9 +113,9 @@ def _get_circuit_breaker(device_id: str) -> pybreaker.CircuitBreaker:
         class AuditListener(pybreaker.CircuitBreakerListener):
             def state_change(self, cb, old_state, new_state):
                 if new_state.name == "open":
-                    emit_audit_event("circuit.opened", ip=device_id)
+                    emit_audit_event("circuit.opened", host=device_id)
                 elif new_state.name == "closed" and old_state and old_state.name == "open":  # pragma: no cover
-                    emit_audit_event("circuit.closed", ip=device_id)
+                    emit_audit_event("circuit.closed", host=device_id)
 
         breaker.add_listener(AuditListener())
 

--- a/naas/library/errorhandlers.py
+++ b/naas/library/errorhandlers.py
@@ -62,7 +62,6 @@ def api_error_generator():
             "status": 422,
             "error": "Invalid type of data in request payload, please see documentation",
         },
-        "InvalidIP": {"status": 422, "error": "Invalid IPv4 address in 'ip' field of payload"},
         "NoWorkersForContext": {"status": 503, "error": "No workers available for the requested context"},
         "QueueFull": {"status": 503, "error": "Queue depth limit reached, please retry later"},
         "InternalServerError": {

--- a/naas/models.py
+++ b/naas/models.py
@@ -76,26 +76,6 @@ def _handle_device_type(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
-def _handle_ip(data: dict[str, Any]) -> dict[str, Any]:
-    """
-    Map deprecated ip parameter to host with warning.
-
-    Args:
-        data: Request data dictionary that may contain ip
-
-    Returns:
-        Modified data dictionary with ip mapped to host
-    """
-    data = data.copy()
-    if "ip" in data:
-        logger.warning("Parameter 'ip' is deprecated, use 'host' instead. Support for 'ip' will be removed in v2.0")
-        if "host" not in data:
-            data["host"] = data.pop("ip")
-        else:
-            data.pop("ip")
-    return data
-
-
 class _BaseCommandRequest(BaseModel):
     """Base model for command request endpoints with common fields and validators."""
 
@@ -135,9 +115,8 @@ class _BaseCommandRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def handle_deprecated_params(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Support deprecated device_type and ip parameters."""
-        data = _handle_device_type(data)
-        return _handle_ip(data)
+        """Support deprecated device_type parameter."""
+        return _handle_device_type(data)
 
     @field_validator("host")
     @classmethod
@@ -254,9 +233,8 @@ class SendConfigRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def handle_deprecated_params(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Support deprecated device_type and ip parameters."""
-        data = _handle_device_type(data)
-        return _handle_ip(data)
+        """Support deprecated device_type parameter."""
+        return _handle_device_type(data)
 
     @field_validator("host")
     @classmethod

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -174,7 +174,7 @@ class SendCommand(Resource):
         # Emit audit event
         emit_audit_event(
             "job.submitted",
-            ip=ip_str,
+            host=ip_str,
             platform=validated.platform,
             port=validated.port,
             command_count=len(validated.commands),

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -161,7 +161,7 @@ class SendCommandStructured(Resource):
 
         emit_audit_event(
             "job.submitted",
-            ip=ip_str,
+            host=ip_str,
             platform=validated.platform,
             port=validated.port,
             command_count=len(validated.commands),

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -177,7 +177,7 @@ class SendConfig(Resource):
         # Emit audit event
         emit_audit_event(
             "job.submitted",
-            ip=ip_str,
+            host=ip_str,
             platform=validated.platform,
             port=validated.port,
             command_count=len(validated.config),

--- a/tests/contract/test_api_endpoints.py
+++ b/tests/contract/test_api_endpoints.py
@@ -76,7 +76,7 @@ class TestSendCommand:
     def test_post_requires_auth(self, client):
         """POST /send_command without auth should return 401."""
         payload = {
-            "ip": "192.0.2.1",
+            "host": "192.0.2.1",
             "commands": ["show version"],
         }
         response = client.post("/send_command", json=payload)
@@ -104,14 +104,14 @@ class TestSendCommand:
 
     def test_post_requires_commands(self, client, auth_headers):
         """POST /send_command without commands should return 422."""
-        payload = {"ip": "192.0.2.1"}
+        payload = {"host": "192.0.2.1"}
         response = client.post("/send_command", json=payload, headers=auth_headers)
         assert response.status_code == 422
 
     def test_post_requires_commands_list(self, client, auth_headers):
         """POST /send_command with non-list commands should return 422."""
         payload = {
-            "ip": "192.0.2.1",
+            "host": "192.0.2.1",
             "commands": "show version",
         }
         response = client.post("/send_command", json=payload, headers=auth_headers)
@@ -136,7 +136,7 @@ class TestSendConfig:
     def test_post_requires_auth(self, client):
         """POST /send_config without auth should return 401."""
         payload = {
-            "ip": "192.0.2.1",
+            "host": "192.0.2.1",
             "commands": ["interface Ethernet1", "description Test"],
         }
         response = client.post("/send_config", json=payload)
@@ -155,14 +155,14 @@ class TestSendConfig:
 
     def test_post_requires_commands(self, client, auth_headers):
         """POST /send_config without commands should return 422."""
-        payload = {"ip": "192.0.2.1"}
+        payload = {"host": "192.0.2.1"}
         response = client.post("/send_config", json=payload, headers=auth_headers)
         assert response.status_code == 422
 
     def test_post_rejects_save_config_non_bool(self, client, auth_headers):
         """POST /send_config should reject save_config as non-bool."""
         payload = {
-            "ip": "192.0.2.1",
+            "host": "192.0.2.1",
             "commands": ["interface Ethernet1"],
             "save_config": "yes",
         }

--- a/tests/integration/test_ssh_device.py
+++ b/tests/integration/test_ssh_device.py
@@ -14,7 +14,7 @@ from redis import Redis
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 # cisshgo connection details — fixed IP assigned in docker-compose.test.yml
-# so the NAAS API can accept it (ip field validates as IPv4 address)
+# so the NAAS API can accept it (host field validates as IPv4 address)
 CISSHGO_HOST = "240.11.2.100"
 CISSHGO_PORT = 10022
 CISSHGO_PLATFORM = "cisco_ios"
@@ -97,7 +97,7 @@ def _submit_and_poll(
 
 def _device_payload(commands: list[str], ip: str = CISSHGO_HOST) -> dict:
     return {
-        "ip": ip,
+        "host": ip,
         "platform": CISSHGO_PLATFORM,
         "port": CISSHGO_PORT,
         "commands": commands,
@@ -106,7 +106,7 @@ def _device_payload(commands: list[str], ip: str = CISSHGO_HOST) -> dict:
 
 def _config_payload(config: list[str], ip: str = CISSHGO_HOST) -> dict:
     return {
-        "ip": ip,
+        "host": ip,
         "platform": CISSHGO_PLATFORM,
         "port": CISSHGO_PORT,
         "config": config,
@@ -168,7 +168,7 @@ class TestAuthFailure:
     def test_wrong_password_job_fails(self, api_url, wait_for_api, wait_for_cisshgo, redis_client):
         """Wrong device password results in an auth error in the job result."""
         payload = {
-            "ip": CISSHGO_HOST,
+            "host": CISSHGO_HOST,
             "platform": CISSHGO_PLATFORM,
             "port": CISSHGO_PORT,
             "commands": ["show version"],
@@ -207,7 +207,7 @@ class TestDeviceLockout:
 
         # Next submission should be rejected with 403
         payload = {
-            "ip": locked_ip,
+            "host": locked_ip,
             "platform": CISSHGO_PLATFORM,
             "port": CISSHGO_PORT,
             "commands": ["show version"],
@@ -251,7 +251,7 @@ class TestCircuitBreaker:
         )
 
         payload = {
-            "ip": cb_ip,
+            "host": cb_ip,
             "platform": CISSHGO_PLATFORM,
             "port": CISSHGO_PORT,
             "commands": ["show version"],
@@ -277,7 +277,7 @@ class TestErrorHandling:
     def test_invalid_platform_fails(self, api_url, wait_for_api, wait_for_cisshgo):
         """Job with unsupported platform is rejected at the API level with 422."""
         payload = {
-            "ip": CISSHGO_HOST,
+            "host": CISSHGO_HOST,
             "platform": "not_a_real_platform",
             "port": CISSHGO_PORT,
             "commands": ["show version"],
@@ -295,7 +295,7 @@ class TestErrorHandling:
     def test_unreachable_host_fails(self, api_url, wait_for_api):
         """Job targeting unreachable host completes with connection error in result."""
         payload = {
-            "ip": "192.0.2.254",  # TEST-NET, guaranteed unreachable
+            "host": "192.0.2.254",  # TEST-NET, guaranteed unreachable
             "platform": CISSHGO_PLATFORM,
             "port": CISSHGO_PORT,
             "commands": ["show version"],
@@ -315,24 +315,12 @@ class TestErrorHandling:
 
 
 class TestHostField:
-    """Tests for the new 'host' field and deprecated 'ip' field."""
+    """Tests for the 'host' field."""
 
     def test_host_field_with_ip(self, api_url, wait_for_api, wait_for_cisshgo):
         """Job submitted with 'host' field (IP) succeeds."""
         payload = {
             "host": CISSHGO_HOST,
-            "platform": CISSHGO_PLATFORM,
-            "port": CISSHGO_PORT,
-            "commands": ["show version"],
-        }
-        result = _submit_and_poll(api_url, payload)
-        assert result["status"] == "finished"
-        assert result["results"] is not None
-
-    def test_deprecated_ip_field_still_works(self, api_url, wait_for_api, wait_for_cisshgo):
-        """Job submitted with deprecated 'ip' field still succeeds (backwards compat)."""
-        payload = {
-            "ip": CISSHGO_HOST,
             "platform": CISSHGO_PLATFORM,
             "port": CISSHGO_PORT,
             "commands": ["show version"],

--- a/tests/k8s/test_e2e.py
+++ b/tests/k8s/test_e2e.py
@@ -69,7 +69,7 @@ def main() -> None:
     wait_for_api(NAAS_URL, timeout=60)
 
     payload: dict[str, object] = {
-        "ip": CISSHGO_HOST,
+        "host": CISSHGO_HOST,
         "platform": "cisco_ios",
         "port": CISSHGO_PORT,
         "commands": ["show version"],

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -15,7 +15,7 @@ class TestAuditEvents:
         caplog.set_level(logging.INFO)
         emit_audit_event(
             "job.submitted",
-            ip="192.168.1.1",
+            host="192.168.1.1",
             platform="cisco_ios",
             port=22,
             command_count=3,
@@ -39,19 +39,19 @@ class TestAuditEvents:
     def test_device_locked_out_valid(self, caplog):
         """Test device.locked_out event with all required fields."""
         caplog.set_level(logging.INFO)
-        emit_audit_event("device.locked_out", ip="192.168.1.1", failure_count=10)
+        emit_audit_event("device.locked_out", host="192.168.1.1", failure_count=10)
         assert "Audit event" in caplog.text
 
     def test_circuit_opened_valid(self, caplog):
         """Test circuit.opened event with all required fields."""
         caplog.set_level(logging.INFO)
-        emit_audit_event("circuit.opened", ip="192.168.1.1")
+        emit_audit_event("circuit.opened", host="192.168.1.1")
         assert "Audit event" in caplog.text
 
     def test_circuit_closed_valid(self, caplog):
         """Test circuit.closed event with all required fields."""
         caplog.set_level(logging.INFO)
-        emit_audit_event("circuit.closed", ip="192.168.1.1")
+        emit_audit_event("circuit.closed", host="192.168.1.1")
         assert "Audit event" in caplog.text
 
     def test_unknown_event_type(self):
@@ -62,4 +62,4 @@ class TestAuditEvents:
     def test_missing_required_fields(self):
         """Test that missing required fields raise ValueError."""
         with pytest.raises(ValueError, match="Missing required fields"):
-            emit_audit_event("job.submitted", ip="192.168.1.1")
+            emit_audit_event("job.submitted", host="192.168.1.1")

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -32,7 +32,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.168.1.1",
+                    "host": "192.168.1.1",
                     "port": 22,
                     "platform": "cisco_ios",
                     "commands": ["show version"],
@@ -54,7 +54,7 @@ class TestSendCommand:
         response = client.post(
             "/v1/send_command",
             json={
-                "ip": "192.168.1.1",
+                "host": "192.168.1.1",
                 "commands": ["show version"],
             },
         )
@@ -71,7 +71,7 @@ class TestSendCommand:
             with patch("naas.resources.send_command.device_lockout", return_value=True):
                 response = client.post(
                     "/v1/send_command",
-                    json={"ip": "192.168.1.1", "commands": ["show version"]},
+                    json={"host": "192.168.1.1", "commands": ["show version"]},
                     headers={"Authorization": f"Basic {auth}"},
                 )
         assert response.status_code == 403
@@ -103,7 +103,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.168.1.1",
+                    "host": "192.168.1.1",
                     "commands": [],
                 },
                 headers={"Authorization": f"Basic {auth}"},
@@ -121,7 +121,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                     "commands": ["show version", "  ", "show run"],
                 },
                 headers={"Authorization": f"Basic {auth}"},
@@ -139,7 +139,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.168.1.1",
+                    "host": "192.168.1.1",
                     "port": 99999,
                     "commands": ["show version"],
                 },
@@ -158,7 +158,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                     "commands": ["show version"],
                     "platform": "not_a_real_platform",
                 },
@@ -177,44 +177,9 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                     "commands": ["show version"],
                     "device_type": "arista_eos",
-                },
-                headers={"Authorization": f"Basic {auth}"},
-            )
-
-        assert response.status_code == 202
-
-    def test_send_command_ip_backward_compat(self, app, client):
-        """Test POST with deprecated ip field maps to host."""
-        auth = b64encode(b"testuser:testpass").decode()
-        app.config["redis"].set("naas_cred_salt", b"test-salt")
-
-        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
-            response = client.post(
-                "/v1/send_command",
-                json={
-                    "ip": "192.0.2.1",
-                    "commands": ["show version"],
-                },
-                headers={"Authorization": f"Basic {auth}"},
-            )
-
-        assert response.status_code == 202
-
-    def test_send_command_ip_ignored_when_host_present(self, app, client):
-        """Test POST with both ip and host uses host."""
-        auth = b64encode(b"testuser:testpass").decode()
-        app.config["redis"].set("naas_cred_salt", b"test-salt")
-
-        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
-            response = client.post(
-                "/v1/send_command",
-                json={
-                    "host": "192.0.2.1",
-                    "ip": "10.0.0.1",
-                    "commands": ["show version"],
                 },
                 headers={"Authorization": f"Basic {auth}"},
             )
@@ -247,7 +212,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                     "commands": ["show version"],
                     "device_type": "arista_eos",
                     "platform": "cisco_nxos",
@@ -336,7 +301,7 @@ class TestSendCommand:
             response = client.post(
                 "/v1/send_command",
                 json={
-                    "ip": "192.168.1.1",
+                    "host": "192.168.1.1",
                     "port": 22,
                     "platform": "cisco_ios",
                     "commands": ["show version"],
@@ -479,7 +444,7 @@ class TestSendConfig:
             response = client.post(
                 "/v1/send_config",
                 json={
-                    "ip": "192.168.1.1",
+                    "host": "192.168.1.1",
                     "port": 22,
                     "platform": "cisco_ios",
                     "commands": ["interface gi0/1", "description test"],
@@ -504,7 +469,7 @@ class TestSendConfig:
             response = client.post(
                 "/v1/send_config",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                     "commands": ["interface gi0/1", "  ", "description test"],
                 },
                 headers={"Authorization": f"Basic {auth}"},
@@ -522,7 +487,7 @@ class TestSendConfig:
             response = client.post(
                 "/v1/send_config",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                 },
                 headers={"Authorization": f"Basic {auth}"},
             )
@@ -704,7 +669,7 @@ class TestSendConfig:
             response = client.post(
                 "/v1/send_config",
                 json={
-                    "ip": "192.0.2.1",
+                    "host": "192.0.2.1",
                     "commands": ["interface gi0/1"],
                     "platform": "not_a_real_platform",
                 },
@@ -719,7 +684,7 @@ class TestSendConfig:
         response = client.post(
             "/v1/send_config",
             json={
-                "ip": "192.168.1.1",
+                "host": "192.168.1.1",
                 "commands": ["interface gi0/1"],
             },
         )
@@ -736,7 +701,7 @@ class TestSendConfig:
             with patch("naas.resources.send_config.device_lockout", return_value=True):
                 response = client.post(
                     "/v1/send_config",
-                    json={"ip": "192.168.1.1", "commands": ["interface gi0/1"]},
+                    json={"host": "192.168.1.1", "commands": ["interface gi0/1"]},
                     headers={"Authorization": f"Basic {auth}"},
                 )
         assert response.status_code == 403

--- a/tests/unit/test_send_command_structured.py
+++ b/tests/unit/test_send_command_structured.py
@@ -28,7 +28,7 @@ class TestSendCommandStructured:
                     response = client.post(
                         "/v1/send_command_structured",
                         json={
-                            "ip": "192.168.1.1",
+                            "host": "192.168.1.1",
                             "commands": ["show version"],
                         },
                         headers={"Authorization": f"Basic {auth}"},
@@ -55,7 +55,7 @@ class TestSendCommandStructured:
                     response = client.post(
                         "/v1/send_command_structured",
                         json={
-                            "ip": "192.168.1.1",
+                            "host": "192.168.1.1",
                             "commands": ["show custom"],
                             "textfsm_template": "Value TEST (\\S+)\\n\\nStart\\n  ^${TEST}",
                         },
@@ -74,7 +74,7 @@ class TestSendCommandStructured:
             response = client.post(
                 "/v1/send_command_structured",
                 json={
-                    "ip": "192.168.1.1",
+                    "host": "192.168.1.1",
                     "commands": ["show version"],
                 },
                 headers={"Authorization": f"Basic {auth}"},
@@ -99,7 +99,7 @@ class TestSendCommandStructured:
                     response = client.post(
                         "/v1/send_command_structured",
                         json={
-                            "ip": "192.168.1.1",
+                            "host": "192.168.1.1",
                             "commands": ["show interfaces"],
                             "ttp_template": "interface {{ interface }}",
                         },
@@ -127,7 +127,7 @@ class TestSendCommandStructured:
                     response = client.post(
                         "/v1/send_command_structured",
                         json={
-                            "ip": "192.168.1.1",
+                            "host": "192.168.1.1",
                             "commands": ["show version"],
                             "tags": {"change": "CHG001"},
                         },
@@ -144,7 +144,7 @@ class TestSendCommandStructured:
         response = client.post(
             "/v1/send_command_structured",
             json={
-                "ip": "192.168.1.1",
+                "host": "192.168.1.1",
                 "commands": ["show version"],
                 "textfsm_template": "Value TEST (\\S+)",
                 "ttp_template": "interface {{ interface }}",
@@ -170,7 +170,7 @@ class TestSendCommandStructured:
                 with patch("naas.resources.send_command_structured.job_unlocker", return_value=True):
                     response = client.post(
                         "/v1/send_command_structured",
-                        json={"ip": "192.168.1.1", "commands": ["show version"]},
+                        json={"host": "192.168.1.1", "commands": ["show version"]},
                         headers={"Authorization": f"Basic {auth}"},
                     )
 
@@ -193,7 +193,7 @@ class TestSendCommandStructured:
                         with patch("naas.resources.send_command_structured.emit_audit_event"):
                             response = client.post(
                                 "/v1/send_command_structured",
-                                json={"ip": "192.168.1.1", "commands": ["show version"]},
+                                json={"host": "192.168.1.1", "commands": ["show version"]},
                                 headers={"Authorization": f"Basic {auth}"},
                             )
 
@@ -214,7 +214,7 @@ class TestSendCommandStructured:
             with patch("naas.resources.send_command_structured.RQJob.fetch", return_value=existing_job):
                 response = client.post(
                     "/v1/send_command_structured",
-                    json={"ip": "192.168.1.1", "commands": ["show version"]},
+                    json={"host": "192.168.1.1", "commands": ["show version"]},
                     headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "my-key"},
                 )
 
@@ -236,7 +236,7 @@ class TestSendCommandStructured:
                         with patch("naas.resources.send_command_structured.emit_audit_event"):
                             response = client.post(
                                 "/v1/send_command_structured",
-                                json={"ip": "192.168.1.1", "commands": ["show version"]},
+                                json={"host": "192.168.1.1", "commands": ["show version"]},
                                 headers={"Authorization": f"Basic {auth}", "X-Idempotency-Key": "stale-key"},
                             )
 


### PR DESCRIPTION
Closes #272

**BREAKING CHANGE:** The `ip` request field has been removed. Use `host` instead.

### Changes
- Remove `_handle_ip` deprecation shim from `models.py`
- Remove `InvalidIP` error handler
- Update audit event schemas and emitters (`ip` → `host`)
- Update all tests to use `host` in API payloads
- Remove deprecated-ip backward compat tests
- Update `api-usage.md` (remove deprecation notice, update error example)

### Unchanged
- `netmiko_lib.py` / `failed_jobs.py` — these use `ip` as Netmiko's own parameter name, not our API surface

### Testing
- 269 unit tests passing, 100% coverage
- `invoke check` clean (ruff + mypy)