### PR TITLE
feat: add JWT-based API key authentication (#101)

### DIFF
--- a/changes/101.feature.md
+++ b/changes/101.feature.md
@@ -1,0 +1,1 @@
+Add JWT-based API key authentication with create, validate, and revoke support.

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -9,6 +9,7 @@ Detailed examples for common NAAS API operations.
 ## Contents
 
 - [Authentication](#authentication)
+- [API Key Management](#api-key-management)
 - [Send Command](#send-command)
 - [Send Configuration](#send-configuration)
 - [Job Cancellation](#job-cancellation)
@@ -20,7 +21,16 @@ Detailed examples for common NAAS API operations.
 
 ## Authentication
 
-NAAS uses HTTP Basic Authentication. The API passes credentials through to the network device.
+NAAS supports two authentication methods: HTTP Basic and API key (Bearer JWT).
+
+### Basic Authentication
+
+!!! warning "Deprecation notice"
+    Basic auth will be **disabled by default** in v3.0. Migrate to API key
+    authentication for programmatic access. Basic auth will remain available
+    as an opt-in configuration option.
+
+The original auth method. Credentials are passed through to the network device.
 
 ```bash
 # Using curl with -u flag
@@ -32,6 +42,87 @@ curl -k -H "Authorization: Basic $(echo -n 'username:password' | base64)" \
 ```
 
 **Important**: Always use HTTPS. Credentials are transmitted to the network device.
+
+### API Key Authentication
+
+API keys are JWTs that authenticate the caller to NAAS independently of device credentials.
+Device credentials are provided in the request body instead of the Authorization header.
+
+```bash
+# Send a command using an API key
+curl -k -X POST https://localhost:8443/v1/send_command \
+  -H "Authorization: Bearer eyJhbG..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "host": "192.168.1.1",
+    "platform": "cisco_ios",
+    "commands": ["show version"],
+    "username": "admin",
+    "password": "device_password"
+  }'
+```
+
+When using API key auth, `username` and `password` are **required** in the request body.
+`enable` is optional (defaults to the password value).
+
+**Key differences from Basic auth:**
+
+- API key identifies the caller; device credentials are separate
+- API key users are not subject to TACACS lockout
+- Keys embed role and context claims (for future RBAC support)
+
+## API Key Management
+
+Create, list, and revoke API keys. Keys are returned once at creation — store them securely.
+
+All key management endpoints require **Basic auth** — API keys cannot be used to manage
+other keys. The Basic auth password must match the `NAAS_ADMIN_SECRET` environment variable.
+If `NAAS_ADMIN_SECRET` is not set, key management is disabled.
+
+### Create a Key
+
+```bash
+curl -k -X POST https://localhost:8443/v1/api-keys \
+  -u "admin:$NAAS_ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "admin", "ttl": 7776000}'
+```
+
+Response:
+
+```json
+{
+  "key_id": "k-a1b2c3d4e5f6",
+  "token": "eyJhbG...",
+  "role": "admin",
+  "contexts": ["*"],
+  "expires_at": "2026-07-04T00:00:00Z"
+}
+```
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `role` | `admin` | Role: `admin`, `operator`, or `viewer` |
+| `contexts` | `["*"]` | Allowed routing contexts |
+| `ttl` | `7776000` (90 days) | Expiration in seconds, `0` for no expiry |
+| `created_by` | `system` | Creator identity (for audit) |
+
+### List Keys
+
+```bash
+curl -k -u "admin:$NAAS_ADMIN_SECRET" https://localhost:8443/v1/api-keys
+```
+
+Returns metadata only — tokens are never shown after creation.
+
+### Revoke a Key
+
+```bash
+curl -k -X DELETE -u "admin:$NAAS_ADMIN_SECRET" \
+  https://localhost:8443/v1/api-keys/k-a1b2c3d4e5f6
+```
+
+Revoked keys are immediately rejected on subsequent requests.
 
 ## Send Command
 

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -173,6 +173,19 @@
             "title": "Context",
             "type": "string"
           },
+          "enable": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Enable password (optional, defaults to password)",
+            "title": "Enable"
+          },
           "expect_string": {
             "anyOf": [
               {
@@ -190,6 +203,19 @@
             "description": "Device IP address or hostname",
             "title": "Host",
             "type": "string"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Device password (required for API key auth)",
+            "title": "Password"
           },
           "platform": {
             "default": "cisco_ios",
@@ -227,6 +253,19 @@
             "default": null,
             "description": "Optional key-value metadata tags (max 10, keys/values max 64 chars, alphanumeric + hyphens/underscores/colons)",
             "title": "Tags"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Device username (required for API key auth)",
+            "title": "Username"
           },
           "webhook_url": {
             "anyOf": [
@@ -274,10 +313,36 @@
             "title": "Context",
             "type": "string"
           },
+          "enable": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Enable password (optional, defaults to password)",
+            "title": "Enable"
+          },
           "host": {
             "description": "Device IP address or hostname",
             "title": "Host",
             "type": "string"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Device password (required for API key auth)",
+            "title": "Password"
           },
           "platform": {
             "default": "cisco_ios",
@@ -341,6 +406,19 @@
             "default": null,
             "description": "TTP template string or ttp://<path> reference (mutually exclusive with textfsm_template)",
             "title": "Ttp Template"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Device username (required for API key auth)",
+            "title": "Username"
           },
           "webhook_url": {
             "anyOf": [
@@ -419,10 +497,36 @@
             "title": "Context",
             "type": "string"
           },
+          "enable": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Enable password (optional, defaults to password)",
+            "title": "Enable"
+          },
           "host": {
             "description": "Device IP address or hostname",
             "title": "Host",
             "type": "string"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Device password (required for API key auth)",
+            "title": "Password"
           },
           "platform": {
             "default": "cisco_ios",
@@ -466,6 +570,19 @@
             "default": null,
             "description": "Optional key-value metadata tags (max 10, keys/values max 64 chars)",
             "title": "Tags"
+          },
+          "username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Device username (required for API key auth)",
+            "title": "Username"
           },
           "webhook_url": {
             "anyOf": [
@@ -714,6 +831,44 @@
         ],
         "responses": {},
         "summary": "Given the requested job_id, return status and/or any results if finished. :param job_id: :return: A dict of job status and/or results if finished.",
+        "tags": []
+      }
+    },
+    "/v1/api-keys": {
+      "get": {
+        "description": "",
+        "operationId": "get__v1_api-keys",
+        "parameters": [],
+        "responses": {},
+        "summary": "List all active API keys (metadata only, not tokens).",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__v1_api-keys",
+        "parameters": [],
+        "responses": {},
+        "summary": "Create a new API key. Returns the JWT token once.",
+        "tags": []
+      }
+    },
+    "/v1/api-keys/{key_id}": {
+      "delete": {
+        "description": "",
+        "operationId": "delete__v1_api-keys_{key_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Revoke an API key.",
         "tags": []
       }
     },

--- a/naas/app.py
+++ b/naas/app.py
@@ -21,6 +21,7 @@ from naas import __base_response__
 from naas.config import app_configure
 from naas.library.errorhandlers import api_error_generator
 from naas.library.worker_cache import get_cached_workers
+from naas.resources.api_keys import ApiKey, ApiKeys
 from naas.resources.cancel_job import CancelJob
 from naas.resources.contexts import Contexts
 from naas.resources.failed_jobs import FailedJobs, ReplayJob
@@ -105,6 +106,8 @@ api.add_resource(FailedJobs, "/v1/jobs/failed")
 api.add_resource(CancelJob, "/v1/jobs/<string:job_id>")
 api.add_resource(ReplayJob, "/v1/jobs/<string:job_id>/replay")
 api.add_resource(Contexts, "/v1/contexts")
+api.add_resource(ApiKeys, "/v1/api-keys")
+api.add_resource(ApiKey, "/v1/api-keys/<string:key_id>")
 
 # Legacy unversioned routes (deprecated aliases — kept for backward compatibility)
 _LEGACY_PREFIXES = ("/send_command", "/send_config")

--- a/naas/config.py
+++ b/naas/config.py
@@ -73,6 +73,11 @@ JOB_REAPER_ENABLED: bool = os.environ.get("JOB_REAPER_ENABLED", "true").lower() 
 JOB_REAPER_INTERVAL: int = int(os.environ.get("JOB_REAPER_INTERVAL", 60))
 WORKER_STALE_THRESHOLD: int = int(os.environ.get("WORKER_STALE_THRESHOLD", 120))
 
+# API key config
+API_KEY_DEFAULT_TTL: int = int(os.environ.get("API_KEY_DEFAULT_TTL", 7776000))  # 90 days
+API_KEY_MAX_TTL: int = int(os.environ.get("API_KEY_MAX_TTL", 0))  # 0 = unlimited
+NAAS_ADMIN_SECRET: str = os.environ.get("NAAS_ADMIN_SECRET", "")
+
 
 def app_configure(app):
     # Configure our environment

--- a/naas/library/api_keys.py
+++ b/naas/library/api_keys.py
@@ -1,0 +1,162 @@
+"""JWT-based API key management.
+
+Create, validate, and revoke API keys implemented as signed JWTs.
+See ADR 0003 for design rationale.
+"""
+
+import json
+import logging
+import time
+from uuid import uuid4
+
+import jwt
+from flask import current_app
+from redis import Redis
+
+from naas.config import API_KEY_DEFAULT_TTL, API_KEY_MAX_TTL
+
+logger = logging.getLogger(__name__)
+
+REVOKED_KEYS_SET = "naas:revoked_keys"
+KEY_META_PREFIX = "naas:api_keys:"
+
+
+def _get_jwt_secret() -> str:
+    """Load JWT signing secret from the secrets backend."""
+    secrets = current_app.config["secrets"]
+    result: str = secrets.get_secret("NAAS_JWT_SECRET")
+    return result
+
+
+def create_api_key(
+    role: str = "admin",
+    contexts: list[str] | None = None,
+    ttl: int | None = None,
+    created_by: str = "system",
+) -> dict[str, str | list[str]]:
+    """Create a new API key (JWT).
+
+    Args:
+        role: Role for this key (admin, operator, viewer).
+        contexts: Allowed routing contexts. Defaults to ["*"] (all).
+        ttl: Time-to-live in seconds. None uses API_KEY_DEFAULT_TTL, 0 for no expiry.
+        created_by: Identity of the creator (for audit metadata).
+
+    Returns:
+        Dict with key_id, token, role, contexts, and expires_at.
+    """
+    if contexts is None:
+        contexts = ["*"]
+    if ttl is None:
+        ttl = API_KEY_DEFAULT_TTL
+    if API_KEY_MAX_TTL > 0 and ttl > API_KEY_MAX_TTL:
+        ttl = API_KEY_MAX_TTL
+
+    key_id = f"k-{uuid4().hex[:12]}"
+    now = int(time.time())
+    claims: dict = {
+        "sub": key_id,
+        "role": role,
+        "contexts": contexts,
+        "iat": now,
+    }
+    expires_at = ""
+    if ttl > 0:
+        claims["exp"] = now + ttl
+        expires_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now + ttl))
+
+    token = jwt.encode(claims, _get_jwt_secret(), algorithm="HS256")
+
+    # Store metadata in Redis for the list endpoint
+    redis: Redis = current_app.config["redis"]
+    meta = {
+        "role": role,
+        "contexts": json.dumps(contexts),
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+        "expires_at": expires_at,
+        "created_by": created_by,
+    }
+    redis.hset(f"{KEY_META_PREFIX}{key_id}", mapping=meta)  # type: ignore[arg-type]
+    if ttl > 0:
+        redis.expire(f"{KEY_META_PREFIX}{key_id}", ttl)
+
+    return {
+        "key_id": key_id,
+        "token": token,
+        "role": role,
+        "contexts": contexts,
+        "expires_at": expires_at,
+    }
+
+
+def validate_api_key(token: str) -> dict:
+    """Validate a JWT API key and return its claims.
+
+    Args:
+        token: The JWT token string.
+
+    Returns:
+        Decoded claims dict with sub, role, contexts, iat, and optionally exp.
+
+    Raises:
+        jwt.InvalidTokenError: If the token is invalid, expired, or revoked.
+    """
+    claims: dict = jwt.decode(token, _get_jwt_secret(), algorithms=["HS256"])
+
+    # Check revocation
+    redis: Redis = current_app.config["redis"]
+    if redis.sismember(REVOKED_KEYS_SET, claims["sub"]):
+        raise jwt.InvalidTokenError(f"API key '{claims['sub']}' has been revoked")
+
+    return claims
+
+
+def revoke_api_key(key_id: str) -> bool:
+    """Revoke an API key by adding it to the revocation set.
+
+    Args:
+        key_id: The key ID (sub claim) to revoke.
+
+    Returns:
+        True if the key was found and revoked, False if not found.
+    """
+    redis: Redis = current_app.config["redis"]
+
+    # Check key exists in metadata
+    if not redis.exists(f"{KEY_META_PREFIX}{key_id}"):
+        return False
+
+    # Add to revocation set
+    redis.sadd(REVOKED_KEYS_SET, key_id)
+
+    # Clean up metadata
+    redis.delete(f"{KEY_META_PREFIX}{key_id}")
+
+    logger.info("Revoked API key %s", key_id)
+    return True
+
+
+def list_api_keys() -> list[dict[str, str]]:
+    """List all active API key metadata (not tokens).
+
+    Returns:
+        List of dicts with key_id, role, contexts, created_at, expires_at, created_by.
+    """
+    redis: Redis = current_app.config["redis"]
+    keys: list[bytes] = redis.keys(f"{KEY_META_PREFIX}*")  # type: ignore[assignment]
+    result = []
+    for key in keys:
+        key_id = key.decode().removeprefix(KEY_META_PREFIX)
+        meta: dict[bytes, bytes] = redis.hgetall(key.decode())  # type: ignore[assignment]
+        if meta:
+            result.append(
+                {
+                    "key_id": key_id,
+                    "role": meta[b"role"].decode(),
+                    "contexts": json.loads(meta[b"contexts"].decode()),
+                    "created_at": meta[b"created_at"].decode(),
+                    "expires_at": meta[b"expires_at"].decode(),
+                    "created_by": meta[b"created_by"].decode(),
+                }
+            )
+    return result

--- a/naas/library/decorators.py
+++ b/naas/library/decorators.py
@@ -5,6 +5,7 @@ from functools import wraps
 from uuid import uuid4
 
 from flask import g, request
+from werkzeug.exceptions import UnprocessableEntity
 
 from naas.library import validation
 from naas.library.auth import Credentials
@@ -42,11 +43,25 @@ def valid_post(f):
         v.is_duplicate_job(g.request_id)
 
         # Create a credentials object, and store it on the g object
-        g.credentials = Credentials(
-            username=request.authorization.username,
-            password=request.authorization.password,
-            enable=request.json.get("enable", None),
-        )
+        if g.auth_method == "bearer":
+            # JWT auth: device credentials come from request body
+            body = request.json
+            username = body.get("username")
+            password = body.get("password")
+            if not username or not password:
+                raise UnprocessableEntity("username and password are required in request body when using API key auth")
+            g.credentials = Credentials(
+                username=username,
+                password=password,
+                enable=body.get("enable"),
+            )
+        else:
+            # Basic auth: device credentials from Authorization header
+            g.credentials = Credentials(
+                username=request.authorization.username,
+                password=request.authorization.password,
+                enable=request.json.get("enable", None),
+            )
 
         return f(*args, **kwargs)
 

--- a/naas/library/validation.py
+++ b/naas/library/validation.py
@@ -4,9 +4,11 @@
 
 from uuid import UUID
 
-from flask import current_app, request
+import jwt
+from flask import current_app, g, request
 from werkzeug.exceptions import BadRequest
 
+from naas.library.api_keys import validate_api_key
 from naas.library.auth import tacacs_auth_lockout
 from naas.library.errorhandlers import DuplicateRequestID, LockedOut, NoAuth, NoJSON
 
@@ -31,7 +33,25 @@ class Validate:
 
     @staticmethod
     def has_auth() -> None:
-        """Ensure that the request has provided authorization headers (basic with username and password)."""
+        """Ensure the request has valid authentication (Basic or Bearer JWT).
+
+        Sets ``g.auth_method`` to ``"basic"`` or ``"bearer"`` and, for Bearer,
+        stores decoded claims on ``g.jwt_claims``.
+        """
+        auth_header = request.headers.get("Authorization", "")
+
+        # Bearer JWT path
+        if auth_header.startswith("Bearer "):
+            token = auth_header.removeprefix("Bearer ")
+            try:
+                g.jwt_claims = validate_api_key(token)
+                g.auth_method = "bearer"
+                return
+            except jwt.InvalidTokenError as exc:
+                current_app.logger.error("Invalid API key: %s", exc)
+                raise NoAuth
+
+        # Basic auth path (existing behaviour)
         if (
             not request.authorization
             or request.authorization.username is None
@@ -39,10 +59,13 @@ class Validate:
         ):
             current_app.logger.error("user did not pass authentication information")
             raise NoAuth
+        g.auth_method = "basic"
 
     @staticmethod
     def locked_out() -> None:
         """Validate if this user is locked out from accessing the API."""
+        if getattr(g, "auth_method", None) == "bearer":
+            return  # JWT-authenticated users are not subject to TACACS lockout
         if request.authorization and request.authorization.username:
             if tacacs_auth_lockout(username=request.authorization.username, redis=current_app.config["redis"]):
                 current_app.logger.error(f"{request.authorization.username} is currently locked out.")

--- a/naas/models.py
+++ b/naas/models.py
@@ -76,6 +76,9 @@ class _BaseCommandRequest(BaseModel):
         default=None,
         description="Optional HTTPS URL to POST a job completion notification to (never includes results)",
     )
+    username: str | None = Field(default=None, description="Device username (required for API key auth)")
+    password: str | None = Field(default=None, description="Device password (required for API key auth)")
+    enable: str | None = Field(default=None, description="Enable password (optional, defaults to password)")
 
     @field_validator("tags")
     @classmethod
@@ -188,6 +191,9 @@ class SendConfigRequest(BaseModel):
         default=None,
         description="Optional HTTPS URL to POST a job completion notification to (never includes results)",
     )
