### PR TITLE
feat: add role-based access control (#102)

### DIFF
--- a/changes/102.feature.md
+++ b/changes/102.feature.md
@@ -1,0 +1,1 @@
+Add role-based access control with admin, operator, and viewer roles.

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -1004,7 +1004,7 @@
     },
     "/v1/jobs/{job_id}": {
       "delete": {
-        "description": "Args:     job_id: UUID of the job to cancel.\n\nReturns:     Empty response with 204 status on success.     400 if job_id is not a valid UUID.     403 if credentials do not match the job submitter.     404 if job not found.     409 if job already finished or failed.",
+        "description": "Returns:     Empty response with 204 status on success.     400 if job_id is not a valid UUID.     403 if credentials do not match the job submitter.     404 if job not found.     409 if job already finished or failed.",
         "operationId": "delete__v1_jobs_{job_id}",
         "parameters": [
           {
@@ -1018,7 +1018,7 @@
           }
         ],
         "responses": {},
-        "summary": "Cancel a job by job_id.",
+        "summary": "Args:     job_id: UUID of the job to cancel.",
         "tags": []
       }
     },

--- a/naas/library/auth.py
+++ b/naas/library/auth.py
@@ -1,6 +1,7 @@
 # Auth related functions
 
 from datetime import datetime, timedelta
+from functools import wraps
 from hashlib import sha512
 from typing import TYPE_CHECKING
 from uuid import uuid4
@@ -126,3 +127,37 @@ class Credentials:
         salt_shaker = sha512(pork.encode())
         salted_pork = salt_shaker.hexdigest()  # Particularly nice
         return salted_pork
+
+
+# Role hierarchy — higher rank = more permissions
+ROLE_RANK: dict[str, int] = {"viewer": 0, "operator": 1, "admin": 2}
+
+
+def require_role(minimum_role: str):
+    """Decorator to enforce a minimum role for JWT-authenticated requests.
+
+    Basic auth users are implicitly admin (backward compatibility).
+    Calls has_auth() if auth has not yet been established on this request.
+    """
+
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            from flask import g
+
+            if not hasattr(g, "auth_method"):
+                from naas.library.validation import Validate
+
+                Validate.has_auth()
+            if getattr(g, "auth_method", "basic") == "basic":
+                return f(*args, **kwargs)
+            user_role = g.jwt_claims.get("role", "viewer")
+            if ROLE_RANK.get(user_role, 0) < ROLE_RANK[minimum_role]:
+                from werkzeug.exceptions import Forbidden
+
+                raise Forbidden
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/naas/resources/cancel_job.py
+++ b/naas/resources/cancel_job.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import Conflict, Forbidden
 
 from naas import __base_response__
 from naas.library.audit import emit_audit_event
-from naas.library.auth import Credentials, job_unlocker
+from naas.library.auth import Credentials, job_unlocker, require_role
 from naas.library.validation import Validate
 
 
@@ -16,9 +16,9 @@ class CancelJob(Resource):
     """Resource for cancelling jobs."""
 
     @staticmethod
+    @require_role("operator")
     def delete(job_id: str):
         """
-        Cancel a job by job_id.
 
         Args:
             job_id: UUID of the job to cancel.

--- a/naas/resources/contexts.py
+++ b/naas/resources/contexts.py
@@ -6,11 +6,13 @@ from rq import Queue, Worker
 from spectree import Response
 
 from naas.config import NAAS_CONTEXTS
+from naas.library.auth import require_role
 from naas.models import ContextInfo, ContextsResponse
 from naas.spec import spec
 
 
 class Contexts(Resource):
+    @require_role("viewer")
     @spec.validate(resp=Response(HTTP_200=ContextsResponse))
     def get(self):
         """

--- a/naas/resources/failed_jobs.py
+++ b/naas/resources/failed_jobs.py
@@ -10,7 +10,7 @@ from rq.registry import FailedJobRegistry
 
 from naas import __base_response__
 from naas.config import FAILED_JOB_MAX_RETAIN, JOB_TIMEOUT, JOB_TTL_FAILED, JOB_TTL_SUCCESS
