### PR TITLE
feat: restore /v1/ backward compat, register /v2/ routes (#356, #357)

### DIFF
--- a/changes/356.feature.md
+++ b/changes/356.feature.md
@@ -1,0 +1,1 @@
+Restore /v1/ backward compatibility (accept ip/device_type, skip RBAC/context auth).

--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -173,6 +173,19 @@
             "title": "Context",
             "type": "string"
           },
+          "device_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecated: use platform instead (v1 compat)",
+            "title": "Device Type"
+          },
           "enable": {
             "anyOf": [
               {
@@ -200,9 +213,30 @@
             "title": "Expect String"
           },
           "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Device IP address or hostname",
-            "title": "Host",
-            "type": "string"
+            "title": "Host"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecated: use host instead (v1 compat)",
+            "title": "Ip"
           },
           "password": {
             "anyOf": [
@@ -295,7 +329,6 @@
           }
         },
         "required": [
-          "host",
           "commands"
         ],
         "title": "SendCommandRequest",
@@ -326,6 +359,19 @@
             "title": "Context",
             "type": "string"
           },
+          "device_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecated: use platform instead (v1 compat)",
+            "title": "Device Type"
+          },
           "enable": {
             "anyOf": [
               {
@@ -340,9 +386,30 @@
             "title": "Enable"
           },
           "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Device IP address or hostname",
-            "title": "Host",
-            "type": "string"
+            "title": "Host"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecated: use host instead (v1 compat)",
+            "title": "Ip"
           },
           "password": {
             "anyOf": [
@@ -461,7 +528,6 @@
           }
         },
         "required": [
-          "host",
           "commands"
         ],
         "title": "SendCommandStructuredRequest",
@@ -523,6 +589,19 @@
             "title": "Context",
             "type": "string"
           },
+          "device_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecated: use platform instead (v1 compat)",
+            "title": "Device Type"
+          },
           "enable": {
             "anyOf": [
               {
@@ -537,9 +616,30 @@
             "title": "Enable"
           },
           "host": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
             "description": "Device IP address or hostname",
-            "title": "Host",
-            "type": "string"
+            "title": "Host"
+          },
+          "ip": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Deprecated: use host instead (v1 compat)",
+            "title": "Ip"
           },
           "password": {
             "anyOf": [
@@ -637,9 +737,6 @@
             "title": "Webhook Url"
           }
         },
-        "required": [
-          "host"
-        ],
         "title": "SendConfigRequest",
         "type": "object"
       },
