### PR TITLE
feat: add pluggable secrets backend abstraction (#103)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --extra dev --extra vault
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/changes/103.feature.md
+++ b/changes/103.feature.md
@@ -1,0 +1,1 @@
+Add pluggable secrets backend with environment variable (default) and HashiCorp Vault providers.

--- a/naas/config.py
+++ b/naas/config.py
@@ -120,3 +120,8 @@ def app_configure(app):
     # Initialize an rq Queue and store it for later (default context queue)
     q = Queue("naas-default", connection=redis)
     app.config["q"] = q
+
+    # Initialize secrets backend
+    from naas.library.secrets import get_secrets_backend
+
+    app.config["secrets"] = get_secrets_backend()

--- a/naas/library/secrets.py
+++ b/naas/library/secrets.py
@@ -1,0 +1,124 @@
+"""Pluggable secrets backend for application secret retrieval.
+
+Provides a Protocol and implementations for loading secrets from
+environment variables (default) or HashiCorp Vault.
+
+See ADR 0002 for design rationale.
+"""
+
+import logging
+import os
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+SECRETS_BACKEND: str = os.environ.get("SECRETS_BACKEND", "env")
+
+
+class SecretsBackend(Protocol):
+    """Interface for secret retrieval backends."""
+
+    def get_secret(self, name: str) -> str:
+        """Retrieve a secret by name.
+
+        Args:
+            name: Secret identifier.
+
+        Returns:
+            The secret value.
+
+        Raises:
+            KeyError: If the secret is not found.
+        """
+        ...
+
+
+class EnvSecretsBackend:
+    """Read secrets from environment variables."""
+
+    def get_secret(self, name: str) -> str:
+        """Retrieve a secret from environment variables.
+
+        Args:
+            name: Environment variable name.
+
+        Returns:
+            The environment variable value.
+
+        Raises:
+            KeyError: If the environment variable is not set.
+        """
+        try:
+            return os.environ[name]
+        except KeyError:
+            raise KeyError(f"Secret '{name}' not found in environment variables") from None
+
+
+class VaultSecretsBackend:
+    """Read secrets from HashiCorp Vault KV v2 engine.
+
+    Requires the ``hvac`` package: ``pip install naas[vault]``
+    """
+
+    def __init__(self, url: str, token: str, path: str = "secret/data/naas") -> None:
+        """Initialize Vault client.
+
+        Args:
+            url: Vault server URL.
+            token: Vault authentication token.
+            path: KV v2 mount path and secret path.
+        """
+        try:
+            import hvac
+        except ImportError:
+            raise ImportError("VaultSecretsBackend requires 'hvac'. Install with: pip install naas[vault]") from None
+
+        self._client = hvac.Client(url=url, token=token)
+        self._path = path
+        if not self._client.is_authenticated():
+            raise RuntimeError("Vault authentication failed")
+
+    def get_secret(self, name: str) -> str:
+        """Retrieve a secret from Vault.
+
+        Args:
+            name: Key within the Vault secret.
+
+        Returns:
+            The secret value.
+
+        Raises:
+            KeyError: If the key is not found in Vault.
+        """
+        response = self._client.secrets.kv.v2.read_secret_version(path=self._path)
+        data: dict[str, str] = response["data"]["data"]
+        if name not in data:
+            raise KeyError(f"Secret '{name}' not found in Vault path '{self._path}'")
+        return data[name]
+
+
+def get_secrets_backend() -> SecretsBackend:
+    """Create a secrets backend based on SECRETS_BACKEND config.
+
+    Returns:
+        A SecretsBackend implementation.
+
+    Raises:
+        ValueError: If SECRETS_BACKEND is not a recognized value.
+    """
+    backend = SECRETS_BACKEND.lower()
+
+    if backend == "env":
+        logger.info("Using environment variable secrets backend")
+        return EnvSecretsBackend()
+
+    if backend == "vault":
+        url = os.environ.get("VAULT_ADDR", "")
+        token = os.environ.get("VAULT_TOKEN", "")
+        path = os.environ.get("VAULT_SECRETS_PATH", "secret/data/naas")
+        if not url or not token:
+            raise ValueError("VaultSecretsBackend requires VAULT_ADDR and VAULT_TOKEN environment variables")
+        logger.info("Using HashiCorp Vault secrets backend at %s", url)
+        return VaultSecretsBackend(url=url, token=token, path=path)
+
+    raise ValueError(f"Unknown SECRETS_BACKEND: '{backend}'. Valid options: env, vault")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
     "requests>=2.31.0",
     "towncrier>=23.11.0",
 ]