+    username: str | None = Field(default=None, description="Device username (required for API key auth)")
+    password: str | None = Field(default=None, description="Device password (required for API key auth)")
+    enable: str | None = Field(default=None, description="Enable password (optional, defaults to password)")
 
     @field_validator("tags")
     @classmethod

--- a/naas/resources/api_keys.py
+++ b/naas/resources/api_keys.py
@@ -1,0 +1,56 @@
+"""API resources for API key management.
+
+All endpoints require Basic auth — API keys cannot be used to manage other keys.
+"""
+
+from flask import request
+from flask_restful import Resource
+
+from naas import __base_response__
+from naas.config import NAAS_ADMIN_SECRET
+from naas.library.api_keys import create_api_key, list_api_keys, revoke_api_key
+from naas.library.errorhandlers import NoAuth
+
+
+def _require_admin_auth() -> None:
+    """Ensure the request uses Basic auth with the admin secret."""
+    if not NAAS_ADMIN_SECRET:
+        raise NoAuth  # admin secret not configured — deny all key management
+    auth = request.authorization
+    if not auth or not auth.username or auth.password != NAAS_ADMIN_SECRET:
+        raise NoAuth
+
+
+class ApiKeys(Resource):
+    """Resource for creating and listing API keys."""
+
+    @staticmethod
+    def post():
+        """Create a new API key. Returns the JWT token once."""
+        _require_admin_auth()
+        data = request.get_json(force=True)
+        result = create_api_key(
+            role=data.get("role", "admin"),
+            contexts=data.get("contexts"),
+            ttl=data.get("ttl"),
+            created_by=request.authorization.username,  # type: ignore[union-attr]
+        )
+        return {**result, **__base_response__}, 201
+
+    @staticmethod
+    def get():
+        """List all active API keys (metadata only, not tokens)."""
+        _require_admin_auth()
+        return {"keys": list_api_keys(), **__base_response__}, 200
+
+
+class ApiKey(Resource):
+    """Resource for revoking a single API key."""
+
+    @staticmethod
+    def delete(key_id: str):
+        """Revoke an API key."""
+        _require_admin_auth()
+        if revoke_api_key(key_id):
+            return "", 204
+        return {"error": f"Key '{key_id}' not found", **__base_response__}, 404

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "textfsm>=1.1.0",
     "ttp>=0.10.0",
     "ttp-templates>=0.4.0",