@@ -1292,6 +1389,431 @@
       "get": {
         "description": "",
         "operationId": "get__v1_send_config_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Given the requested job_id, return status and/or any results if finished. :param job_id: :return: A dict of job status and/or results if finished.",
+        "tags": []
+      }
+    },
+    "/v2/api-keys": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_api-keys",
+        "parameters": [],
+        "responses": {},
+        "summary": "List all active API keys (metadata only, not tokens).",
+        "tags": []
+      },
+      "post": {
+        "description": "",
+        "operationId": "post__v2_api-keys",
+        "parameters": [],
+        "responses": {},
+        "summary": "Create a new API key. Returns the JWT token once.",
+        "tags": []
+      }
+    },
+    "/v2/api-keys/{key_id}": {
+      "delete": {
+        "description": "",
+        "operationId": "delete__v2_api-keys_{key_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Revoke an API key.",
+        "tags": []
+      }
+    },
+    "/v2/api-keys/{key_id}/rotate": {
+      "post": {
+        "description": "",
+        "operationId": "post__v2_api-keys_{key_id}_rotate",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "key_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Rotate an API key. Returns a new token, revokes the old key.",
+        "tags": []
+      }
+    },
+    "/v2/contexts": {
+      "get": {
+        "description": ":return: ContextsResponse with per-context status",
+        "operationId": "get__v2_contexts",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContextsResponse.c5eb086"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "summary": "List all configured contexts with active worker counts and queue depths.",
+        "tags": []
+      }
+    },
+    "/v2/jobs": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_jobs",
+        "parameters": [
+          {
+            "description": "",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "minimum": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Per Page",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "finished",
+                    "failed",
+                    "started",
+                    "queued"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "title": "Status"
+            }
+          },
+          {
+            "description": "Filter by tag in 'key:value' format",
+            "in": "query",
+            "name": "tag",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null,
+              "description": "Filter by tag in 'key:value' format",
+              "title": "Tag"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "List jobs with pagination and filtering. Query parameters: - page: Page number (default: 1) - per_page: Results per page (default: 20, max: 100) - status: Filter by status (finished, failed, started, queued) :return: Dict with jobs list and pagination info",
+        "tags": []
+      }
+    },
+    "/v2/jobs/failed": {
+      "get": {
+        "description": "Returns:     200: {\"jobs\": [...], \"total\": int}     401: Unauthorized",
+        "operationId": "get__v2_jobs_failed",
+        "parameters": [],
+        "responses": {},
+        "summary": "List jobs in the failed (dead letter) registry.",
+        "tags": []
+      }
+    },
+    "/v2/jobs/{job_id}": {
+      "delete": {
+        "description": "Returns:     Empty response with 204 status on success.     400 if job_id is not a valid UUID.     403 if credentials do not match the job submitter.     404 if job not found.     409 if job already finished or failed.",
+        "operationId": "delete__v2_jobs_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Args:     job_id: UUID of the job to cancel.",
+        "tags": []
+      }
+    },
+    "/v2/jobs/{job_id}/replay": {
+      "post": {
+        "description": "The stored credentials are never used \u2014 the caller's Basic Auth credentials are substituted instead.\n\nArgs:     job_id: UUID of the failed job to replay.\n\nReturns:     202: JobResponse (new job enqueued)     401: Unauthorized     403: Caller credentials don't match original job submitter     404: Job not found in failed registry     409: Job is not in failed state",
+        "operationId": "post__v2_jobs_{job_id}_replay",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Re-enqueue a failed job using the caller's current credentials.",
+        "tags": []
+      }
+    },
+    "/v2/send-command": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_send-command",
+        "parameters": [],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "Requires you submit the following in the payload:     ip: str     commands: Sequence[str] Optional:     port: int - Default 22     platform: str - Default cisco_ios     enable: Optional[str] - Default the password provided for basic auth\n\nSecured by Basic Auth, which is then passed to the network device. :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header",
+        "operationId": "post__v2_send-command",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendCommandRequest.c5eb086"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse.c5eb086"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "summary": "Will enqueue an attempt to run commands on a device.",
+        "tags": []
+      }
+    },
+    "/v2/send-command-structured": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_send-command-structured",
+        "parameters": [],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "Returns parsed list[dict] per command (or raw string if no template found). Uses ntc-templates by default, or custom template if provided.\n\nRequires:     ip: str     commands: Sequence[str] Optional:     port: int - Default 22     platform: str - Default cisco_ios (use \"autodetect\" for SSHDetect)     read_timeout: float - Default 30.0 seconds     textfsm_template: str - Custom TextFSM template (uses ntc-templates if omitted)\n\nSecured by Basic Auth, which is then passed to the network device. :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header",
+        "operationId": "post__v2_send-command-structured",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendCommandStructuredRequest.c5eb086"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse.c5eb086"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "summary": "Enqueue a send_command job with TextFSM parsing for structured output.",
+        "tags": []
+      }
+    },
+    "/v2/send-command-structured/{job_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_send-command-structured_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Given the requested job_id, return status and/or any results if finished. :param job_id: :return: A dict of job status and/or results if finished.",
+        "tags": []
+      }
+    },
+    "/v2/send-command/{job_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_send-command_{job_id}",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Given the requested job_id, return status and/or any results if finished. :param job_id: :return: A dict of job status and/or results if finished.",
+        "tags": []
+      }
+    },
+    "/v2/send-config": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_send-config",
+        "parameters": [],
+        "responses": {},
+        "summary": "get <GET>",
+        "tags": []
+      },
+      "post": {
+        "description": "Requires you submit the following in the payload:     ip: str     commands: Sequence[str] Optional:     port: int - Default 22     platform: str - Default cisco_ios     enable: Optional[str] - Default the password provided for basic auth     save_config: bool     commit: bool\n\nSecured by Basic Auth, which is then passed to the network device. :return: A dict of the job ID, a 202 response code, and the job_id as the X-Request-ID header",
+        "operationId": "post__v2_send-config",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendConfigRequest.c5eb086"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobResponse.c5eb086"
+                }
+              }
+            },
+            "description": "Accepted"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationError.6a07bef"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "summary": "Will enqueue an attempt to use netmiko's send_config_set() method to run commands/put configuration on a device.",
+        "tags": []
+      }
+    },
+    "/v2/send-config/{job_id}": {
+      "get": {
+        "description": "",
+        "operationId": "get__v2_send-config_{job_id}",
         "parameters": [
           {
             "description": "",

--- a/naas/app.py
+++ b/naas/app.py
@@ -110,6 +110,26 @@ api.add_resource(ApiKeys, "/v1/api-keys")
 api.add_resource(ApiKey, "/v1/api-keys/<string:key_id>")
 api.add_resource(ApiKeyRotate, "/v1/api-keys/<string:key_id>/rotate")
 
+# v2 routes (hyphenated, RBAC/context auth enforced)
+api.add_resource(SendCommand, "/v2/send-command", endpoint="send_command_v2")
+api.add_resource(SendCommandStructured, "/v2/send-command-structured", endpoint="send_command_structured_v2")
+api.add_resource(SendConfig, "/v2/send-config", endpoint="send_config_v2")
+api.add_resource(
+    GetResults,
+    "/v2/send-command/<string:job_id>",
+    "/v2/send-config/<string:job_id>",
+    "/v2/send-command-structured/<string:job_id>",
+    endpoint="get_results_v2",
+)
+api.add_resource(ListJobs, "/v2/jobs", endpoint="list_jobs_v2")
+api.add_resource(FailedJobs, "/v2/jobs/failed", endpoint="failed_jobs_v2")
+api.add_resource(CancelJob, "/v2/jobs/<string:job_id>", endpoint="cancel_job_v2")
+api.add_resource(ReplayJob, "/v2/jobs/<string:job_id>/replay", endpoint="replay_job_v2")
+api.add_resource(Contexts, "/v2/contexts", endpoint="contexts_v2")
+api.add_resource(ApiKeys, "/v2/api-keys", endpoint="api_keys_v2")
+api.add_resource(ApiKey, "/v2/api-keys/<string:key_id>", endpoint="api_key_v2")
+api.add_resource(ApiKeyRotate, "/v2/api-keys/<string:key_id>/rotate", endpoint="api_key_rotate_v2")
+
 # Legacy unversioned routes (deprecated aliases — kept for backward compatibility)
 _LEGACY_PREFIXES = ("/send_command", "/send_config")
 

--- a/naas/library/auth.py
+++ b/naas/library/auth.py
@@ -138,6 +138,7 @@ def require_role(minimum_role: str):
 
     Basic auth users are implicitly admin (backward compatibility).
     Calls has_auth() if auth has not yet been established on this request.
+    RBAC is only enforced on /v2/ routes.
     """
 
     def decorator(f):
@@ -145,10 +146,15 @@ def require_role(minimum_role: str):
         def wrapper(*args, **kwargs):
             from flask import g
 
+            from naas.library.versioning import is_v2_request
+
             if not hasattr(g, "auth_method"):
                 from naas.library.validation import Validate
 
                 Validate.has_auth()
+            # Skip RBAC on non-v2 routes
+            if not is_v2_request():
+                return f(*args, **kwargs)
             if getattr(g, "auth_method", "basic") == "basic":
                 return f(*args, **kwargs)
             user_role = g.jwt_claims.get("role", "viewer")

--- a/naas/library/decorators.py
+++ b/naas/library/decorators.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import Forbidden, UnprocessableEntity
 from naas.library import validation
 from naas.library.audit import emit_audit_event
 from naas.library.auth import Credentials
+from naas.library.versioning import is_v2_request
 
 
 def valid_post(f):
@@ -32,6 +33,14 @@ def valid_post(f):
         v.has_auth()
         v.locked_out()
         v.is_json()
+
+        # Reject deprecated fields on v2 routes
+        if is_v2_request():
+            body = request.json
+            if "ip" in body:
+                raise UnprocessableEntity("'ip' field is not accepted on /v2/ routes. Use 'host' instead.")
+            if "device_type" in body:
+                raise UnprocessableEntity("'device_type' field is not accepted on /v2/ routes. Use 'platform' instead.")
 
         # Capture or create the x-request-id, and store it on the g object
         if "x-request-id" not in v.headers.keys():
@@ -56,17 +65,18 @@ def valid_post(f):
                 password=password,
                 enable=body.get("enable"),
             )
-            # Context authorization: check JWT contexts claim
-            context = body.get("context", "default")
-            allowed = g.jwt_claims.get("contexts", [])
-            if "*" not in allowed and context not in allowed:
-                emit_audit_event(
-                    "auth.context_denied",
-                    identity=g.jwt_claims["sub"],
-                    context=context,
-                    allowed_contexts=",".join(allowed),
-                )
-                raise Forbidden(f"API key not authorized for context '{context}'")
+            # Context authorization: check JWT contexts claim (v2 only)
+            if is_v2_request():
+                context = body.get("context", "default")
+                allowed = g.jwt_claims.get("contexts", [])
+                if "*" not in allowed and context not in allowed:
+                    emit_audit_event(
+                        "auth.context_denied",
+                        identity=g.jwt_claims["sub"],
+                        context=context,
+                        allowed_contexts=",".join(allowed),
+                    )
+                    raise Forbidden(f"API key not authorized for context '{context}'")
         else:
             # Basic auth: device credentials from Authorization header
             g.credentials = Credentials(

--- a/naas/library/versioning.py
+++ b/naas/library/versioning.py
@@ -1,0 +1,8 @@
+"""API version detection helpers."""
+
+from flask import request
+
+
+def is_v2_request() -> bool:
+    """Return True if the current request targets a /v2/ route."""
+    return bool(request.path.startswith("/v2/"))

--- a/naas/models.py
+++ b/naas/models.py
@@ -58,10 +58,12 @@ class _BaseCommandRequest(BaseModel):
 
     model_config = {"strict": True}
 
-    host: str = Field(..., description="Device IP address or hostname")
+    host: str | None = Field(default=None, description="Device IP address or hostname")
+    ip: str | None = Field(default=None, description="Deprecated: use host instead (v1 compat)")
     commands: list[str] = Field(..., min_length=1, description="Commands to execute")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
+    device_type: str | None = Field(default=None, description="Deprecated: use platform instead (v1 compat)")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
     conn_timeout: float = Field(default=10.0, ge=1.0, description="TCP connection timeout in seconds")
     context: str = Field(
@@ -98,15 +100,15 @@ class _BaseCommandRequest(BaseModel):
 
     @field_validator("host")
     @classmethod
-    def validate_host(cls, v: str) -> str:
+    def validate_host(cls, v: str | None) -> str | None:
         """Validate host is a valid IP address or hostname."""
-        # Try IP first
+        if v is None:
+            return v  # pragma: no cover
         try:
             ip_address(v)
             return v
         except Exception:
             pass
-        # Try hostname
         if len(v) <= 253 and _HOSTNAME_RE.match(v):
             return v
         raise ValueError(f"'{v}' is not a valid IP address or hostname")
@@ -126,6 +128,23 @@ class _BaseCommandRequest(BaseModel):
         if v not in netmiko_platforms:
             raise ValueError(f"Invalid platform '{v}'. Must be a valid Netmiko device type.")
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_deprecated_fields(cls, data: Any) -> Any:
+        """Map deprecated v1 fields: ip → host, device_type → platform."""
+        if isinstance(data, dict):
+            if "ip" in data and data["ip"] is not None:
+                data.setdefault("host", data.pop("ip"))
+            else:
+                data.pop("ip", None)
+            if "device_type" in data and data["device_type"] is not None:
+                data["platform"] = data.pop("device_type")
+            else:
+                data.pop("device_type", None)
+            if not data.get("host"):
+                raise ValueError("host (or ip for v1) is required")
+        return data
 
 
 class SendCommandRequest(_BaseCommandRequest):
@@ -177,11 +196,13 @@ class SendConfigRequest(BaseModel):
 
     model_config = {"strict": True}
 
-    host: str = Field(..., description="Device IP address or hostname")
+    host: str | None = Field(default=None, description="Device IP address or hostname")
+    ip: str | None = Field(default=None, description="Deprecated: use host instead (v1 compat)")
     config: list[str] | None = Field(default=None, min_length=1, description="Configuration commands")
     commands: list[str] | None = Field(default=None, min_length=1, description="Configuration commands (alias)")
     port: int = Field(default=22, ge=1, le=65535, description="SSH port")
     platform: str = Field(default="cisco_ios", description="Netmiko device type (use 'autodetect' for SSHDetect)")
+    device_type: str | None = Field(default=None, description="Deprecated: use platform instead (v1 compat)")
     read_timeout: float = Field(default=30.0, ge=1.0, description="Read timeout in seconds for device responses")
     conn_timeout: float = Field(default=10.0, ge=1.0, description="TCP connection timeout in seconds")
     save_config: bool = Field(default=False, description="Save configuration after applying")
@@ -217,8 +238,10 @@ class SendConfigRequest(BaseModel):
 
     @field_validator("host")
     @classmethod
-    def validate_host(cls, v: str) -> str:
+    def validate_host(cls, v: str | None) -> str | None:
         """Validate host is a valid IP address or hostname."""
+        if v is None:
+            return v  # pragma: no cover
         try:
             ip_address(v)
             return v
@@ -243,6 +266,23 @@ class SendConfigRequest(BaseModel):
         if v not in netmiko_platforms:
             raise ValueError(f"Invalid platform '{v}'. Must be a valid Netmiko device type.")
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def resolve_deprecated_fields(cls, data: Any) -> Any:
+        """Map deprecated v1 fields: ip → host, device_type → platform."""
+        if isinstance(data, dict):
+            if "ip" in data and data["ip"] is not None:
+                data.setdefault("host", data.pop("ip"))
+            else:
+                data.pop("ip", None)
+            if "device_type" in data and data["device_type"] is not None:
+                data["platform"] = data.pop("device_type")
+            else:
+                data.pop("device_type", None)
+            if not data.get("host"):
+                raise ValueError("host (or ip for v1) is required")
+        return data
 
     @model_validator(mode="after")
     def resolve_config(self) -> "SendConfigRequest":

--- a/tests/unit/test_api_keys.py
+++ b/tests/unit/test_api_keys.py
@@ -303,7 +303,7 @@ class TestRBAC:
     def test_viewer_cannot_send_command(self, app, client):
         token = self._make_token(app, "viewer")
         response = client.post(
-            "/v1/send_command",
+            "/v2/send-command",
             json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -312,7 +312,7 @@ class TestRBAC:
     def test_viewer_cannot_send_config(self, app, client):
         token = self._make_token(app, "viewer")
         response = client.post(
-            "/v1/send_config",
+            "/v2/send-config",
             json={"host": "192.168.1.1", "config": ["no shutdown"], "username": "u", "password": "p"},
             headers={"Authorization": f"Bearer {token}"},
         )
@@ -325,6 +325,35 @@ class TestRBAC:
             "/v1/send_command",
             json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
             headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202
+
+    def test_v1_viewer_bypasses_rbac(self, app, client):
+        token = self._make_token(app, "viewer")
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v1/send_command",
+            json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202
+
+    def test_v2_operator_passes_rbac(self, app, client):
+        token = self._make_token(app, "operator")
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v2/send-command",
+            json={"host": "192.168.1.1", "commands": ["show version"], "username": "u", "password": "p"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 202
+
+    def test_v2_basic_auth_passes_rbac(self, app, client):
+        app.config["redis"].set("naas_cred_salt", b"test-salt")
+        response = client.post(
+            "/v2/send-command",
+            json={"host": "192.168.1.1", "commands": ["show version"]},
+            headers={"Authorization": "Basic dGVzdDp0ZXN0"},
         )
         assert response.status_code == 202
 
@@ -372,7 +401,7 @@ class TestContextAuthz:
     def test_wrong_context_forbidden(self, app, client):
         token = self._make_token(app, ["oob-dc1"])
         response = client.post(
-            "/v1/send_command",
+            "/v2/send-command",
             json={
                 "host": "192.168.1.1",
                 "commands": ["show version"],
@@ -393,3 +422,27 @@ class TestContextAuthz:
             headers={"Authorization": f"Bearer {token}"},
         )
         assert response.status_code == 202
+
+
+class TestV2RejectsDeprecatedFields:
+    """Tests that /v2/ routes reject ip and device_type fields."""
+
+    def test_v2_rejects_ip_field(self, app, client):
+        with app.app_context():
+            response = client.post(
+                "/v2/send-command",
+                json={"ip": "192.168.1.1", "commands": ["show version"]},
+                headers={"Authorization": "Basic dGVzdDp0ZXN0"},
+            )
+        assert response.status_code == 422
+        assert "ip" in response.json["message"].lower()
+
+    def test_v2_rejects_device_type_field(self, app, client):
+        with app.app_context():
+            response = client.post(
+                "/v2/send-command",
+                json={"host": "192.168.1.1", "commands": ["show version"], "device_type": "cisco_nxos"},
+                headers={"Authorization": "Basic dGVzdDp0ZXN0"},
+            )
+        assert response.status_code == 422
+        assert "device_type" in response.json["message"].lower()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -117,3 +117,43 @@ class TestWebhookUrlValidation:
         """SendConfigRequest also validates webhook_url."""
         req = SendConfigRequest(host="192.0.2.1", commands=["interface Gi0/1"], webhook_url="https://example.com/cb")
         assert req.webhook_url == "https://example.com/cb"
+
+
+class TestV1DeprecatedFields:
+    """Tests for v1 backward-compatible ip/device_type field resolution."""
+
+    def test_ip_mapped_to_host(self):
+        req = SendCommandRequest.model_validate({"ip": "192.168.1.1", "commands": ["show version"]})
+        assert req.host == "192.168.1.1"
+
+    def test_device_type_mapped_to_platform(self):
+        req = SendCommandRequest.model_validate(
+            {"host": "192.168.1.1", "commands": ["show version"], "device_type": "cisco_nxos"}
+        )
+        assert req.platform == "cisco_nxos"
+
+    def test_host_takes_precedence_over_ip(self):
+        req = SendCommandRequest.model_validate({"host": "10.0.0.1", "ip": "192.168.1.1", "commands": ["show version"]})
+        assert req.host == "10.0.0.1"
+
+    def test_missing_host_and_ip_raises(self):
+        with pytest.raises(ValidationError, match="host"):
+            SendCommandRequest.model_validate({"commands": ["show version"]})
+
+    def test_send_config_ip_mapped(self):
+        req = SendConfigRequest.model_validate({"ip": "192.168.1.1", "config": ["no shutdown"]})
+        assert req.host == "192.168.1.1"
+
+    def test_send_config_device_type_mapped(self):
+        req = SendConfigRequest.model_validate(
+            {"host": "192.168.1.1", "config": ["no shutdown"], "device_type": "cisco_nxos"}
+        )
+        assert req.platform == "cisco_nxos"
+
+    def test_send_config_missing_host_and_ip_raises(self):
+        with pytest.raises(ValidationError, match="host"):
+            SendConfigRequest.model_validate({"config": ["no shutdown"]})
+
+
+class TestV1RBACSkip:
+    """Test that RBAC is skipped on /v1/ routes."""


### PR DESCRIPTION
Closes #356, closes #357

Restores the v1 API contract and introduces /v2/ routes:

**v1 (restored):** accepts `ip`/`device_type`, no RBAC, no context auth, underscore delimiters
**v2 (new):** `host`/`platform` only, RBAC enforced, context auth enforced, hyphenated delimiters

Both versions share the same resource classes — behavior is controlled by `is_v2_request()` checks in decorators. 343 tests, 100% coverage.