-from naas.library.auth import Credentials, job_locker, job_unlocker
+from naas.library.auth import Credentials, job_locker, job_unlocker, require_role
 from naas.library.callbacks import on_job_complete, on_job_failure
 from naas.library.context import get_queue_for_context
 from naas.library.sanitize import sanitize_error
@@ -40,6 +40,7 @@ class FailedJobs(Resource):
     """GET /v1/jobs/failed — list jobs in the failed registry."""
 
     @staticmethod
+    @require_role("operator")
     def get():
         """
         List jobs in the failed (dead letter) registry.
@@ -81,6 +82,7 @@ class ReplayJob(Resource):
     """POST /v1/jobs/{job_id}/replay — re-enqueue a failed job."""
 
     @staticmethod
+    @require_role("operator")
     def post(job_id: str):
         """
         Re-enqueue a failed job using the caller's current credentials.

--- a/naas/resources/get_results.py
+++ b/naas/resources/get_results.py
@@ -7,13 +7,14 @@ from rq.job import Job
 from werkzeug.exceptions import Forbidden
 
 from naas import __base_response__
-from naas.library.auth import Credentials, job_unlocker
+from naas.library.auth import Credentials, job_unlocker, require_role
 from naas.library.validation import Validate
 from naas.models import JobResultResponse
 
 
 class GetResults(Resource):
     @staticmethod
+    @require_role("viewer")
     def get(job_id: str):
         """
         Given the requested job_id, return status and/or any results if finished.

--- a/naas/resources/list_jobs.py
+++ b/naas/resources/list_jobs.py
@@ -6,6 +6,7 @@ from rq.job import Job
 from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
 
 from naas import __base_response__
+from naas.library.auth import require_role
 from naas.library.validation import Validate
 from naas.models import ListJobsQuery
 from naas.spec import spec
@@ -13,6 +14,7 @@ from naas.spec import spec
 
 class ListJobs(Resource):
     @staticmethod
+    @require_role("viewer")
     @spec.validate(query=ListJobsQuery)
     def get():
         """

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -10,7 +10,7 @@ from spectree import Response
 from naas import __base_response__
 from naas.config import JOB_TIMEOUT, JOB_TTL_FAILED, JOB_TTL_SUCCESS
 from naas.library.audit import emit_audit_event
-from naas.library.auth import device_lockout, job_locker, job_unlocker
+from naas.library.auth import device_lockout, job_locker, job_unlocker, require_role
 from naas.library.callbacks import on_job_complete, on_job_failure
 from naas.library.context import get_queue_for_context
 from naas.library.decorators import valid_post
@@ -28,6 +28,7 @@ class SendCommand(Resource):
         return __base_response__
 
     @valid_post
