### PR TITLE
ci: skip build/test/k8s jobs on docs-only PRs (#330)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,31 @@ on:
     branches: [main, develop, 'release/**']
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'naas/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Dockerfile'
+              - 'docker-compose*.yml'
+              - 'k8s/**'
+              - '.github/workflows/build.yml'
+
   build:
     name: Build
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -42,12 +65,14 @@ jobs:
           retention-days: 1
 
   k8s-changes:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     outputs:
       changed: ${{ steps.filter.outputs.k8s }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -55,7 +80,7 @@ jobs:
               - 'k8s/**'
               - 'Dockerfile'
               - 'tests/k8s/**'
-              - '.github/workflows/test.yml'
+              - '.github/workflows/build.yml'
 
   k8s-tests:
     runs-on: ubuntu-latest
@@ -150,11 +175,15 @@ jobs:
   build-and-k8s-summary:
     name: Build and K8s Tests
     runs-on: ubuntu-latest
-    needs: [build, k8s-tests]
+    needs: [changes, build, k8s-tests]
     if: always()
     steps:
       - name: Check results
         run: |
+          if [[ "${{ needs.changes.outputs.code }}" != "true" ]]; then
+            echo "No code changes — build and k8s tests skipped"
+            exit 0
+          fi
           if [[ "${{ needs.build.result }}" == "failure" || "${{ needs.build.result }}" == "cancelled" ]]; then
             echo "Build failed or was cancelled"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,29 @@ on:
     branches: [main, develop, 'release/**']
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'naas/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Dockerfile'
+              - 'docker-compose*.yml'
+              - '.github/workflows/test.yml'
+
   unit-tests:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -41,6 +63,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   integration-tests:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -71,6 +95,8 @@ jobs:
         run: docker compose -f tests/integration/docker-compose.test.yml down -v
 
   contract-tests:
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -96,11 +122,15 @@ jobs:
   tests-summary:
     name: Tests
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests, contract-tests]
+    needs: [changes, unit-tests, integration-tests, contract-tests]
     if: always()
     steps:
       - name: Check test results
         run: |
+          if [[ "${{ needs.changes.outputs.code }}" != "true" ]]; then
+            echo "No code changes — tests skipped"
+            exit 0
+          fi
           if [[ "${{ needs.unit-tests.result }}" == "failure" || "${{ needs.unit-tests.result }}" == "cancelled" ]]; then
             echo "Unit tests failed or were cancelled"
             exit 1

--- a/changes/330.testing.md
+++ b/changes/330.testing.md
@@ -1,0 +1,1 @@
+Skip build, test, and k8s CI jobs on docs-only PRs.


### PR DESCRIPTION
Closes #330

Adds `dorny/paths-filter` change detection to `test.yml` and `build.yml`. When a PR only touches docs/changelog/markdown files, the expensive jobs (unit tests, integration tests, contract tests, Docker build, k8s tests) are skipped.

The required status checks (`Tests` and `Build and K8s Tests` summary jobs) still run and pass — they detect no code changes and exit 0.

### How it works
- A `changes` job runs `dorny/paths-filter` to detect if code-relevant files changed
- Test/build jobs have `if: needs.changes.outputs.code == 'true'`
- Summary jobs check `changes.outputs.code` — if no code changes, they pass immediately