### PR TITLE
feat: add synchronous NaasClient with full v2 API coverage (#371)

### DIFF
--- a/packages/naas-client/naas_client/__init__.py
+++ b/packages/naas-client/naas_client/__init__.py
@@ -2,6 +2,7 @@
 
 __version__ = "1.0.0a1"
 
+from naas_client.client import NaasClient
 from naas_client.exceptions import (
     NaasApiError,
     NaasAuthError,
@@ -29,6 +30,7 @@ __all__ = [
     "JobSubmission",
     "NaasApiError",
     "NaasAuthError",
+    "NaasClient",
     "NaasError",
     "NaasJobError",
     "NaasTimeoutError",

--- a/packages/naas-client/naas_client/client.py
+++ b/packages/naas-client/naas_client/client.py
@@ -1,0 +1,196 @@
+"""Synchronous NAAS client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from naas_client.exceptions import NaasApiError, NaasAuthError, NaasTimeoutError
+from naas_client.models import (
+    ApiKeyCreateResponse,
+    ApiKeyListItem,
+    ApiKeyListResponse,
+    ContextsResponse,
+    FailedJobsResponse,
+    HealthCheckResponse,
+    JobResult,
+    JobSubmission,
+    ListJobsResponse,
+)
+
+_AUTH_ERROR_CODES = {401, 403}
+
+
+class NaasClient:
+    """Synchronous Python client for the NAAS v2 API.
+
+    Args:
+        base_url: NAAS server URL (e.g. "https://naas.example.com").
+        username: Basic auth username (mutually exclusive with api_key).
+        password: Basic auth password.
+        api_key: JWT API key (mutually exclusive with username/password).
+        verify: TLS certificate verification. Defaults to True.
+        timeout: Request timeout in seconds. Defaults to 30.
+        max_retries: Retries on transient failures (5xx, connection errors). Defaults to 3.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        username: str | None = None,
+        password: str | None = None,
+        api_key: str | None = None,
+        verify: bool = True,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._max_retries = max_retries
+
+        headers: dict[str, str] = {}
+        auth: httpx.BasicAuth | None = None
+        if api_key:
+            headers["X-API-Key"] = api_key
+        elif username and password:
+            auth = httpx.BasicAuth(username, password)
+
+        transport = httpx.HTTPTransport(retries=max_retries)
+        self._client = httpx.Client(
+            base_url=self._base_url,
+            auth=auth,
+            headers=headers,
+            verify=verify,
+            timeout=timeout,
+            transport=transport,
+        )
+
+    def close(self) -> None:
+        """Close the underlying HTTP connection."""
+        self._client.close()
+
+    def __enter__(self) -> NaasClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        """Make a request and handle errors."""
+        try:
+            resp = self._client.request(method, path, **kwargs)
+        except httpx.TimeoutException as exc:
+            raise NaasTimeoutError(str(exc)) from exc
+
+        if resp.status_code >= 400:
+            cls = NaasAuthError if resp.status_code in _AUTH_ERROR_CODES else NaasApiError
+            raise cls(resp.status_code, resp.reason_phrase or "Error", body=resp.text)
+
+        return resp
+
+    # -- Commands / Config ---------------------------------------------------
+
+    def send_command(self, **kwargs: Any) -> JobSubmission:
+        """Submit a send-command job. Returns job submission metadata."""
+        resp = self._request("POST", "/v2/send-command", json=kwargs)
+        return JobSubmission.model_validate(resp.json())
+
+    def send_command_structured(self, **kwargs: Any) -> JobSubmission:
+        """Submit a structured send-command job (TextFSM/TTP parsing)."""
+        resp = self._request("POST", "/v2/send-command-structured", json=kwargs)
+        return JobSubmission.model_validate(resp.json())
+
+    def send_config(self, **kwargs: Any) -> JobSubmission:
+        """Submit a send-config job."""
+        resp = self._request("POST", "/v2/send-config", json=kwargs)
+        return JobSubmission.model_validate(resp.json())
+
+    def get_command_result(self, job_id: str) -> JobResult:
+        """Poll a send-command job result."""
+        resp = self._request("GET", f"/v2/send-command/{job_id}")
+        return JobResult.model_validate(resp.json())
+
+    def get_config_result(self, job_id: str) -> JobResult:
+        """Poll a send-config job result."""
+        resp = self._request("GET", f"/v2/send-config/{job_id}")
+        return JobResult.model_validate(resp.json())
+
+    # -- Job management ------------------------------------------------------
+
+    def list_jobs(
+        self,
+        *,
+        page: int = 1,
+        per_page: int = 20,
+        status: str | None = None,
+        tag: str | None = None,
+    ) -> ListJobsResponse:
+        """List jobs with pagination and optional filtering."""
+        params: dict[str, Any] = {"page": page, "per_page": per_page}
+        if status:
+            params["status"] = status
+        if tag:
+            params["tag"] = tag
+        resp = self._request("GET", "/v2/jobs", params=params)
+        return ListJobsResponse.model_validate(resp.json())
+
+    def cancel_job(self, job_id: str) -> None:
+        """Cancel a queued or running job."""
+        self._request("DELETE", f"/v2/jobs/{job_id}")
+
+    def replay_job(self, job_id: str) -> JobSubmission:
+        """Re-enqueue a failed job."""
+        resp = self._request("POST", f"/v2/jobs/{job_id}/replay")
+        return JobSubmission.model_validate(resp.json())
+
+    def failed_jobs(self) -> FailedJobsResponse:
+        """List jobs in the failed (dead letter) registry."""
+        resp = self._request("GET", "/v2/jobs/failed")
+        return FailedJobsResponse.model_validate(resp.json())
+
+    # -- Contexts ------------------------------------------------------------
+
+    def list_contexts(self) -> ContextsResponse:
+        """List active routing contexts."""
+        resp = self._request("GET", "/v2/contexts")
+        return ContextsResponse.model_validate(resp.json())
+
+    # -- API keys ------------------------------------------------------------
+
+    def list_api_keys(self) -> list[ApiKeyListItem]:
+        """List active API keys (metadata only)."""
+        resp = self._request("GET", "/v2/api-keys")
+        return ApiKeyListResponse.model_validate(resp.json()).keys
+
+    def create_api_key(
+        self,
+        *,
+        role: str = "admin",
+        contexts: list[str] | None = None,
+        ttl: int | None = None,
+    ) -> ApiKeyCreateResponse:
+        """Create a new API key. Returns the JWT token (shown once)."""
+        payload: dict[str, Any] = {"role": role}
+        if contexts is not None:
+            payload["contexts"] = contexts
+        if ttl is not None:
+            payload["ttl"] = ttl
+        resp = self._request("POST", "/v2/api-keys", json=payload)
+        return ApiKeyCreateResponse.model_validate(resp.json())
+
+    def delete_api_key(self, key_id: str) -> None:
+        """Revoke an API key."""
+        self._request("DELETE", f"/v2/api-keys/{key_id}")
+
+    def rotate_api_key(self, key_id: str) -> ApiKeyCreateResponse:
+        """Rotate an API key. Returns a new JWT token."""
+        resp = self._request("POST", f"/v2/api-keys/{key_id}/rotate")
+        return ApiKeyCreateResponse.model_validate(resp.json())
+
+    # -- Health --------------------------------------------------------------
+
+    def healthcheck(self) -> HealthCheckResponse:
+        """Check NAAS server health."""
+        resp = self._request("GET", "/healthcheck")
+        return HealthCheckResponse.model_validate(resp.json())

--- a/packages/naas-client/tests/test_client.py
+++ b/packages/naas-client/tests/test_client.py
@@ -1,0 +1,252 @@
+"""Tests for naas_client.client.NaasClient."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import httpx
+import pytest
+
+from naas_client.client import NaasClient
+from naas_client.exceptions import NaasApiError, NaasAuthError, NaasTimeoutError
+from naas_client.models import (
+    ApiKeyCreateResponse,
+    ContextsResponse,
+    FailedJobsResponse,
+    HealthCheckResponse,
+    JobResult,
+    JobSubmission,
+    ListJobsResponse,
+)
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+BASE = "https://naas.test"
+
+JOB_SUBMISSION = {
+    "job_id": "abc-123",
+    "message": "Job enqueued",
+    "queue_position": 1,
+    "enqueued_at": "2026-04-09T12:00:00Z",
+    "timeout": 300,
+}
+
+JOB_RESULT = {
+    "job_id": "abc-123",
+    "status": "finished",
+    "results": {"show version": "Cisco IOS"},
+}
+
+HEALTH_RESPONSE = {
+    "status": "healthy",
+    "version": "2.0.0",
+    "uptime_seconds": 0,
+    "components": {
+        "redis": {"status": "healthy"},
+        "queue": {"status": "healthy", "depth": 0},
+        "workers": {"status": "healthy", "count": 1, "active_jobs": 0},
+        "failed_jobs": 0,
+    },
+}
+
+API_KEY_RESPONSE = {
+    "key_id": "k-1",
+    "token": "eyJ...",
+    "role": "admin",
+    "contexts": ["*"],
+    "expires_at": "2026-07-01T00:00:00Z",
+}
+
+API_KEY_LIST_ITEM = {
+    "key_id": "k-1",
+    "role": "admin",
+    "contexts": ["*"],
+    "created_at": "2026-01-01T00:00:00Z",
+    "expires_at": "2026-07-01T00:00:00Z",
+    "created_by": "admin",
+}
+
+
+class TestAuth:
+    def test_basic_auth(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=HEALTH_RESPONSE)
+        with NaasClient(BASE, username="admin", password="secret") as c:
+            c.healthcheck()
+        req = httpx_mock.get_requests()[0]
+        assert req.headers.get("authorization", "").startswith("Basic ")
+
+    def test_api_key_auth(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=HEALTH_RESPONSE)
+        with NaasClient(BASE, api_key="my-jwt") as c:
+            c.healthcheck()
+        req = httpx_mock.get_requests()[0]
+        assert req.headers["x-api-key"] == "my-jwt"
+
+
+class TestErrorHandling:
+    def test_401_raises_auth_error(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=401, text="Unauthorized")
+        with NaasClient(BASE, username="x", password="x") as c, pytest.raises(NaasAuthError) as exc_info:
+            c.healthcheck()
+        assert exc_info.value.status_code == 401
+
+    def test_403_raises_auth_error(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=403, text="Forbidden")
+        with NaasClient(BASE, username="x", password="x") as c, pytest.raises(NaasAuthError):
+            c.healthcheck()
+
+    def test_500_raises_api_error(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=500, text="Internal Server Error")
+        with NaasClient(BASE, username="x", password="x") as c, pytest.raises(NaasApiError) as exc_info:
+            c.healthcheck()
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.body == "Internal Server Error"
+
+    def test_timeout_raises_timeout_error(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_exception(httpx.ReadTimeout("timed out"))
+        with NaasClient(BASE, username="x", password="x") as c, pytest.raises(NaasTimeoutError):
+            c.healthcheck()
+
+
+class TestCommands:
+    def test_send_command(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.send_command(host="10.0.0.1", platform="cisco_ios", commands=["show version"])
+        assert isinstance(result, JobSubmission)
+        assert result.job_id == "abc-123"
+        assert httpx_mock.get_requests()[0].url.path == "/v2/send-command"
+
+    def test_send_command_structured(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.send_command_structured(host="10.0.0.1", commands=["show version"])
+        assert isinstance(result, JobSubmission)
+        assert httpx_mock.get_requests()[0].url.path == "/v2/send-command-structured"
+
+    def test_send_config(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.send_config(host="10.0.0.1", config=["interface Gi0/1", "shutdown"])
+        assert isinstance(result, JobSubmission)
+        assert httpx_mock.get_requests()[0].url.path == "/v2/send-config"
+
+    def test_get_command_result(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=JOB_RESULT)
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.get_command_result("abc-123")
+        assert isinstance(result, JobResult)
+        assert result.status == "finished"
+        assert httpx_mock.get_requests()[0].url.path == "/v2/send-command/abc-123"
+
+    def test_get_config_result(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=JOB_RESULT)
+        with NaasClient(BASE, username="x", password="x") as c:
+            c.get_config_result("abc-123")
+        assert httpx_mock.get_requests()[0].url.path == "/v2/send-config/abc-123"
+
+
+class TestJobManagement:
+    def test_list_jobs(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"jobs": [], "pagination": {"page": 1, "per_page": 20, "total": 0, "pages": 0}})
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.list_jobs()
+        assert isinstance(result, ListJobsResponse)
+
+    def test_list_jobs_with_filters(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"jobs": [], "pagination": {"page": 2, "per_page": 10, "total": 0, "pages": 0}})
+        with NaasClient(BASE, username="x", password="x") as c:
+            c.list_jobs(page=2, per_page=10, status="failed", tag="env:prod")
+        params = httpx_mock.get_requests()[0].url.params
+        assert params["page"] == "2"
+        assert params["status"] == "failed"
+        assert params["tag"] == "env:prod"
+
+    def test_cancel_job(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=204)
+        with NaasClient(BASE, username="x", password="x") as c:
+            c.cancel_job("abc-123")
+        assert httpx_mock.get_requests()[0].method == "DELETE"
+        assert httpx_mock.get_requests()[0].url.path == "/v2/jobs/abc-123"
+
+    def test_replay_job(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.replay_job("abc-123")
+        assert isinstance(result, JobSubmission)
+        assert httpx_mock.get_requests()[0].url.path == "/v2/jobs/abc-123/replay"
+
+    def test_failed_jobs(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"jobs": [], "total": 0})
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.failed_jobs()
+        assert isinstance(result, FailedJobsResponse)
+
+
+class TestContexts:
+    def test_list_contexts(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"contexts": [{"name": "default", "workers": 4, "queue_depth": 0}]})
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.list_contexts()
+        assert isinstance(result, ContextsResponse)
+        assert result.contexts[0].name == "default"
+
+
+class TestApiKeys:
+    def test_list_api_keys(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"keys": [API_KEY_LIST_ITEM]})
+        with NaasClient(BASE, username="x", password="x") as c:
+            keys = c.list_api_keys()
+        assert len(keys) == 1
+        assert keys[0].key_id == "k-1"
+
+    def test_create_api_key(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=201, json={**API_KEY_RESPONSE, "role": "operator", "contexts": ["default"]})
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.create_api_key(role="operator", contexts=["default"], ttl=3600)
+        assert isinstance(result, ApiKeyCreateResponse)
+        payload = json.loads(httpx_mock.get_requests()[0].read())
+        assert payload["role"] == "operator"
+        assert payload["contexts"] == ["default"]
+        assert payload["ttl"] == 3600
+
+    def test_create_api_key_defaults(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=201, json=API_KEY_RESPONSE)
+        with NaasClient(BASE, username="x", password="x") as c:
+            c.create_api_key()
+        payload = json.loads(httpx_mock.get_requests()[0].read())
+        assert payload == {"role": "admin"}
+
+    def test_delete_api_key(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=204)
+        with NaasClient(BASE, username="x", password="x") as c:
+            c.delete_api_key("k-1")
+        assert httpx_mock.get_requests()[0].method == "DELETE"
+
+    def test_rotate_api_key(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=201, json={**API_KEY_RESPONSE, "token": "new-jwt"})
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.rotate_api_key("k-1")
+        assert result.token == "new-jwt"
+
+
+class TestHealthcheck:
+    def test_healthcheck(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=HEALTH_RESPONSE)
+        with NaasClient(BASE, username="x", password="x") as c:
+            result = c.healthcheck()
+        assert isinstance(result, HealthCheckResponse)
+        assert result.status == "healthy"
+
+
+class TestContextManager:
+    def test_close(self) -> None:
+        c = NaasClient(BASE, username="x", password="x")
+        c.close()
+
+    def test_trailing_slash_stripped(self) -> None:
+        c = NaasClient("https://naas.test/", username="x", password="x")
+        assert c._base_url == "https://naas.test"
+        c.close()

--- a/packages/naas/changes/371.feature.md
+++ b/packages/naas/changes/371.feature.md
@@ -1,0 +1,1 @@
+Add synchronous NaasClient with full v2 API coverage.


### PR DESCRIPTION
## Summary

Adds the synchronous `NaasClient` class with complete v2 API coverage.

## Changes

- **`NaasClient`** class with httpx transport
- **Auth**: Basic auth (`username`/`password`) and API key (`api_key` header)
- **All v2 endpoints**: send_command, send_command_structured, send_config, get_command_result, get_config_result, list_jobs, cancel_job, replay_job, failed_jobs, list_contexts, list_api_keys, create_api_key, delete_api_key, rotate_api_key, healthcheck
- **Error handling**: `NaasAuthError` (401/403), `NaasApiError` (4xx/5xx), `NaasTimeoutError`
- **Retry**: Transient failure retry via httpx transport
- **Context manager**: `with NaasClient(...) as c:`
- 48 tests with pytest-httpx mocking, 100% coverage

## Usage

```python
from naas_client import NaasClient

with NaasClient("https://naas.example.com", username="admin", password="secret") as c:
    job = c.send_command(host="10.0.0.1", platform="cisco_ios", commands=["show version"])
    result = c.get_command_result(job.job_id)
```

Closes #371