### PR TITLE
feat!: remove deprecated device_type field from all endpoints (#55)

### DIFF
--- a/changes/55.breaking.md
+++ b/changes/55.breaking.md
@@ -1,0 +1,1 @@
+Remove deprecated `device_type` field from all endpoints. Use `platform` instead.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -166,10 +166,6 @@ NAAS supports all [Netmiko platforms](https://github.com/ktbyers/netmiko/blob/de
 - `hp_procurve` - HP ProCurve
 - And many more...
 
-!!! warning "Deprecated: `device_type`"
-    The `device_type` field is deprecated and will be removed in v2.0. Use `platform` instead.
-    Both fields are accepted in v1.x, but `device_type` logs a deprecation warning.
-
 ## Send Configuration
 
 Push configuration changes to devices.

--- a/naas/models.py
+++ b/naas/models.py
@@ -53,29 +53,6 @@ def _validate_webhook_url(v: str | None) -> str | None:
     return v
 
 
-def _handle_device_type(data: dict[str, Any]) -> dict[str, Any]:
-    """
-    Map deprecated device_type parameter to platform with warning.
-
-    Args:
-        data: Request data dictionary that may contain device_type
-
-    Returns:
-        Modified data dictionary with device_type mapped to platform
-    """
-    data = data.copy()  # Avoid mutating caller's dict
-    if "device_type" in data:
-        logger.warning(
-            "Parameter 'device_type' is deprecated, use 'platform' instead. "
-            "Support for 'device_type' will be removed in v2.0"
-        )
-        if "platform" not in data:
-            data["platform"] = data.pop("device_type")
-        else:
-            data.pop("device_type")
-    return data
-
-
 class _BaseCommandRequest(BaseModel):
     """Base model for command request endpoints with common fields and validators."""
 
@@ -111,12 +88,6 @@ class _BaseCommandRequest(BaseModel):
     def validate_webhook_url(cls, v: str | None) -> str | None:
         """Validate webhook_url is a valid HTTPS URL."""
         return _validate_webhook_url(v)
-
-    @model_validator(mode="before")
-    @classmethod
-    def handle_deprecated_params(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Support deprecated device_type parameter."""
-        return _handle_device_type(data)
 
     @field_validator("host")
     @classmethod
@@ -229,12 +200,6 @@ class SendConfigRequest(BaseModel):
     def validate_webhook_url(cls, v: str | None) -> str | None:
         """Validate webhook_url is a valid HTTPS URL."""
         return _validate_webhook_url(v)
-
-    @model_validator(mode="before")
-    @classmethod
-    def handle_deprecated_params(cls, data: dict[str, Any]) -> dict[str, Any]:
-        """Support deprecated device_type parameter."""
-        return _handle_device_type(data)
 
     @field_validator("host")
     @classmethod

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -168,24 +168,6 @@ class TestSendCommand:
         assert response.status_code == 422
         assert isinstance(response.json, list)
 
-    def test_send_command_device_type_backward_compat(self, app, client):
-        """Test POST with deprecated device_type maps to platform."""
-        auth = b64encode(b"testuser:testpass").decode()
-        app.config["redis"].set("naas_cred_salt", b"test-salt")
-
-        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
-            response = client.post(
-                "/v1/send_command",
-                json={
-                    "host": "192.0.2.1",
-                    "commands": ["show version"],
-                    "device_type": "arista_eos",
-                },
-                headers={"Authorization": f"Basic {auth}"},
-            )
-
-        assert response.status_code == 202
-
     def test_send_command_hostname(self, app, client):
         """Test POST with hostname instead of IP."""
         auth = b64encode(b"testuser:testpass").decode()
@@ -197,25 +179,6 @@ class TestSendCommand:
                 json={
                     "host": "router1.example.com",
                     "commands": ["show version"],
-                },
-                headers={"Authorization": f"Basic {auth}"},
-            )
-
-        assert response.status_code == 202
-
-    def test_send_command_device_type_ignored_when_platform_present(self, app, client):
-        """Test POST with both device_type and platform uses platform."""
-        auth = b64encode(b"testuser:testpass").decode()
-        app.config["redis"].set("naas_cred_salt", b"test-salt")
-
-        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
-            response = client.post(
-                "/v1/send_command",
-                json={
-                    "host": "192.0.2.1",
-                    "commands": ["show version"],
-                    "device_type": "arista_eos",
-                    "platform": "cisco_nxos",
                 },
                 headers={"Authorization": f"Basic {auth}"},
             )


### PR DESCRIPTION
Closes #55

**BREAKING CHANGE:** The `device_type` request field has been removed. Use `platform` instead.

### Changes
- Remove `_handle_device_type` deprecation shim and both `handle_deprecated_params` model validators
- Remove deprecated-device_type backward compat tests (2 tests)
- Remove deprecation notice from `api-usage.md`

### Unchanged
- `netmiko_lib.py` / `failed_jobs.py` — use `device_type` as Netmiko's internal parameter name
- `q.enqueue(..., device_type=)` calls — Netmiko's parameter, not our API

### Testing
- 267 unit tests passing, 100% coverage
- `invoke check` clean