### PR TITLE
feat: add HMAC-SHA256 signing for webhook payloads (#277)

### DIFF
--- a/changes/277.feature.md
+++ b/changes/277.feature.md
@@ -1,0 +1,1 @@
+Add HMAC-SHA256 signing for webhook payloads via optional webhook_secret field.

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -267,6 +267,19 @@
             "description": "Device username (required for API key auth)",
             "title": "Username"
           },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional shared secret for HMAC-SHA256 webhook payload signing",
+            "title": "Webhook Secret"
+          },
           "webhook_url": {
             "anyOf": [
               {
@@ -419,6 +432,19 @@
             "default": null,
             "description": "Device username (required for API key auth)",
             "title": "Username"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional shared secret for HMAC-SHA256 webhook payload signing",
+            "title": "Webhook Secret"
           },
           "webhook_url": {
             "anyOf": [
@@ -583,6 +609,19 @@
             "default": null,
             "description": "Device username (required for API key auth)",
             "title": "Username"
+          },
+          "webhook_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Optional shared secret for HMAC-SHA256 webhook payload signing",
+            "title": "Webhook Secret"
           },
           "webhook_url": {
             "anyOf": [

--- a/naas/library/callbacks.py
+++ b/naas/library/callbacks.py
@@ -22,6 +22,7 @@ def _fire_webhook_if_configured(job: "Job", status: str) -> None:
     webhook_url = job.meta.get("webhook_url", "") if isinstance(job.meta, dict) else ""
     if not webhook_url:
         return
+    webhook_secret = job.meta.get("webhook_secret", "") if isinstance(job.meta, dict) else ""
     enqueued_at = job.enqueued_at.isoformat() if job.enqueued_at else ""
     fire_webhook(
         url=webhook_url,
@@ -29,6 +30,7 @@ def _fire_webhook_if_configured(job: "Job", status: str) -> None:
         status=status,
         enqueued_at=enqueued_at,
         completed_at=_get_completed_at(),
+        secret=webhook_secret,
     )
 
 

--- a/naas/library/webhook.py
+++ b/naas/library/webhook.py
@@ -4,6 +4,9 @@ Fire-and-forget HTTP POST notification on job completion.
 Payload contains only job metadata — never results or credentials.
 """
 
+import hashlib
+import hmac
+import json
 import logging
 
 import requests
@@ -13,7 +16,12 @@ logger = logging.getLogger(__name__)
 _WEBHOOK_TIMEOUT = 10  # seconds
 
 
-def fire_webhook(url: str, job_id: str, status: str, enqueued_at: str, completed_at: str) -> None:
+def _sign_payload(payload_bytes: bytes, secret: str) -> str:
+    """Compute HMAC-SHA256 signature for webhook payload."""
+    return "sha256=" + hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+
+
+def fire_webhook(url: str, job_id: str, status: str, enqueued_at: str, completed_at: str, secret: str = "") -> None:
     """
     POST a job completion notification to the given URL.
 
@@ -26,6 +34,7 @@ def fire_webhook(url: str, job_id: str, status: str, enqueued_at: str, completed
         status: Job status string (e.g. "finished", "failed")
         enqueued_at: ISO 8601 enqueue timestamp
         completed_at: ISO 8601 completion timestamp
+        secret: Optional shared secret for HMAC-SHA256 signing
     """
     payload = {
         "job_id": job_id,
@@ -33,8 +42,12 @@ def fire_webhook(url: str, job_id: str, status: str, enqueued_at: str, completed
         "enqueued_at": enqueued_at,
         "completed_at": completed_at,
     }
+    headers: dict[str, str] = {"X-NAAS-Delivery": job_id}
+    if secret:
+        payload_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+        headers["X-NAAS-Signature"] = _sign_payload(payload_bytes, secret)
     try:
-        response = requests.post(url, json=payload, timeout=_WEBHOOK_TIMEOUT)
+        response = requests.post(url, json=payload, headers=headers, timeout=_WEBHOOK_TIMEOUT)
         response.raise_for_status()
         logger.info("Webhook delivered: job_id=%s url=%s status=%d", job_id, url, response.status_code)
     except Exception as e:

--- a/naas/models.py
+++ b/naas/models.py
@@ -76,6 +76,10 @@ class _BaseCommandRequest(BaseModel):
         default=None,
         description="Optional HTTPS URL to POST a job completion notification to (never includes results)",
     )
+    webhook_secret: str | None = Field(
+        default=None,
+        description="Optional shared secret for HMAC-SHA256 webhook payload signing",
+    )
     username: str | None = Field(default=None, description="Device username (required for API key auth)")
     password: str | None = Field(default=None, description="Device password (required for API key auth)")
     enable: str | None = Field(default=None, description="Enable password (optional, defaults to password)")
@@ -190,6 +194,10 @@ class SendConfigRequest(BaseModel):
     webhook_url: str | None = Field(
         default=None,
         description="Optional HTTPS URL to POST a job completion notification to (never includes results)",
+    )
+    webhook_secret: str | None = Field(
+        default=None,
+        description="Optional shared secret for HMAC-SHA256 webhook payload signing",
     )
     username: str | None = Field(default=None, description="Device username (required for API key auth)")
     password: str | None = Field(default=None, description="Device password (required for API key auth)")

--- a/naas/resources/failed_jobs.py
+++ b/naas/resources/failed_jobs.py
@@ -156,7 +156,10 @@ class ReplayJob(Resource):
             failure_ttl=JOB_TTL_FAILED,
             on_success=Callback(on_job_complete),
             on_failure=Callback(on_job_failure),
-            meta={"webhook_url": job.meta.get("webhook_url", "") if isinstance(job.meta, dict) else ""},
+            meta={
+                "webhook_url": job.meta.get("webhook_url", "") if isinstance(job.meta, dict) else "",
+                "webhook_secret": job.meta.get("webhook_secret", "") if isinstance(job.meta, dict) else "",
+            },
         )
 
         job_locker(salted_creds=caller_creds.salted_hash(), job=new_job)

--- a/naas/resources/send_command.py
+++ b/naas/resources/send_command.py
@@ -144,7 +144,11 @@ class SendCommand(Resource):
             failure_ttl=JOB_TTL_FAILED,
             on_success=Callback(on_job_complete),
             on_failure=Callback(on_job_failure),
-            meta={"webhook_url": validated.webhook_url or "", "context": validated.context},
+            meta={
+                "webhook_url": validated.webhook_url or "",
+                "webhook_secret": validated.webhook_secret or "",
+                "context": validated.context,
+            },
         )
         job_id = job.id
         current_app.logger.info("%s: Enqueued job for %s@%s:%s", job_id, g.credentials.username, ip_str, validated.port)

--- a/naas/resources/send_command_structured.py
+++ b/naas/resources/send_command_structured.py
@@ -137,7 +137,11 @@ class SendCommandStructured(Resource):
             failure_ttl=JOB_TTL_FAILED,
             on_success=Callback(on_job_complete),
             on_failure=Callback(on_job_failure),
-            meta={"webhook_url": validated.webhook_url or "", "context": validated.context},
+            meta={
+                "webhook_url": validated.webhook_url or "",
+                "webhook_secret": validated.webhook_secret or "",
+                "context": validated.context,
+            },
         )
         job_id = job.id
         current_app.logger.info(

--- a/naas/resources/send_config.py
+++ b/naas/resources/send_config.py
@@ -147,7 +147,11 @@ class SendConfig(Resource):
             failure_ttl=JOB_TTL_FAILED,
             on_success=Callback(on_job_complete),
             on_failure=Callback(on_job_failure),
-            meta={"webhook_url": validated.webhook_url or "", "context": validated.context},
+            meta={
+                "webhook_url": validated.webhook_url or "",
+                "webhook_secret": validated.webhook_secret or "",
+                "context": validated.context,
+            },
         )
         job_id = job.id
         current_app.logger.info("%s: Enqueued job for %s@%s:%s", job_id, g.credentials.username, ip_str, validated.port)

--- a/tests/unit/test_webhook.py
+++ b/tests/unit/test_webhook.py
@@ -1,8 +1,11 @@
 """Unit tests for naas.library.webhook."""
 
+import hashlib
+import hmac
+import json
 from unittest.mock import MagicMock, patch
 
-from naas.library.webhook import fire_webhook
+from naas.library.webhook import _sign_payload, fire_webhook
 
 
 class TestFireWebhook:
@@ -20,16 +23,11 @@ class TestFireWebhook:
                 completed_at="2026-01-01T00:00:05+00:00",
             )
 
-        mock_post.assert_called_once_with(
-            "https://example.com/callback",
-            json={
-                "job_id": "abc-123",
-                "status": "finished",
-                "enqueued_at": "2026-01-01T00:00:00+00:00",
-                "completed_at": "2026-01-01T00:00:05+00:00",
-            },
-            timeout=10,
-        )
+        mock_post.assert_called_once()
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"]["job_id"] == "abc-123"
+        assert kwargs["headers"]["X-NAAS-Delivery"] == "abc-123"
+        assert "X-NAAS-Signature" not in kwargs["headers"]
 
     def test_swallows_connection_error(self):
         """fire_webhook does not raise on connection failure (fire-and-forget)."""
@@ -55,3 +53,55 @@ class TestFireWebhook:
                 enqueued_at="",
                 completed_at="",
             )  # must not raise
+
+
+class TestWebhookHMAC:
+    def test_sign_payload(self):
+        """_sign_payload returns sha256=<hex> format."""
+        sig = _sign_payload(b'{"key":"value"}', "my-secret")
+        assert sig.startswith("sha256=")
+        expected = hmac.new(b"my-secret", b'{"key":"value"}', hashlib.sha256).hexdigest()
+        assert sig == f"sha256={expected}"
+
+    def test_fire_webhook_includes_signature_when_secret_provided(self):
+        """fire_webhook adds X-NAAS-Signature header when secret is set."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        with patch("naas.library.webhook.requests.post", return_value=mock_response) as mock_post:
+            fire_webhook(
+                url="https://example.com/callback",
+                job_id="abc-123",
+                status="finished",
+                enqueued_at="2026-01-01T00:00:00+00:00",
+                completed_at="2026-01-01T00:00:05+00:00",
+                secret="my-secret",
+            )
+
+        _, kwargs = mock_post.call_args
+        assert "X-NAAS-Signature" in kwargs["headers"]
+        assert kwargs["headers"]["X-NAAS-Signature"].startswith("sha256=")
+
+    def test_signature_is_verifiable(self):
+        """Signature can be verified by the receiver using the same secret."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        secret = "test-webhook-secret"
+
+        with patch("naas.library.webhook.requests.post", return_value=mock_response) as mock_post:
+            fire_webhook(
+                url="https://example.com/callback",
+                job_id="abc-123",
+                status="finished",
+                enqueued_at="2026-01-01T00:00:00+00:00",
+                completed_at="2026-01-01T00:00:05+00:00",
+                secret=secret,
+            )
+
+        _, kwargs = mock_post.call_args
+        payload = kwargs["json"]
+        sig_header = kwargs["headers"]["X-NAAS-Signature"]
+        # Receiver verification
+        payload_bytes = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+        expected = "sha256=" + hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+        assert hmac.compare_digest(sig_header, expected)


### PR DESCRIPTION
Closes #277

Adds optional `webhook_secret` field to all request models. When provided, the webhook POST includes:
- `X-NAAS-Signature: sha256=<hmac-hex-digest>` (computed over canonical JSON)
- `X-NAAS-Delivery: <job_id>`

Same pattern as GitHub webhooks. Unsigned webhooks continue to work. 330 tests, 100% coverage.