+    "pyjwt>=2.12.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -30,6 +30,8 @@ services:
       - NAAS_CONTEXTS=default,alt
       - GUNICORN_WORKERS=2
       - WEBHOOK_ALLOW_HTTP=true
+      - NAAS_JWT_SECRET=integration-test-jwt-secret
+      - NAAS_ADMIN_SECRET=integration-test-admin-secret
     networks:
       - naas-test
     depends_on:

--- a/tests/integration/test_api_keys.py
+++ b/tests/integration/test_api_keys.py
@@ -1,0 +1,115 @@
+"""Integration tests for API key authentication."""
+
+import time
+
+import jwt
+import pytest
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+JWT_SECRET = "integration-test-jwt-secret"
+CISSHGO_HOST = "240.11.2.100"
+ADMIN_AUTH = ("admin", "integration-test-admin-secret")
+
+
+@pytest.fixture(scope="session")
+def api_url():
+    return "https://localhost:18443"
+
+
+class TestApiKeyLifecycle:
+    """Test create → use → list → revoke → reject flow against live stack."""
+
+    def test_create_and_use_api_key(self, api_url):
+        """Create a key, use it to send a command, verify it works."""
+        # Create (requires Basic auth)
+        resp = requests.post(f"{api_url}/v1/api-keys", json={"role": "admin"}, auth=ADMIN_AUTH, verify=False)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["key_id"].startswith("k-")
+        token = data["token"]
+
+        # Use it to send a command
+        resp = requests.post(
+            f"{api_url}/v1/send_command",
+            json={
+                "host": CISSHGO_HOST,
+                "port": 10022,
+                "platform": "cisco_ios",
+                "commands": ["show version"],
+                "username": "admin",
+                "password": "admin",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+            verify=False,
+        )
+        assert resp.status_code == 202
+
+    def test_list_keys(self, api_url):
+        """List endpoint returns metadata for created keys."""
+        create_resp = requests.post(
+            f"{api_url}/v1/api-keys", json={"role": "operator", "contexts": ["dc1"]}, auth=ADMIN_AUTH, verify=False
+        )
+        key_id = create_resp.json()["key_id"]
+
+        resp = requests.get(f"{api_url}/v1/api-keys", auth=ADMIN_AUTH, verify=False)
+        assert resp.status_code == 200
+        keys = resp.json()["keys"]
+        match = [k for k in keys if k["key_id"] == key_id]
+        assert len(match) == 1
+        assert match[0]["role"] == "operator"
+
+    def test_revoke_then_reject(self, api_url):
+        """Revoked key should be rejected on subsequent use."""
+        create_resp = requests.post(f"{api_url}/v1/api-keys", json={}, auth=ADMIN_AUTH, verify=False)
+        key_id = create_resp.json()["key_id"]
+        token = create_resp.json()["token"]
+
+        # Revoke
+        resp = requests.delete(f"{api_url}/v1/api-keys/{key_id}", auth=ADMIN_AUTH, verify=False)
+        assert resp.status_code == 204
+
+        # Attempt to use revoked key
+        resp = requests.post(
+            f"{api_url}/v1/send_command",
+            json={
+                "host": CISSHGO_HOST,
+                "commands": ["show version"],
+                "username": "admin",
+                "password": "admin",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+            verify=False,
+        )
+        assert resp.status_code == 401
+
+    def test_invalid_token_rejected(self, api_url):
+        """A token signed with the wrong secret should be rejected."""
+        fake_token = jwt.encode({"sub": "k-fake", "iat": int(time.time())}, "wrong-secret", algorithm="HS256")
+        resp = requests.post(
+            f"{api_url}/v1/send_command",
+            json={
+                "host": CISSHGO_HOST,
+                "commands": ["show version"],
+                "username": "admin",
+                "password": "admin",
+            },
+            headers={"Authorization": f"Bearer {fake_token}"},
+            verify=False,
+        )
+        assert resp.status_code == 401
+
+    def test_bearer_missing_body_creds_rejected(self, api_url):
+        """Bearer auth without username/password in body should fail."""
+        create_resp = requests.post(f"{api_url}/v1/api-keys", json={}, auth=ADMIN_AUTH, verify=False)
+        token = create_resp.json()["token"]
+
+        resp = requests.post(
+            f"{api_url}/v1/send_command",
+            json={"host": CISSHGO_HOST, "commands": ["show version"]},
+            headers={"Authorization": f"Bearer {token}"},
+            verify=False,
+        )
+        assert resp.status_code == 422

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -1,0 +1,266 @@
+"""Unit tests for API key authentication."""
+
+import time
+from base64 import b64encode
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+from naas.library.api_keys import (
+    KEY_META_PREFIX,
+    REVOKED_KEYS_SET,
+    create_api_key,
+    list_api_keys,
+    revoke_api_key,
+    validate_api_key,
+)
+
+JWT_SECRET = "test-jwt-secret"
+
+
+@pytest.fixture()
+def _mock_secrets(app):
+    """Inject a mock secrets backend that returns a known JWT secret."""
+    mock_backend = MagicMock()
+    mock_backend.get_secret.return_value = JWT_SECRET
+    app.config["secrets"] = mock_backend
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestCreateApiKey:
+    """Tests for create_api_key."""
+
+    def test_creates_key_with_defaults(self, app):
+        with app.app_context():
+            result = create_api_key()
+        assert result["key_id"].startswith("k-")
+        assert result["role"] == "admin"
+        assert result["contexts"] == ["*"]
+        assert result["token"]
+        assert result["expires_at"]
+
+    def test_custom_role_and_contexts(self, app):
+        with app.app_context():
+            result = create_api_key(role="operator", contexts=["oob-dc1"])
+        assert result["role"] == "operator"
+        assert result["contexts"] == ["oob-dc1"]
+
+    def test_no_expiry_when_ttl_zero(self, app):
+        with app.app_context():
+            result = create_api_key(ttl=0)
+        assert result["expires_at"] == ""
+        claims = jwt.decode(result["token"], JWT_SECRET, algorithms=["HS256"])
+        assert "exp" not in claims
+
+    def test_stores_metadata_in_redis(self, app):
+        with app.app_context():
+            result = create_api_key(created_by="admin-user")
+            meta = app.config["redis"].hgetall(f"{KEY_META_PREFIX}{result['key_id']}")
+        assert meta[b"role"] == b"admin"
+        assert meta[b"created_by"] == b"admin-user"
+
+    def test_max_ttl_caps_expiry(self, app, monkeypatch):
+        monkeypatch.setattr("naas.library.api_keys.API_KEY_MAX_TTL", 60)
+        with app.app_context():
+            result = create_api_key(ttl=9999)
+        claims = jwt.decode(result["token"], JWT_SECRET, algorithms=["HS256"])
+        assert claims["exp"] - claims["iat"] == 60
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestValidateApiKey:
+    """Tests for validate_api_key."""
+
+    def test_valid_token(self, app):
+        with app.app_context():
+            token = create_api_key()["token"]
+            claims = validate_api_key(token)
+        assert claims["role"] == "admin"
+        assert claims["sub"].startswith("k-")
+
+    def test_expired_token_raises(self, app):
+        with app.app_context():
+            token = create_api_key(ttl=1)["token"]
+        time.sleep(1.1)
+        with app.app_context():
+            with pytest.raises(jwt.ExpiredSignatureError):
+                validate_api_key(token)
+
+    def test_invalid_signature_raises(self, app):
+        token = jwt.encode({"sub": "k-fake", "iat": int(time.time())}, "wrong-secret", algorithm="HS256")
+        with app.app_context():
+            with pytest.raises(jwt.InvalidSignatureError):
+                validate_api_key(token)
+
+    def test_revoked_token_raises(self, app):
+        with app.app_context():
+            result = create_api_key()
+            app.config["redis"].sadd(REVOKED_KEYS_SET, result["key_id"])
+            with pytest.raises(jwt.InvalidTokenError, match="revoked"):
+                validate_api_key(result["token"])
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestRevokeApiKey:
+    """Tests for revoke_api_key."""
+
+    def test_revoke_existing_key(self, app):
+        with app.app_context():
+            key_id = create_api_key()["key_id"]
+            assert revoke_api_key(key_id) is True
+            assert app.config["redis"].sismember(REVOKED_KEYS_SET, key_id)
+            assert not app.config["redis"].exists(f"{KEY_META_PREFIX}{key_id}")
+
+    def test_revoke_nonexistent_key(self, app):
+        with app.app_context():
+            assert revoke_api_key("k-doesnotexist") is False
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestListApiKeys:
+    """Tests for list_api_keys."""
+
+    def test_list_returns_metadata(self, app):
+        with app.app_context():
+            key_id = create_api_key(role="operator", contexts=["dc1"], created_by="tester")["key_id"]
+            keys = list_api_keys()
+        match = [k for k in keys if k["key_id"] == key_id]
+        assert len(match) == 1
+        assert match[0]["role"] == "operator"
+        assert match[0]["contexts"] == ["dc1"]
+        assert match[0]["created_by"] == "tester"
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestApiKeysEndpoints:
+    """Tests for /v1/api-keys resource endpoints."""
+
+    _auth_header = {"Authorization": f"Basic {b64encode(b'admin:admin-secret').decode()}"}
+
+    @pytest.fixture(autouse=True)
+    def _set_admin_secret(self, monkeypatch):
+        monkeypatch.setattr("naas.resources.api_keys.NAAS_ADMIN_SECRET", "admin-secret")
+
+    def test_create_key_endpoint(self, app, client):
+        with app.app_context():
+            response = client.post("/v1/api-keys", json={"role": "operator"}, headers=self._auth_header)
+        assert response.status_code == 201
+        assert response.json["key_id"].startswith("k-")
+        assert response.json["token"]
+        assert response.json["role"] == "operator"
+
+    def test_create_key_records_creator(self, app, client):
+        with app.app_context():
+            response = client.post("/v1/api-keys", json={}, headers=self._auth_header)
+            keys = client.get("/v1/api-keys", headers=self._auth_header).json["keys"]
+        match = [k for k in keys if k["key_id"] == response.json["key_id"]]
+        assert match[0]["created_by"] == "admin"
+
+    def test_list_keys_endpoint(self, app, client):
+        with app.app_context():
+            client.post("/v1/api-keys", json={}, headers=self._auth_header)
+            response = client.get("/v1/api-keys", headers=self._auth_header)
+        assert response.status_code == 200
+        assert "keys" in response.json
+
+    def test_revoke_key_endpoint(self, app, client):
+        with app.app_context():
+            key_id = client.post("/v1/api-keys", json={}, headers=self._auth_header).json["key_id"]
+            response = client.delete(f"/v1/api-keys/{key_id}", headers=self._auth_header)
+        assert response.status_code == 204
+
+    def test_revoke_nonexistent_key_endpoint(self, app, client):
+        with app.app_context():
+            response = client.delete("/v1/api-keys/k-doesnotexist", headers=self._auth_header)
+        assert response.status_code == 404
+
+    def test_no_auth_returns_401(self, app, client):
+        with app.app_context():
+            assert client.post("/v1/api-keys", json={}).status_code == 401
+            assert client.get("/v1/api-keys").status_code == 401
+            assert client.delete("/v1/api-keys/k-x").status_code == 401
+
+    def test_wrong_secret_returns_401(self, app, client):
+        bad_auth = {"Authorization": f"Basic {b64encode(b'admin:wrong').decode()}"}
+        with app.app_context():
+            assert client.post("/v1/api-keys", json={}, headers=bad_auth).status_code == 401
+
+    def test_unconfigured_secret_returns_401(self, app, client, monkeypatch):
+        monkeypatch.setattr("naas.resources.api_keys.NAAS_ADMIN_SECRET", "")
+        with app.app_context():
+            assert client.post("/v1/api-keys", json={}, headers=self._auth_header).status_code == 401
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestBearerAuth:
+    """Tests for Bearer JWT auth flow in valid_post."""
+
+    def test_bearer_auth_with_body_creds(self, app, client):
+        """Bearer JWT + body credentials should enqueue a job."""
+        with app.app_context():
+            token = create_api_key()["token"]
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={
+                    "host": "192.168.1.1",
+                    "commands": ["show version"],
+                    "username": "netadmin",
+                    "password": "secret",
+                },
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 202
+
+    def test_bearer_auth_missing_body_creds(self, app, client):
+        """Bearer JWT without username/password in body should return 422."""
+        with app.app_context():
+            token = create_api_key()["token"]
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={"host": "192.168.1.1", "commands": ["show version"]},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert response.status_code == 422
+
+    def test_bearer_auth_invalid_token(self, client):
+        """Invalid Bearer token should return 401."""
+        response = client.post(
+            "/v1/send_command",
+            json={"host": "192.168.1.1", "commands": ["show version"]},
+            headers={"Authorization": "Bearer invalid.token.here"},
+        )
+        assert response.status_code == 401
+
+    def test_bearer_auth_skips_tacacs_lockout(self, app, client):
+        """JWT-authenticated users should bypass TACACS lockout checks."""
+        with app.app_context():
+            token = create_api_key()["token"]
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        # Don't mock tacacs_auth_lockout — it should never be called for bearer
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.168.1.1",
+                "commands": ["show version"],
+                "username": "netadmin",
+                "password": "secret",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202
+
+    def test_basic_auth_still_works(self, app, client):
+        """Basic auth should continue to work unchanged."""
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        with patch("naas.library.validation.tacacs_auth_lockout", return_value=False):
+            response = client.post(
+                "/v1/send_command",
+                json={"host": "192.168.1.1", "commands": ["show version"]},
+                headers={"Authorization": f"Basic {auth}"},
+            )
+        assert response.status_code == 202

--- a/uv.lock
+++ b/uv.lock
@@ -1109,6 +1109,7 @@ dependencies = [
     { name = "prometheus-flask-exporter" },
     { name = "pybreaker" },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "pyserial" },
     { name = "python-json-logger" },
     { name = "pyyaml" },
@@ -1167,6 +1168,7 @@ requires-dist = [
     { name = "prometheus-flask-exporter", specifier = ">=0.23.2" },
     { name = "pybreaker", specifier = ">=1.4.1" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pyjwt", specifier = ">=2.12.1" },
     { name = "pyserial", specifier = ">=3.4" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
@@ -1522,6 +1524,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #101 — Phase 1 of security epic #99

## Summary

Adds JWT-based API key authentication as an alternative to Basic auth, per [ADR 0003](docs/adr/0003-api-key-authentication.md).

## Changes

- **`naas/library/api_keys.py`** — create, validate, revoke, list API keys (HS256-signed JWTs)
- **`naas/resources/api_keys.py`** — POST/GET/DELETE `/v1/api-keys` endpoints, gated by `NAAS_ADMIN_SECRET`
- **`naas/library/validation.py`** — `has_auth()` now accepts Bearer JWT alongside Basic auth
- **`naas/library/decorators.py`** — `valid_post` builds Credentials from body fields for JWT auth
- **`naas/models.py`** — optional `username`/`password`/`enable` fields on request models
- **`naas/config.py`** — `NAAS_ADMIN_SECRET`, `API_KEY_DEFAULT_TTL`, `API_KEY_MAX_TTL`
- **`docs/api-usage.md`** — API key auth docs, key management docs, v3.0 Basic auth deprecation notice

## Auth flow

```
Request → Authorization: Basic → existing flow (device creds from header)
Request → Authorization: Bearer <jwt> → verify signature → check revocation → device creds from body
```

## Testing

- 24 unit tests (302 total, 100% coverage)
- 5 integration tests (create+use, list, revoke+reject, invalid token, missing body creds)
- All existing tests pass unchanged