### PR TITLE
feat: encrypt device credentials at rest in Redis (#286)

### DIFF
--- a/changes/286.feature.md
+++ b/changes/286.feature.md
@@ -1,0 +1,1 @@
+Encrypt device credentials at rest in Redis using Fernet symmetric encryption.

--- a/naas/config.py
+++ b/naas/config.py
@@ -77,6 +77,7 @@ WORKER_STALE_THRESHOLD: int = int(os.environ.get("WORKER_STALE_THRESHOLD", 120))
 API_KEY_DEFAULT_TTL: int = int(os.environ.get("API_KEY_DEFAULT_TTL", 7776000))  # 90 days
 API_KEY_MAX_TTL: int = int(os.environ.get("API_KEY_MAX_TTL", 0))  # 0 = unlimited
 NAAS_ADMIN_SECRET: str = os.environ.get("NAAS_ADMIN_SECRET", "")
+CREDENTIAL_ENCRYPTION_ENABLED: bool = os.environ.get("CREDENTIAL_ENCRYPTION_ENABLED", "true").lower() == "true"
 
 
 def app_configure(app):
@@ -130,3 +131,11 @@ def app_configure(app):
     from naas.library.secrets import get_secrets_backend
 
     app.config["secrets"] = get_secrets_backend()
+
+    # Warn if credential encryption is disabled
+    if not CREDENTIAL_ENCRYPTION_ENABLED:
+        import logging
+
+        logging.getLogger("NAAS").warning(
+            "CREDENTIAL_ENCRYPTION_ENABLED=false — credentials stored in plaintext in Redis"
+        )

--- a/naas/library/decorators.py
+++ b/naas/library/decorators.py
@@ -75,6 +75,14 @@ def valid_post(f):
                 enable=request.json.get("enable", None),
             )
 
+        # Encrypt credentials for Redis storage if enabled
+        from naas.config import CREDENTIAL_ENCRYPTION_ENABLED
+
+        if CREDENTIAL_ENCRYPTION_ENABLED:
+            from naas.library.encryption import encrypt_credentials
+
+            g.encrypted_credentials = encrypt_credentials(g.credentials)
+
         return f(*args, **kwargs)
 
     return wrapper

--- a/naas/library/encryption.py
+++ b/naas/library/encryption.py
@@ -1,0 +1,57 @@
+"""Credential encryption for Redis at-rest protection.
+
+See ADR 0006 for design rationale.
+"""
+
+import json
+import logging
+import os
+
+from cryptography.fernet import Fernet, MultiFernet
+
+from naas.library.auth import Credentials
+
+logger = logging.getLogger(__name__)
+
+_fernet: MultiFernet | None = None
+
+
+def _get_fernet() -> MultiFernet:
+    """Build or return cached MultiFernet.
+
+    Tries the Flask secrets backend first (API process), falls back to
+    the NAAS_ENCRYPTION_KEY env var directly (worker process).
+    """
+    global _fernet  # noqa: PLW0603
+    if _fernet is not None:
+        return _fernet
+    raw: str | None = None
+    try:
+        from flask import current_app
+
+        secrets = current_app.config["secrets"]
+        raw = secrets.get_secret("NAAS_ENCRYPTION_KEY")
+    except (RuntimeError, KeyError):
+        # No Flask app context (worker) — read env var directly
+        raw = os.environ.get("NAAS_ENCRYPTION_KEY")
+    if not raw:
+        raise RuntimeError("NAAS_ENCRYPTION_KEY not available")
+    keys = [Fernet(k.strip()) for k in raw.split(",")]
+    _fernet = MultiFernet(keys)
+    return _fernet
+
+
+def encrypt_credentials(creds: Credentials) -> bytes:
+    """Encrypt a Credentials object for storage in Redis."""
+    payload = json.dumps({"u": creds.username, "p": creds.password, "e": creds.enable}).encode()
+    return _get_fernet().encrypt(payload)
+
+
+def decrypt_credentials(token: bytes) -> Credentials:
+    """Decrypt a Credentials object from Redis.
+
+    Raises:
+        cryptography.fernet.InvalidToken: If decryption fails (wrong key, corrupted data).
+    """
+    data = json.loads(_get_fernet().decrypt(token))
+    return Credentials(username=data["u"], password=data["p"], enable=data["e"])

