### PR TITLE
feat: add context-based authorization for API keys (#291)

### DIFF
--- a/changes/291.feature.md
+++ b/changes/291.feature.md
@@ -1,0 +1,1 @@
+Add context-based authorization for API key authenticated requests.

--- a/naas/library/decorators.py
+++ b/naas/library/decorators.py
@@ -5,7 +5,7 @@ from functools import wraps
 from uuid import uuid4
 
 from flask import g, request
-from werkzeug.exceptions import UnprocessableEntity
+from werkzeug.exceptions import Forbidden, UnprocessableEntity
 
 from naas.library import validation
 from naas.library.auth import Credentials
@@ -55,6 +55,11 @@ def valid_post(f):
                 password=password,
                 enable=body.get("enable"),
             )
+            # Context authorization: check JWT contexts claim
+            context = body.get("context", "default")
+            allowed = g.jwt_claims.get("contexts", [])
+            if "*" not in allowed and context not in allowed:
+                raise Forbidden(f"API key not authorized for context '{context}'")
         else:
             # Basic auth: device credentials from Authorization header
             g.credentials = Credentials(

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -301,3 +301,69 @@ class TestRBAC:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 202
+
+
+@pytest.mark.usefixtures("_mock_secrets")
+class TestContextAuthz:
+    """Tests for context-based authorization."""
+
+    def _make_token(self, app, contexts):
+        with app.app_context():
+            return create_api_key(role="operator", contexts=contexts)["token"]
+
+    def test_wildcard_allows_any_context(self, app, client):
+        token = self._make_token(app, ["*"])
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.168.1.1",
+                "commands": ["show version"],
+                "username": "u",
+                "password": "p",
+                "context": "anything",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202
+
+    def test_matching_context_allowed(self, app, client):
+        token = self._make_token(app, ["oob-dc1"])
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.168.1.1",
+                "commands": ["show version"],
+                "username": "u",
+                "password": "p",
+                "context": "oob-dc1",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202
+
+    def test_wrong_context_forbidden(self, app, client):
+        token = self._make_token(app, ["oob-dc1"])
+        response = client.post(
+            "/v1/send_command",
+            json={
+                "host": "192.168.1.1",
+                "commands": ["show version"],
+                "username": "u",
+                "password": "p",
+                "context": "prod",
+            },
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 403
+
+    def test_default_context_when_omitted(self, app, client):
+        token = self._make_token(app, ["default"])
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v1/send_command",
+            json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202


### PR DESCRIPTION
Closes #291 — Phase 3 of security epic #99

Enforces the `contexts` claim already embedded in JWT API keys. When a Bearer-authenticated user submits a job, the request's `context` field is checked against the token's allowed contexts list.

- `["*"]` allows all contexts (default for new keys)
- Exact match otherwise — `["oob-dc1", "default"]` only allows those two
- Basic auth users bypass context checks (backward compatible)
- 4 new unit tests, 309 total, 100% coverage

3 files changed, 73 insertions.