+    @require_role("operator")
     @spec.validate(json=SendCommandRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -10,7 +10,7 @@ from spectree import Response
 from naas import __base_response__
 from naas.config import JOB_TIMEOUT, JOB_TTL_FAILED, JOB_TTL_SUCCESS
 from naas.library.audit import emit_audit_event
-from naas.library.auth import device_lockout, job_locker, job_unlocker
+from naas.library.auth import device_lockout, job_locker, job_unlocker, require_role
 from naas.library.callbacks import on_job_complete, on_job_failure
 from naas.library.context import get_queue_for_context
 from naas.library.decorators import valid_post
@@ -28,6 +28,7 @@ class SendCommandStructured(Resource):
         return __base_response__
 
     @valid_post
+    @require_role("operator")
     @spec.validate(json=SendCommandStructuredRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -10,7 +10,7 @@ from spectree import Response
 from naas import __base_response__
 from naas.config import JOB_TIMEOUT, JOB_TTL_FAILED, JOB_TTL_SUCCESS
 from naas.library.audit import emit_audit_event
-from naas.library.auth import device_lockout, job_locker, job_unlocker
+from naas.library.auth import device_lockout, job_locker, job_unlocker, require_role
 from naas.library.callbacks import on_job_complete, on_job_failure
 from naas.library.context import get_queue_for_context
 from naas.library.decorators import valid_post
@@ -28,6 +28,7 @@ class SendConfig(Resource):
         return __base_response__
 
     @valid_post
+    @require_role("operator")
     @spec.validate(json=SendConfigRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """

--- a/tests/integration/test_full_stack.py
+++ b/tests/integration/test_full_stack.py
@@ -57,6 +57,6 @@ def test_send_command_job_creation(api_url, wait_for_api):
 
 def test_get_results_not_found(api_url, wait_for_api):
     """Test getting results for non-existent job returns 400 (bad request format)."""
-    response = requests.get(f"{api_url}/send_command/nonexistent", verify=False)
+    response = requests.get(f"{api_url}/send_command/nonexistent", auth=("admin", "admin"), verify=False)
     # Invalid job ID format returns 400
     assert response.status_code == 400

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -264,3 +264,40 @@ class TestBearerAuth:
                 headers={"Authorization": f"Basic {auth}"},
             )
         assert response.status_code == 202
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestRBAC:
+    """Tests for role-based access control enforcement."""
+
+    def _make_token(self, app, role):
+        with app.app_context():
+            return create_api_key(role=role)["token"]
+
+    def test_viewer_cannot_send_command(self, app, client):
+        token = self._make_token(app, "viewer")
+        response = client.post(
+            "/v1/send_command",
+            json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
+
+    def test_viewer_cannot_send_config(self, app, client):
+        token = self._make_token(app, "viewer")
+        response = client.post(
+            "/v1/send_config",
+            json={"host": "192.168.1.1", "config": ["no shutdown"], "username": "u", "password": "p"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
+
+    def test_operator_can_send_command(self, app, client):
+        token = self._make_token(app, "operator")
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v1/send_command",
+            json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202

--- a/tests/unit/test_contexts_resource.py
+++ b/tests/unit/test_contexts_resource.py
@@ -1,9 +1,12 @@
 """Unit tests for GET /v1/contexts endpoint."""
 
+from base64 import b64encode
 from unittest.mock import MagicMock, patch
 
 
 class TestContexts:
+    _auth_header = {"Authorization": f"Basic {b64encode(b'user:pass').decode()}"}
+
     def test_get_contexts(self, client):
         """GET /v1/contexts returns list of configured contexts with worker counts."""
         mock_worker = MagicMock()
@@ -12,7 +15,7 @@ class TestContexts:
         with patch("naas.resources.contexts.Worker.all", return_value=[mock_worker]):
             with patch("naas.resources.contexts.Queue") as mock_queue_cls:
                 mock_queue_cls.return_value.__len__ = lambda self: 3
-                response = client.get("/v1/contexts")
+                response = client.get("/v1/contexts", headers=self._auth_header)
 
         assert response.status_code == 200
         data = response.get_json()


### PR DESCRIPTION
Closes #102 — Phase 2 of security epic #99

## Summary

Enforces the `role` claim already embedded in JWT API keys, per [ADR 0004](docs/adr/0004-role-based-access-control.md).

## Role hierarchy

`admin > operator > viewer`

| Role | Access |
|---|---|
| viewer | GET jobs, contexts, results |
| operator | + send commands/config, cancel/replay jobs |
| admin | + manage API keys |

## Implementation

- `require_role()` decorator in `naas/library/auth.py` (13 lines)
- Applied to all resource methods
- Basic auth users are implicitly admin (no behavior change)
- Calls `has_auth()` automatically for GET endpoints that don't go through `valid_post`

## Testing

- 3 new RBAC tests (viewer blocked, viewer blocked config, operator allowed)
- Updated contexts test for auth requirement
- 305 total tests, 100% coverage