### PR TITLE
docs: add v1→v2 migration guide and API versioning ADR (#359)

### DIFF
--- a/changes/359.doc.md
+++ b/changes/359.doc.md
@@ -1,0 +1,1 @@
+Add v1 → v2 API migration guide and ADR for API versioning strategy.

--- a/docs/adr/0007-api-versioning-strategy.md
+++ b/docs/adr/0007-api-versioning-strategy.md
@@ -1,0 +1,49 @@
+# 7. API Versioning Strategy
+
+Date: 2026-04-07
+
+## Status
+
+Accepted
+
+## Context
+
+NAAS v2.0 introduced breaking changes to the API contract: removed `ip` and `device_type` fields, added mandatory authentication (RBAC, context authorization), and added new endpoints (API key management). These changes were initially applied directly to `/v1/` routes, violating the v1 contract for existing clients.
+
+We needed a strategy to:
+
+1. Honor the original v1 contract for existing clients
+2. Introduce the v2 contract with breaking changes
+3. Provide a clear migration path with deprecation signals
+
+## Decision
+
+Use **path-based API versioning** where the URL prefix (`/v1/`, `/v2/`) represents the API contract version:
+
+- `/v1/` routes preserve the original contract (deprecated, removed in v3.0)
+- `/v2/` routes implement the new contract with all breaking changes
+- Both versions share the same resource classes with version-aware behavior
+- Deprecation signaled via standard HTTP headers (RFC 8594)
+
+Version-aware behavior is implemented via a `is_v2_request()` helper checked in decorators, not by duplicating resource classes.
+
+## Consequences
+
+### Positive
+
+- Existing clients continue working on `/v1/` without changes
+- Clear migration path with deprecation headers and sunset date
+- Single codebase — no resource class duplication
+- Path version has real semantic meaning (contract version, not cosmetic)
+
+### Negative
+
+- Every decorator/validator that behaves differently per version must check `is_v2_request()`
+- New features must decide whether to be v2-only or available on both versions
+- `/v1/` routes must be maintained until v3.0
+
+### Conventions
+
+- New endpoints are registered under `/v2/` only unless backward compatibility is required
+- `/v2/` routes use hyphenated delimiters (`send-command`), `/v1/` keeps underscores
+- The API path version tracks the contract, not the software release version

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,4 +38,5 @@ Do **not** write an ADR for:
 | [0003](0003-api-key-authentication.md) | API key authentication | Accepted |
 | [0004](0004-role-based-access-control.md) | Role-based access control | Accepted |
 | [0005](0005-structured-audit-event-logging.md) | Structured audit event logging | Accepted |
-| [0006](0006-credential-encryption-at-rest.md) | Credential encryption at rest | Proposed |
+| [0006](0006-credential-encryption-at-rest.md) | Credential encryption at rest | Accepted |
+| [0007](0007-api-versioning-strategy.md) | API versioning strategy | Accepted |

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,75 @@
+# Upgrading to v2.0
+
+## API Version Change
+
+NAAS v2.0 introduces `/v2/` API routes. The `/v1/` routes remain available but are **deprecated** and will be removed in v3.0.
+
+All `/v1/` and legacy unversioned responses include deprecation headers:
+
+```http
+X-API-Deprecated: true
+Deprecation: true
+Sunset: 2027-01-01
+Link: </v2/>; rel="successor-version"
+```
+
+## Route Changes
+
+| v1 (deprecated) | v2 (new) |
+| --- | --- |
+| `/v1/send_command` | `/v2/send-command` |
+| `/v1/send_config` | `/v2/send-config` |
+| `/v1/send_command_structured` | `/v2/send-command-structured` |
+| `/v1/send_command/<id>` | `/v2/send-command/<id>` |
+| `/v1/send_config/<id>` | `/v2/send-config/<id>` |
+| `/v1/send_command_structured/<id>` | `/v2/send-command-structured/<id>` |
+| `/v1/jobs` | `/v2/jobs` |
+| `/v1/jobs/failed` | `/v2/jobs/failed` |
+| `/v1/jobs/<id>` | `/v2/jobs/<id>` |
+| `/v1/jobs/<id>/replay` | `/v2/jobs/<id>/replay` |
+| `/v1/contexts` | `/v2/contexts` |
+| `/v1/healthcheck` | `/v2/healthcheck` |
+| *(not available)* | `/v2/api-keys` |
+| *(not available)* | `/v2/api-keys/<id>` |
+| *(not available)* | `/v2/api-keys/<id>/rotate` |
+
+## Field Changes
+
+| v1 (deprecated) | v2 (required) |
+| --- | --- |
+| `ip` | `host` |
+| `device_type` | `platform` |
+
+- `/v1/` routes accept both old and new field names.
+- `/v2/` routes reject `ip` and `device_type` with a 422 error.
+
+## Authentication Changes
+
+| Feature | v1 | v2 |
+| --- | --- | --- |
+| Basic auth | ✅ (device creds in header) | ✅ |
+| API key auth (Bearer JWT) | Accepted but not enforced | ✅ Fully enforced |
+| RBAC | Not enforced | ✅ `admin > operator > viewer` |
+| Context authorization | Not enforced | ✅ JWT `contexts` claim checked |
+
+## New v2 Features
+
+- **API key management** — `POST/GET/DELETE /v2/api-keys`, `POST /v2/api-keys/<id>/rotate`
+- **RBAC** — Role-based access control on all endpoints
+- **Context authorization** — Scope API keys to specific routing contexts
+- **Webhook HMAC signing** — Optional `webhook_secret` field for payload signing
+- **Webhook retry** — Exponential backoff on failed deliveries (5s, 30s, 5min, 30min)
+- **Credential encryption** — Device credentials encrypted at rest in Redis
+- **Audit logging** — Structured events for auth, RBAC, API keys, and webhooks
+
+## Migration Steps
+
+1. Update all API URLs from `/v1/` to `/v2/` with hyphenated paths
+2. Replace `ip` with `host` and `device_type` with `platform` in request payloads
+3. If using API keys: ensure JWT claims include correct `role` and `contexts`
+4. Monitor for `X-API-Deprecated` headers in responses to find remaining v1 usage
+
+## Timeline
+
+- **v2.0** — `/v1/` routes deprecated, `/v2/` routes available
+- **v3.0** — `/v1/` and legacy unversioned routes removed


### PR DESCRIPTION
Closes #359

- `docs/upgrading.md` — complete v1 → v2 migration guide (route mapping, field changes, auth changes, timeline)
- `docs/adr/0007-api-versioning-strategy.md` — ADR for path-based versioning decision
- ADR 0006 marked as Accepted