+vault = [
+    "hvac>=2.1.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -98,6 +98,24 @@ services:
       redis:
         condition: service_healthy
 
+  vault:
+    image: hashicorp/vault:1.17
+    ports:
+      - "18200:8200"
+    environment:
+      - VAULT_DEV_ROOT_TOKEN_ID=test-root-token
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+    cap_add:
+      - IPC_LOCK
+    networks:
+      - naas-test
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:8200/v1/sys/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   cisshgo:
     image: ghcr.io/tbotnz/cisshgo:v0.2.0
     command: ["-listeners", "2", "-startingPort", "10022"]

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -1,0 +1,88 @@
+"""Integration tests for secrets backends."""
+
+import pytest
+import requests
+
+from naas.library.secrets import EnvSecretsBackend, VaultSecretsBackend, get_secrets_backend
+
+VAULT_ADDR = "http://localhost:18200"
+VAULT_TOKEN = "test-root-token"
+VAULT_SECRETS_PATH = "naas-test"
+
+
+@pytest.fixture(scope="module")
+def vault_seed():
+    """Seed Vault with test secrets via HTTP API."""
+    response = requests.post(
+        f"{VAULT_ADDR}/v1/secret/data/{VAULT_SECRETS_PATH}",
+        headers={"X-Vault-Token": VAULT_TOKEN},
+        json={"data": {"ENCRYPTION_KEY": "test-enc-key", "HMAC_KEY": "test-hmac-key"}},
+        timeout=5,
+    )
+    response.raise_for_status()
+    yield
+
+
+@pytest.fixture()
+def wait_for_vault():
+    """Wait for Vault to be ready."""
+    for _ in range(10):
+        try:
+            r = requests.get(f"{VAULT_ADDR}/v1/sys/health", timeout=2)
+            if r.status_code == 200:
+                return
+        except requests.ConnectionError:
+            import time
+
+            time.sleep(1)
+    pytest.fail("Vault did not become ready")
+
+
+class TestEnvSecretsBackendIntegration:
+    """Integration tests for EnvSecretsBackend."""
+
+    def test_round_trip(self, monkeypatch):
+        """Set an env var and retrieve it through the backend."""
+        monkeypatch.setenv("NAAS_TEST_SECRET", "integration-value")
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "env")
+        backend = get_secrets_backend()
+        assert isinstance(backend, EnvSecretsBackend)
+        assert backend.get_secret("NAAS_TEST_SECRET") == "integration-value"
+
+    def test_missing_secret_raises(self, monkeypatch):
+        """Missing env var raises KeyError."""
+        monkeypatch.delenv("DOES_NOT_EXIST", raising=False)
+        backend = EnvSecretsBackend()
+        with pytest.raises(KeyError):
+            backend.get_secret("DOES_NOT_EXIST")
+
+
+class TestVaultSecretsBackendIntegration:
+    """Integration tests for VaultSecretsBackend against real Vault dev server."""
+
+    def test_read_seeded_secret(self, wait_for_vault, vault_seed):
+        """Read a secret that was seeded into Vault."""
+        backend = VaultSecretsBackend(url=VAULT_ADDR, token=VAULT_TOKEN, path=VAULT_SECRETS_PATH)
+        assert backend.get_secret("ENCRYPTION_KEY") == "test-enc-key"
+        assert backend.get_secret("HMAC_KEY") == "test-hmac-key"
+
+    def test_missing_key_raises(self, wait_for_vault, vault_seed):
+        """Missing key in Vault raises KeyError."""
+        backend = VaultSecretsBackend(url=VAULT_ADDR, token=VAULT_TOKEN, path=VAULT_SECRETS_PATH)
+        with pytest.raises(KeyError, match="not found in Vault"):
+            backend.get_secret("NONEXISTENT_KEY")
+
+    def test_factory_creates_vault_backend(self, wait_for_vault, vault_seed, monkeypatch):
+        """Factory creates VaultSecretsBackend when configured."""
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "vault")
+        monkeypatch.setenv("VAULT_ADDR", VAULT_ADDR)
+        monkeypatch.setenv("VAULT_TOKEN", VAULT_TOKEN)
+        monkeypatch.setenv("VAULT_SECRETS_PATH", VAULT_SECRETS_PATH)
+        backend = get_secrets_backend()
+        assert isinstance(backend, VaultSecretsBackend)
+        assert backend.get_secret("ENCRYPTION_KEY") == "test-enc-key"
+
+    def test_bad_token_raises(self, wait_for_vault):
+        """Invalid token raises RuntimeError."""
+        with pytest.raises(RuntimeError, match="authentication failed"):
+            VaultSecretsBackend(url=VAULT_ADDR, token="bad-token", path=VAULT_SECRETS_PATH)

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -1,0 +1,94 @@
+"""Tests for naas.library.secrets module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naas.library.secrets import EnvSecretsBackend, VaultSecretsBackend, get_secrets_backend
+
+
+class TestEnvSecretsBackend:
+    """Tests for EnvSecretsBackend."""
+
+    def test_get_secret_returns_env_var(self, monkeypatch):
+        monkeypatch.setenv("MY_SECRET", "secret_value")
+        backend = EnvSecretsBackend()
+        assert backend.get_secret("MY_SECRET") == "secret_value"
+
+    def test_get_secret_raises_key_error(self, monkeypatch):
+        monkeypatch.delenv("NONEXISTENT_SECRET", raising=False)
+        backend = EnvSecretsBackend()
+        with pytest.raises(KeyError, match="not found in environment"):
+            backend.get_secret("NONEXISTENT_SECRET")
+
+
+class TestVaultSecretsBackend:
+    """Tests for VaultSecretsBackend."""
+
+    def test_init_raises_without_hvac(self):
+        with patch.dict("sys.modules", {"hvac": None}):
+            with pytest.raises(ImportError, match="hvac"):
+                VaultSecretsBackend(url="https://vault:8200", token="test")
+
+    def test_init_raises_on_auth_failure(self):
+        mock_hvac = MagicMock()
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = False
+        mock_hvac.Client.return_value = mock_client
+        with patch.dict("sys.modules", {"hvac": mock_hvac}):
+            with pytest.raises(RuntimeError, match="authentication failed"):
+                VaultSecretsBackend(url="https://vault:8200", token="bad")
+
+    def test_get_secret_returns_value(self):
+        mock_hvac = MagicMock()
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {"data": {"data": {"MY_KEY": "my_value"}}}
+        mock_hvac.Client.return_value = mock_client
+        with patch.dict("sys.modules", {"hvac": mock_hvac}):
+            backend = VaultSecretsBackend(url="https://vault:8200", token="test")
+            assert backend.get_secret("MY_KEY") == "my_value"
+
+    def test_get_secret_raises_key_error(self):
+        mock_hvac = MagicMock()
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_client.secrets.kv.v2.read_secret_version.return_value = {"data": {"data": {}}}
+        mock_hvac.Client.return_value = mock_client
+        with patch.dict("sys.modules", {"hvac": mock_hvac}):
+            backend = VaultSecretsBackend(url="https://vault:8200", token="test")
+            with pytest.raises(KeyError, match="not found in Vault"):
+                backend.get_secret("MISSING")
+
+
+class TestGetSecretsBackend:
+    """Tests for get_secrets_backend factory."""
+
+    def test_default_returns_env_backend(self, monkeypatch):
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "env")
+        backend = get_secrets_backend()
+        assert isinstance(backend, EnvSecretsBackend)
+
+    def test_vault_returns_vault_backend(self, monkeypatch):
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "vault")
+        monkeypatch.setenv("VAULT_ADDR", "https://vault:8200")
+        monkeypatch.setenv("VAULT_TOKEN", "test-token")
+        mock_hvac = MagicMock()
+        mock_client = MagicMock()
+        mock_client.is_authenticated.return_value = True
+        mock_hvac.Client.return_value = mock_client
+        with patch.dict("sys.modules", {"hvac": mock_hvac}):
+            backend = get_secrets_backend()
+            assert isinstance(backend, VaultSecretsBackend)
+
+    def test_vault_raises_without_config(self, monkeypatch):
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "vault")
+        monkeypatch.delenv("VAULT_ADDR", raising=False)
+        monkeypatch.delenv("VAULT_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="VAULT_ADDR and VAULT_TOKEN"):
+            get_secrets_backend()
+
+    def test_unknown_backend_raises(self, monkeypatch):
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "unknown")
+        with pytest.raises(ValueError, match="Unknown SECRETS_BACKEND"):
+            get_secrets_backend()

--- a/uv.lock
+++ b/uv.lock
@@ -613,6 +613,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543, upload-time = "2025-10-30T12:57:47.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921, upload-time = "2025-10-30T12:57:46.253Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1124,6 +1136,9 @@ dev = [
     { name = "ruff" },
     { name = "towncrier" },
 ]
+vault = [
+    { name = "hvac" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1142,6 +1157,7 @@ requires-dist = [
     { name = "flask", specifier = ">=1.1.1" },
     { name = "flask-restful", specifier = ">=0.3.8" },
     { name = "gunicorn", specifier = ">=20.0.4" },
+    { name = "hvac", marker = "extra == 'vault'", specifier = ">=2.1.0" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "netmiko", specifier = ">=3.0.0" },
@@ -1170,7 +1186,7 @@ requires-dist = [
     { name = "ttp", specifier = ">=0.10.0" },
     { name = "ttp-templates", specifier = ">=0.4.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "vault"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #103, Phase 0 of security epic #99

Implements a pluggable `SecretsBackend` protocol per [ADR 0002](docs/adr/0002-secrets-backend-abstraction.md):

- `SecretsBackend` Protocol with `get_secret(name) -> str`
- `EnvSecretsBackend` — reads from env vars (default, zero deps)
- `VaultSecretsBackend` — reads from HashiCorp Vault KV v2 (optional, requires `hvac`)
- `get_secrets_backend()` factory driven by `SECRETS_BACKEND` env var
- Initialized at app startup, stored on `app.config["secrets"]`
- `vault` optional dependency group added to `pyproject.toml`

### Testing
- 277 unit tests passing, 100% coverage
- 10 new tests covering both backends and factory