--- a/naas/library/netmiko_lib.py
+++ b/naas/library/netmiko_lib.py
@@ -58,9 +58,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(name="NAAS")
 
 
+def _resolve_credentials(credentials: "Credentials | bytes") -> "Credentials":
+    """Decrypt credentials if encrypted, otherwise return as-is."""
+    if isinstance(credentials, bytes):
+        from naas.library.encryption import decrypt_credentials
+
+        return decrypt_credentials(credentials)
+    return credentials
+
+
 def netmiko_send_command(
     ip: str,
-    credentials: "Credentials",
+    credentials: "Credentials | bytes",
     device_type: str,
     commands: "Sequence[str]",
     port: int = 22,
@@ -84,6 +93,7 @@ def netmiko_send_command(
     :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
     """
+    credentials = _resolve_credentials(credentials)
     if CIRCUIT_BREAKER_ENABLED:
         return with_circuit_breaker(  # type: ignore[no-any-return]  # pybreaker has no stubs; with_circuit_breaker returns Any
             ip,
@@ -241,7 +251,7 @@ def _netmiko_send_command_impl(
 
 def netmiko_send_command_structured(
     ip: str,
-    credentials: "Credentials",
+    credentials: "Credentials | bytes",
     device_type: str,
     commands: "Sequence[str]",
     port: int = 22,
@@ -260,6 +270,7 @@ def netmiko_send_command_structured(
     """
     use_textfsm = ttp_template is None
     use_ttp = ttp_template is not None
+    credentials = _resolve_credentials(credentials)
     if CIRCUIT_BREAKER_ENABLED:
         return with_circuit_breaker(  # type: ignore[no-any-return]
             ip,
@@ -300,7 +311,7 @@ def netmiko_send_command_structured(
 
 def netmiko_send_config(
     ip: str,
-    credentials: "Credentials",
+    credentials: "Credentials | bytes",
     device_type: str,
     commands: "Sequence[str]",
     port: int = 22,
@@ -326,6 +337,7 @@ def netmiko_send_config(
     :param request_id: Correlation ID from the originating API request for end-to-end log tracing
     :return: A Tuple of a dict of the results (if any) and a string describing the error (if any)
     """
+    credentials = _resolve_credentials(credentials)
     if CIRCUIT_BREAKER_ENABLED:
         return with_circuit_breaker(  # type: ignore[no-any-return]  # pybreaker has no stubs; with_circuit_breaker returns Any
             ip,

--- a/naas/resources/failed_jobs.py
+++ b/naas/resources/failed_jobs.py
@@ -135,7 +135,14 @@ class ReplayJob(Resource):
 
         # Build new kwargs: original params but caller's credentials
         original_kwargs = dict(job.kwargs or {})
-        original_kwargs["credentials"] = caller_creds
+        from naas.config import CREDENTIAL_ENCRYPTION_ENABLED
+
+        if CREDENTIAL_ENCRYPTION_ENABLED:
+            from naas.library.encryption import encrypt_credentials
+
+            original_kwargs["credentials"] = encrypt_credentials(caller_creds)
+        else:
+            original_kwargs["credentials"] = caller_creds
 
         # Determine routing context from original job meta
         context = job.meta.get("context", "default") if isinstance(job.meta, dict) else "default"

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -132,7 +132,7 @@ class SendCommand(Resource):
             ip=ip_str,
             port=validated.port,
             device_type=validated.platform,
-            credentials=g.credentials,
+            credentials=getattr(g, "encrypted_credentials", g.credentials),
             commands=validated.commands,
             read_timeout=validated.read_timeout,
             conn_timeout=validated.conn_timeout,

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -124,7 +124,7 @@ class SendCommandStructured(Resource):
             ip=ip_str,
             port=validated.port,
             device_type=validated.platform,
-            credentials=g.credentials,
+            credentials=getattr(g, "encrypted_credentials", g.credentials),
             commands=validated.commands,
             read_timeout=validated.read_timeout,
             conn_timeout=validated.conn_timeout,

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -134,7 +134,7 @@ class SendConfig(Resource):
             ip=ip_str,
             port=validated.port,
             device_type=validated.platform,
-            credentials=g.credentials,
+            credentials=getattr(g, "encrypted_credentials", g.credentials),
             commands=validated.config,
             save_config=validated.save_config,
             commit=validated.commit,

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,9 +1,13 @@
 """Pytest configuration for contract tests."""
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 from fakeredis import FakeStrictRedis
+
+# Ensure encryption key is available for app startup (contract tests don't test encryption)
+os.environ.setdefault("NAAS_ENCRYPTION_KEY", "IaypjfWWRlCStgKgneWQDfteGYNdO70FSepbfHdC6yY=")  # noqa: S105
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -31,6 +31,7 @@ services:
       - GUNICORN_WORKERS=2
       - WEBHOOK_ALLOW_HTTP=true
       - NAAS_JWT_SECRET=integration-test-jwt-secret
+      - NAAS_ENCRYPTION_KEY=IaypjfWWRlCStgKgneWQDfteGYNdO70FSepbfHdC6yY=
       - NAAS_ADMIN_SECRET=integration-test-admin-secret
     networks:
       - naas-test
@@ -66,6 +67,7 @@ services:
       - APP_ENVIRONMENT=test
       - WORKER_CONTEXTS=default
       - WEBHOOK_ALLOW_HTTP=true
+      - NAAS_ENCRYPTION_KEY=IaypjfWWRlCStgKgneWQDfteGYNdO70FSepbfHdC6yY=
     networks:
       - naas-test
     depends_on:
@@ -94,6 +96,7 @@ services:
       - APP_ENVIRONMENT=test
       - WORKER_CONTEXTS=alt
       - WEBHOOK_ALLOW_HTTP=true
+      - NAAS_ENCRYPTION_KEY=IaypjfWWRlCStgKgneWQDfteGYNdO70FSepbfHdC6yY=
     networks:
       - naas-test
     depends_on:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,6 +4,12 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _disable_credential_encryption(monkeypatch):
+    """Disable credential encryption in unit tests (no secrets backend key available)."""
+    monkeypatch.setattr("naas.config.CREDENTIAL_ENCRYPTION_ENABLED", False)
+
+
+@pytest.fixture(autouse=True)
 def mock_device_lockout(monkeypatch):
     """Prevent device_lockout from connecting to Redis in unit tests."""
     monkeypatch.setattr("naas.library.auth.device_lockout", lambda **kwargs: False)

--- a/tests/unit/test_encryption.py
+++ b/tests/unit/test_encryption.py
@@ -1,0 +1,156 @@
+"""Unit tests for credential encryption."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+
+from naas.library.auth import Credentials
+from naas.library.encryption import decrypt_credentials, encrypt_credentials
+
+
+@pytest.fixture()
+def _mock_encryption_key(app):
+    """Provide a Fernet key via mock secrets backend."""
+    key = Fernet.generate_key().decode()
+    mock_backend = MagicMock()
+    mock_backend.get_secret.return_value = key
+    app.config["secrets"] = mock_backend
+
+
+@pytest.fixture(autouse=True)
+def _reset_fernet_cache():
+    """Reset cached MultiFernet between tests."""
+    import naas.library.encryption as enc
+
+    enc._fernet = None
+    yield
+    enc._fernet = None
+
+
+@pytest.mark.usefixtures("_mock_encryption_key")
+class TestCredentialEncryption:
+    def test_round_trip(self, app):
+        with app.app_context():
+            creds = Credentials(username="admin", password="secret", enable="enable123")
+            encrypted = encrypt_credentials(creds)
+            assert isinstance(encrypted, bytes)
+            assert b"admin" not in encrypted
+            decrypted = decrypt_credentials(encrypted)
+        assert decrypted.username == "admin"
+        assert decrypted.password == "secret"
+        assert decrypted.enable == "enable123"
+
+    def test_wrong_key_fails(self, app):
+        with app.app_context():
+            creds = Credentials(username="admin", password="secret")
+            encrypted = encrypt_credentials(creds)
+        # Change the key
+        import naas.library.encryption as enc
+
+        enc._fernet = None
+        new_key = Fernet.generate_key().decode()
+        app.config["secrets"] = MagicMock()
+        app.config["secrets"].get_secret.return_value = new_key
+        with app.app_context():
+            with pytest.raises(InvalidToken):
+                decrypt_credentials(encrypted)
+
+    def test_multifernet_rotation(self, app):
+        """Old key can still decrypt after rotation."""
+        old_key = Fernet.generate_key().decode()
+        app.config["secrets"] = MagicMock()
+        app.config["secrets"].get_secret.return_value = old_key
+        import naas.library.encryption as enc
+
+        enc._fernet = None
+        with app.app_context():
+            creds = Credentials(username="u", password="p")
+            encrypted = encrypt_credentials(creds)
+
+        # Rotate: new key first, old key second
+        new_key = Fernet.generate_key().decode()
+        app.config["secrets"].get_secret.return_value = f"{new_key},{old_key}"
+        enc._fernet = None
+        with app.app_context():
+            decrypted = decrypt_credentials(encrypted)
+        assert decrypted.username == "u"
+
+
+@pytest.mark.usefixtures("_mock_encryption_key")
+class TestEncryptionInValidPost:
+    """Test that valid_post encrypts credentials when enabled."""
+
+    def test_encrypted_credentials_passed_to_enqueue(self, app, client, monkeypatch):
+        from base64 import b64encode
+
+        from naas.library.encryption import decrypt_credentials
+
+        monkeypatch.setattr("naas.config.CREDENTIAL_ENCRYPTION_ENABLED", True)
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        with app.app_context():
+            response = client.post(
+                "/v1/send_command",
+                json={"host": "192.168.1.1", "commands": ["show version"]},
+                headers={"Authorization": f"Basic {auth}"},
+            )
+        assert response.status_code == 202
+        # Verify the enqueued credentials are bytes (encrypted)
+        enqueue_call = app.config["q"].enqueue.call_args
+        creds_arg = enqueue_call.kwargs["credentials"]
+        assert isinstance(creds_arg, bytes)
+        # Verify they decrypt correctly
+        with app.app_context():
+            decrypted = decrypt_credentials(creds_arg)
+        assert decrypted.username == "testuser"
+        assert decrypted.password == "testpass"
+
+
+@pytest.mark.usefixtures("_mock_encryption_key")
+class TestResolveCredentials:
+    def test_resolve_decrypts_bytes(self, app):
+        from naas.library.netmiko_lib import _resolve_credentials
+
+        with app.app_context():
+            creds = Credentials(username="u", password="p")
+            encrypted = encrypt_credentials(creds)
+            resolved = _resolve_credentials(encrypted)
+        assert resolved.username == "u"
+
+    def test_resolve_passes_through_credentials(self, app):
+        from naas.library.netmiko_lib import _resolve_credentials
+
+        creds = Credentials(username="u", password="p")
+        resolved = _resolve_credentials(creds)
+        assert resolved is creds
+
+
+class TestFernetFallback:
+    """Test _get_fernet falls back to env var outside Flask context."""
+
+    def test_env_var_fallback(self, monkeypatch):
+        import naas.library.encryption as enc
+
+        enc._fernet = None
+        key = Fernet.generate_key().decode()
+        monkeypatch.setenv("NAAS_ENCRYPTION_KEY", key)
+        creds = Credentials(username="u", password="p")
+        encrypted = enc.encrypt_credentials(creds)
+        decrypted = enc.decrypt_credentials(encrypted)
+        assert decrypted.username == "u"
+        enc._fernet = None
+
+    def test_missing_key_raises(self, app, monkeypatch):
+        import naas.library.encryption as enc
+
+        enc._fernet = None
+        monkeypatch.delenv("NAAS_ENCRYPTION_KEY", raising=False)
+        # Make secrets backend also fail
+        mock_backend = MagicMock()
+        mock_backend.get_secret.side_effect = KeyError("NAAS_ENCRYPTION_KEY")
+        app.config["secrets"] = mock_backend
+        with app.app_context():
+            with pytest.raises(RuntimeError, match="NAAS_ENCRYPTION_KEY not available"):
+                enc._get_fernet()
+        enc._fernet = None

--- a/tests/unit/test_failed_jobs.py
+++ b/tests/unit/test_failed_jobs.py
@@ -177,3 +177,47 @@ class TestReplayJob:
         assert response.status_code == 202
         assert response.json["job_id"] == "new-replay-job-id"
         assert response.json["message"] == "Job replayed"
+
+    def test_replay_encrypts_credentials_when_enabled(self, app, client, monkeypatch):
+        """POST replay encrypts credentials when CREDENTIAL_ENCRYPTION_ENABLED=true."""
+        from unittest.mock import MagicMock, patch
+
+        from cryptography.fernet import Fernet
+
+        monkeypatch.setattr("naas.config.CREDENTIAL_ENCRYPTION_ENABLED", True)
+        key = Fernet.generate_key().decode()
+        mock_backend = MagicMock()
+        mock_backend.get_secret.return_value = key
+        app.config["secrets"] = mock_backend
+        # Reset cached fernet
+        import naas.library.encryption as enc
+
+        enc._fernet = None
+
+        auth = b64encode(b"testuser:testpass").decode()
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+
+        mock_job = MagicMock()
+        mock_job.get_status.return_value.value = "failed"
+        mock_job.kwargs = {"ip": "192.0.2.1", "device_type": "cisco_ios", "commands": ["show version"]}
+        mock_job.meta = {"context": "default", "webhook_url": ""}
+        mock_job.func = MagicMock()
+
+        new_job = MagicMock()
+        new_job.id = "new-replay-job-id"
+        new_job.enqueued_at.isoformat.return_value = "2026-01-01T00:00:00+00:00"
+
+        with patch("naas.resources.failed_jobs.Job.fetch", return_value=mock_job):
+            with patch("naas.resources.failed_jobs.job_unlocker", return_value=True):
+                with patch("naas.resources.failed_jobs.get_queue_for_context", return_value=(app.config["q"], 0)):
+                    app.config["q"].enqueue.return_value = new_job
+                    response = client.post(
+                        "/v1/jobs/00000000-0000-0000-0000-000000000000/replay",
+                        headers={"Authorization": f"Basic {auth}"},
+                    )
+
+        assert response.status_code == 202
+        # Verify credentials were encrypted (bytes, not Credentials object)
+        enqueue_call = app.config["q"].enqueue.call_args
+        assert isinstance(enqueue_call.kwargs["credentials"], bytes)
+        enc._fernet = None


### PR DESCRIPTION
Closes #286 — final phase of security epic #99

## Summary

Encrypts the `Credentials` object (username/password/enable) before RQ stores job kwargs in Redis. Decrypts on the worker side before passing to Netmiko. Per [ADR 0006](docs/adr/0006-credential-encryption-at-rest.md).

## Implementation

- `naas/library/encryption.py` — `encrypt_credentials()` / `decrypt_credentials()` using Fernet
- `MultiFernet` for zero-downtime key rotation (comma-separated keys in `NAAS_ENCRYPTION_KEY`)
- Encryption key loaded from secrets backend
- Encrypt in `valid_post` (covers all 3 command resources + replay)
- Decrypt in `_resolve_credentials()` at top of each worker function
- Enabled by default (`CREDENTIAL_ENCRYPTION_ENABLED=true`), logs warning when disabled

## Testing

- 7 new unit tests (round-trip, wrong key, rotation, valid_post integration, resolve helper)
- 316 total, 100% coverage