### PR TITLE
feat: add AWS Secrets Manager backend (#347)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --extra dev --extra vault
+        run: uv sync --extra dev --extra vault --extra aws
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/changes/347.feature.md
+++ b/changes/347.feature.md
@@ -1,0 +1,1 @@
+Add AWS Secrets Manager as an optional secrets backend.

--- a/naas/library/secrets.py
+++ b/naas/library/secrets.py
@@ -97,6 +97,60 @@ class VaultSecretsBackend:
         return data[name]
 
 
+class AWSSecretsBackend:
+    """Read secrets from AWS Secrets Manager.
+
+    Requires the ``boto3`` package: ``pip install naas[aws]``
+    """
+
+    def __init__(self, secret_name: str, region: str, endpoint_url: str | None = None) -> None:
+        """Initialize AWS Secrets Manager client.
+
+        Args:
+            secret_name: Name of the secret in AWS Secrets Manager.
+            region: AWS region name.
+            endpoint_url: Optional endpoint URL (for LocalStack/testing).
+        """
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("AWSSecretsBackend requires 'boto3'. Install with: pip install naas[aws]") from None
+
+        kwargs: dict = {"region_name": region}
+        if endpoint_url:
+            kwargs["endpoint_url"] = endpoint_url
+        self._client = boto3.client("secretsmanager", **kwargs)
+        self._secret_name = secret_name
+        self._cache: dict[str, str] | None = None
+
+    def _load(self) -> dict[str, str]:
+        """Load and cache the secret value as a JSON dict."""
+        if self._cache is not None:
+            return self._cache
+        import json
+
+        response = self._client.get_secret_value(SecretId=self._secret_name)
+        self._cache = json.loads(response["SecretString"])
+        return self._cache
+
+    def get_secret(self, name: str) -> str:
+        """Retrieve a key from the AWS Secrets Manager secret.
+
+        Args:
+            name: Key within the JSON secret.
+
+        Returns:
+            The secret value.
+
+        Raises:
+            KeyError: If the key is not found.
+        """
+        data = self._load()
+        if name not in data:
+            raise KeyError(f"Secret '{name}' not found in AWS secret '{self._secret_name}'")
+        return data[name]
+
+
 def get_secrets_backend() -> SecretsBackend:
     """Create a secrets backend based on SECRETS_BACKEND config.
 
@@ -121,4 +175,13 @@ def get_secrets_backend() -> SecretsBackend:
         logger.info("Using HashiCorp Vault secrets backend at %s", url)
         return VaultSecretsBackend(url=url, token=token, path=path)
 
-    raise ValueError(f"Unknown SECRETS_BACKEND: '{backend}'. Valid options: env, vault")
+    if backend == "aws":
+        secret_name = os.environ.get("AWS_SECRET_NAME", "")
+        region = os.environ.get("AWS_REGION", "")
+        if not secret_name or not region:
+            raise ValueError("AWSSecretsBackend requires AWS_SECRET_NAME and AWS_REGION environment variables")
+        endpoint_url = os.environ.get("AWS_ENDPOINT_URL", None)
+        logger.info("Using AWS Secrets Manager backend (secret=%s, region=%s)", secret_name, region)
+        return AWSSecretsBackend(secret_name=secret_name, region=region, endpoint_url=endpoint_url)
+
+    raise ValueError(f"Unknown SECRETS_BACKEND: '{backend}'. Valid options: env, vault, aws")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
 vault = [
     "hvac>=2.1.0",
 ]
+aws = [
+    "boto3>=1.34.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/docker-compose.test.yml
+++ b/tests/integration/docker-compose.test.yml
@@ -121,6 +121,21 @@ services:
       retries: 10
       start_period: 5s
 
+  localstack:
+    image: localstack/localstack:3
+    ports:
+      - "14566:4566"
+    environment:
+      - SERVICES=secretsmanager
+    networks:
+      - naas-test
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
+
   cisshgo:
     image: ghcr.io/tbotnz/cisshgo:v0.2.0
     command: ["-listeners", "2", "-startingPort", "10022"]

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -3,7 +3,7 @@
 import pytest
 import requests
 
-from naas.library.secrets import EnvSecretsBackend, VaultSecretsBackend, get_secrets_backend
+from naas.library.secrets import AWSSecretsBackend, EnvSecretsBackend, VaultSecretsBackend, get_secrets_backend
 
 VAULT_ADDR = "http://localhost:18200"
 VAULT_TOKEN = "test-root-token"
@@ -86,3 +86,75 @@ class TestVaultSecretsBackendIntegration:
         """Invalid token raises RuntimeError."""
         with pytest.raises(RuntimeError, match="authentication failed"):
             VaultSecretsBackend(url=VAULT_ADDR, token="bad-token", path=VAULT_SECRETS_PATH)
+
+
+LOCALSTACK_URL = "http://localhost:14566"
+AWS_SECRET_NAME = "naas-integration-test"
+AWS_REGION = "us-east-1"
+
+
+@pytest.fixture(scope="module")
+def aws_seed():
+    """Seed LocalStack Secrets Manager with test secrets."""
+    import boto3
+
+    client = boto3.client(
+        "secretsmanager",
+        endpoint_url=LOCALSTACK_URL,
+        region_name=AWS_REGION,
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+    import json
+
+    client.create_secret(
+        Name=AWS_SECRET_NAME,
+        SecretString=json.dumps({"DB_PASSWORD": "test-db-pass", "API_TOKEN": "test-api-token"}),
+    )
+    yield
+
+
+@pytest.fixture()
+def wait_for_localstack():
+    """Wait for LocalStack to be ready."""
+    import time
+
+    for _ in range(10):
+        try:
+            r = requests.get(f"{LOCALSTACK_URL}/_localstack/health", timeout=2)
+            if r.status_code == 200:
+                return
+        except requests.ConnectionError:
+            time.sleep(1)
+    pytest.fail("LocalStack did not become ready")
+
+
+class TestAWSSecretsBackendIntegration:
+    """Integration tests for AWSSecretsBackend against LocalStack."""
+
+    def test_read_seeded_secret(self, wait_for_localstack, aws_seed, monkeypatch):
+        """Read secrets seeded into LocalStack."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        backend = AWSSecretsBackend(secret_name=AWS_SECRET_NAME, region=AWS_REGION, endpoint_url=LOCALSTACK_URL)
+        assert backend.get_secret("DB_PASSWORD") == "test-db-pass"
+        assert backend.get_secret("API_TOKEN") == "test-api-token"
+
+    def test_missing_key_raises(self, wait_for_localstack, aws_seed, monkeypatch):
+        """Missing key raises KeyError."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        backend = AWSSecretsBackend(secret_name=AWS_SECRET_NAME, region=AWS_REGION, endpoint_url=LOCALSTACK_URL)
+        with pytest.raises(KeyError, match="not found in AWS secret"):
+            backend.get_secret("NONEXISTENT")
+
+    def test_factory_creates_aws_backend(self, wait_for_localstack, aws_seed, monkeypatch):
+        """Factory creates AWSSecretsBackend when configured."""
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "aws")
+        monkeypatch.setenv("AWS_SECRET_NAME", AWS_SECRET_NAME)
+        monkeypatch.setenv("AWS_REGION", AWS_REGION)
+        monkeypatch.setenv("AWS_ENDPOINT_URL", LOCALSTACK_URL)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test")
+        backend = get_secrets_backend()
+        assert isinstance(backend, AWSSecretsBackend)

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from naas.library.secrets import EnvSecretsBackend, VaultSecretsBackend, get_secrets_backend
+from naas.library.secrets import AWSSecretsBackend, EnvSecretsBackend, VaultSecretsBackend, get_secrets_backend
 
 
 class TestEnvSecretsBackend:
@@ -91,4 +91,60 @@ class TestGetSecretsBackend:
     def test_unknown_backend_raises(self, monkeypatch):
         monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "unknown")
         with pytest.raises(ValueError, match="Unknown SECRETS_BACKEND"):
+            get_secrets_backend()
+
+
+class TestAWSSecretsBackend:
+    """Tests for AWSSecretsBackend."""
+
+    def test_init_raises_without_boto3(self):
+        with patch.dict("sys.modules", {"boto3": None}):
+            with pytest.raises(ImportError, match="boto3"):
+                AWSSecretsBackend(secret_name="my-secret", region="us-east-1")
+
+    def test_get_secret_returns_value(self):
+        mock_boto3 = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": '{"MY_KEY": "my_value"}'}
+        mock_boto3.client.return_value = mock_client
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            backend = AWSSecretsBackend(secret_name="my-secret", region="us-east-1")
+            assert backend.get_secret("MY_KEY") == "my_value"
+
+    def test_get_secret_raises_key_error(self):
+        mock_boto3 = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": "{}"}
+        mock_boto3.client.return_value = mock_client
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            backend = AWSSecretsBackend(secret_name="my-secret", region="us-east-1")
+            with pytest.raises(KeyError, match="not found in AWS secret"):
+                backend.get_secret("MISSING")
+
+    def test_caches_secret_value(self):
+        mock_boto3 = MagicMock()
+        mock_client = MagicMock()
+        mock_client.get_secret_value.return_value = {"SecretString": '{"K": "V"}'}
+        mock_boto3.client.return_value = mock_client
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            backend = AWSSecretsBackend(secret_name="my-secret", region="us-east-1")
+            backend.get_secret("K")
+            backend.get_secret("K")
+            mock_client.get_secret_value.assert_called_once()
+
+    def test_factory_creates_aws_backend(self, monkeypatch):
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "aws")
+        monkeypatch.setenv("AWS_SECRET_NAME", "my-secret")
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "http://localhost:4566")
+        mock_boto3 = MagicMock()
+        with patch.dict("sys.modules", {"boto3": mock_boto3}):
+            backend = get_secrets_backend()
+            assert isinstance(backend, AWSSecretsBackend)
+
+    def test_factory_raises_without_config(self, monkeypatch):
+        monkeypatch.setattr("naas.library.secrets.SECRETS_BACKEND", "aws")
+        monkeypatch.delenv("AWS_SECRET_NAME", raising=False)
+        monkeypatch.delenv("AWS_REGION", raising=False)
+        with pytest.raises(ValueError, match="AWS_SECRET_NAME and AWS_REGION"):
             get_secrets_backend()

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.42.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/89/2d647bd717da55a8cc68602b197f53a5fa36fb95a2f9e76c4aff11a9cfd1/boto3-1.42.84.tar.gz", hash = "sha256:6a84b3293a5d8b3adf827a54588e7dcffcf0a85410d7dadca615544f97d27579", size = 112816, upload-time = "2026-04-06T19:39:07.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/31/cdf4326841613d1d181a77b3038a988800fb3373ca50de1639fba9fa87de/boto3-1.42.84-py3-none-any.whl", hash = "sha256:4d03ad3211832484037337292586f71f48707141288d9ac23049c04204f4ab03", size = 140555, upload-time = "2026-04-06T19:39:06.009Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.84"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/b7/1c03423843fb0d1795b686511c00ee63fed1234c2400f469aeedfd42212f/botocore-1.42.84.tar.gz", hash = "sha256:234064604c80d9272a5e9f6b3566d260bcaa053a5e05246db90d7eca1c2cf44b", size = 15148615, upload-time = "2026-04-06T19:38:56.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/37/0c0c90361c8a1b9e6c75222ca24ae12996a298c0e18822a72ab229c37207/botocore-1.42.84-py3-none-any.whl", hash = "sha256:15f3fe07dfa6545e46a60c4b049fe2bdf63803c595ae4a4eec90e8f8172764f3", size = 14827061, upload-time = "2026-04-06T19:38:53.613Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +756,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1124,6 +1161,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+aws = [
+    { name = "boto3" },
+]
 dev = [
     { name = "fakeredis" },
     { name = "ipython" },
@@ -1153,6 +1193,7 @@ dev = [
 requires-dist = [
     { name = "aniso8601", specifier = ">=8.0.0" },
     { name = "bcrypt", specifier = ">=3.1.7" },
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34.0" },
     { name = "cryptography", specifier = ">=2.8" },
     { name = "fakeredis", marker = "extra == 'dev'", specifier = ">=2.21.0" },
     { name = "flask", specifier = ">=1.1.1" },
@@ -1188,7 +1229,7 @@ requires-dist = [
     { name = "ttp", specifier = ">=0.10.0" },
     { name = "ttp-templates", specifier = ">=0.4.0" },
 ]
-provides-extras = ["dev", "vault"]
+provides-extras = ["dev", "vault", "aws"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1831,6 +1872,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
     { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
     { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #347 — adds `AWSSecretsBackend` as a third optional secrets backend.

Configure with:
```bash
SECRETS_BACKEND=aws
AWS_SECRET_NAME=naas/production
AWS_REGION=us-east-1
```

Stores secrets as a JSON object in AWS Secrets Manager, caches after first load. 6 new unit tests, 324 total, 100% coverage.