### PR TITLE
feat: add deprecation headers to /v1/ and legacy responses (#358)

### DIFF
--- a/changes/358.deprecation.md
+++ b/changes/358.deprecation.md
@@ -1,0 +1,1 @@
+Add deprecation headers to /v1/ and legacy unversioned route responses.

--- a/naas/app.py
+++ b/naas/app.py
@@ -131,16 +131,21 @@ api.add_resource(ApiKey, "/v2/api-keys/<string:key_id>", endpoint="api_key_v2")
 api.add_resource(ApiKeyRotate, "/v2/api-keys/<string:key_id>/rotate", endpoint="api_key_rotate_v2")
 
 # Legacy unversioned routes (deprecated aliases — kept for backward compatibility)
-_LEGACY_PREFIXES = ("/send_command", "/send_config")
+_DEPRECATED_PREFIXES = ("/v1/", "/send_command", "/send_config", "/healthcheck")
 
 
 @app.after_request
 def add_version_headers(response):
-    """Inject X-API-Version and deprecation headers on every response."""
-    response.headers["X-API-Version"] = "v1"
-    if request.path.startswith(_LEGACY_PREFIXES):
+    """Inject API version and deprecation headers on every response."""
+    if request.path.startswith("/v2/"):
+        response.headers["X-API-Version"] = "v2"
+    elif request.path.startswith("/v1/"):
+        response.headers["X-API-Version"] = "v1"
+    if request.path.startswith(_DEPRECATED_PREFIXES):
         response.headers["X-API-Deprecated"] = "true"
-        response.headers["X-API-Sunset"] = "2027-01-01"
+        response.headers["Deprecation"] = "true"
+        response.headers["Sunset"] = "2027-01-01"
+        response.headers["Link"] = '</v2/>; rel="successor-version"'
     return response
 
 

--- a/tests/unit/test_resources_api.py
+++ b/tests/unit/test_resources_api.py
@@ -11,16 +11,27 @@ class TestSendCommand:
         """Test GET returns base response."""
         response = client.get("/v1/send_command")
         assert response.status_code == 200
-        assert "app" in response.json
         assert response.json["app"] == "naas"
         assert response.headers["X-API-Version"] == "v1"
+        assert response.headers["X-API-Deprecated"] == "true"
+        assert response.headers["Deprecation"] == "true"
+
+    def test_v2_send_command_no_deprecation(self, client):
+        """Test /v2/ routes do not include deprecation headers."""
+        response = client.get("/v2/send-command")
+        assert response.status_code == 200
+        assert response.headers["X-API-Version"] == "v2"
+        assert "X-API-Deprecated" not in response.headers
+        assert "Deprecation" not in response.headers
 
     def test_send_command_legacy_route_deprecated(self, client):
         """Test legacy /send_command route returns deprecation headers."""
         response = client.get("/send_command")
         assert response.status_code == 200
         assert response.headers["X-API-Deprecated"] == "true"
-        assert "X-API-Sunset" in response.headers
+        assert response.headers["Deprecation"] == "true"
+        assert "Sunset" in response.headers
+        assert "successor-version" in response.headers.get("Link", "")
 
     def test_send_command_post_success(self, app, client):
         """Test POST enqueues job successfully."""
@@ -395,7 +406,7 @@ class TestSendConfig:
         response = client.get("/send_config")
         assert response.status_code == 200
         assert response.headers["X-API-Deprecated"] == "true"
-        assert "X-API-Sunset" in response.headers
+        assert "Sunset" in response.headers
 
     def test_send_config_post_success(self, app, client):
         """Test POST enqueues job successfully."""


### PR DESCRIPTION
Closes #358

All `/v1/` and legacy unversioned route responses now include:
- `X-API-Deprecated: true`
- `Deprecation: true` (RFC 8594)
- `Sunset: 2027-01-01`
- `Link: </v2/>; rel="successor-version"`

`/v2/` routes return `X-API-Version: v2` with no deprecation headers. 344 tests, 100% coverage.