### PR TITLE
feat: add Job object with polling and wait support (#372)

### DIFF
--- a/packages/naas-client/naas_client/__init__.py
+++ b/packages/naas-client/naas_client/__init__.py
@@ -10,6 +10,7 @@ from naas_client.exceptions import (
     NaasJobError,
     NaasTimeoutError,
 )
+from naas_client.job import Job
 from naas_client.models import (
     ApiKeyCreateResponse,
     ContextInfo,
@@ -25,6 +26,7 @@ __all__ = [
     "ContextInfo",
     "ContextsResponse",
     "HealthCheckResponse",
+    "Job",
     "JobResult",
     "JobStatus",
     "JobSubmission",

--- a/packages/naas-client/naas_client/client.py
+++ b/packages/naas-client/naas_client/client.py
@@ -7,6 +7,7 @@ from typing import Any
 import httpx
 
 from naas_client.exceptions import NaasApiError, NaasAuthError, NaasTimeoutError
+from naas_client.job import Job
 from naas_client.models import (
     ApiKeyCreateResponse,
     ApiKeyListItem,
@@ -91,20 +92,23 @@ class NaasClient:
 
     # -- Commands / Config ---------------------------------------------------
 
-    def send_command(self, **kwargs: Any) -> JobSubmission:
-        """Submit a send-command job. Returns job submission metadata."""
+    def send_command(self, **kwargs: Any) -> Job:
+        """Submit a send-command job. Returns a Job object for polling."""
         resp = self._request("POST", "/v2/send-command", json=kwargs)
-        return JobSubmission.model_validate(resp.json())
+        sub = JobSubmission.model_validate(resp.json())
+        return Job(self, sub.job_id, "command")
 
-    def send_command_structured(self, **kwargs: Any) -> JobSubmission:
+    def send_command_structured(self, **kwargs: Any) -> Job:
         """Submit a structured send-command job (TextFSM/TTP parsing)."""
         resp = self._request("POST", "/v2/send-command-structured", json=kwargs)
-        return JobSubmission.model_validate(resp.json())
+        sub = JobSubmission.model_validate(resp.json())
+        return Job(self, sub.job_id, "command")
 
-    def send_config(self, **kwargs: Any) -> JobSubmission:
+    def send_config(self, **kwargs: Any) -> Job:
         """Submit a send-config job."""
         resp = self._request("POST", "/v2/send-config", json=kwargs)
-        return JobSubmission.model_validate(resp.json())
+        sub = JobSubmission.model_validate(resp.json())
+        return Job(self, sub.job_id, "config")
 
     def get_command_result(self, job_id: str) -> JobResult:
         """Poll a send-command job result."""

--- a/packages/naas-client/naas_client/job.py
+++ b/packages/naas-client/naas_client/job.py
@@ -1,0 +1,84 @@
+"""Job object with polling and wait support."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from naas_client.exceptions import NaasJobError, NaasTimeoutError
+from naas_client.models import JobResult, JobStatus
+
+if TYPE_CHECKING:
+    from naas_client.client import NaasClient
+
+
+class Job:
+    """A submitted NAAS job with polling and wait capabilities.
+
+    Args:
+        client: NaasClient instance for polling.
+        job_id: Job identifier.
+        job_type: "command" or "config" (determines polling endpoint).
+    """
+
+    def __init__(self, client: NaasClient, job_id: str, job_type: str) -> None:
+        self._client = client
+        self.job_id = job_id
+        self._job_type = job_type
+        self._result: JobResult | None = None
+
+    def poll(self) -> JobResult:
+        """Fetch current job status (single request)."""
+        if self._job_type == "config":
+            self._result = self._client.get_config_result(self.job_id)
+        else:
+            self._result = self._client.get_command_result(self.job_id)
+        return self._result
+
+    def wait(self, *, timeout: float = 60, interval: float = 1.0) -> JobResult:
+        """Block until job completes or timeout.
+
+        Args:
+            timeout: Maximum seconds to wait.
+            interval: Seconds between polls.
+
+        Returns:
+            JobResult with final status.
+
+        Raises:
+            NaasTimeoutError: If timeout exceeded.
+            NaasJobError: If job failed.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            result = self.poll()
+            if result.status in (JobStatus.FINISHED, JobStatus.FAILED):
+                if result.status == JobStatus.FAILED:
+                    raise NaasJobError(self.job_id, result.error or "Unknown error")
+                return result
+            time.sleep(interval)
+        raise NaasTimeoutError(f"Job {self.job_id} did not complete within {timeout}s")
+
+    @property
+    def is_complete(self) -> bool:
+        """True if last poll showed finished or failed."""
+        return self._result is not None and self._result.status in (JobStatus.FINISHED, JobStatus.FAILED)
+
+    @property
+    def is_failed(self) -> bool:
+        """True if last poll showed failed."""
+        return self._result is not None and self._result.status == JobStatus.FAILED
+
+    @property
+    def result(self) -> JobResult | None:
+        """Last polled result, or None if never polled."""
+        return self._result
+
+    def cancel(self) -> None:
+        """Cancel this job."""
+        self._client.cancel_job(self.job_id)
+
+    def replay(self) -> Job:
+        """Re-enqueue this job. Returns a new Job."""
+        submission = self._client.replay_job(self.job_id)
+        return Job(self._client, submission.job_id, self._job_type)

--- a/packages/naas-client/tests/test_client.py
+++ b/packages/naas-client/tests/test_client.py
@@ -10,6 +10,7 @@ import pytest
 
 from naas_client.client import NaasClient
 from naas_client.exceptions import NaasApiError, NaasAuthError, NaasTimeoutError
+from naas_client.job import Job
 from naas_client.models import (
     ApiKeyCreateResponse,
     ContextsResponse,
@@ -115,7 +116,7 @@ class TestCommands:
         httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
         with NaasClient(BASE, username="x", password="x") as c:
             result = c.send_command(host="10.0.0.1", platform="cisco_ios", commands=["show version"])
-        assert isinstance(result, JobSubmission)
+        assert isinstance(result, Job)
         assert result.job_id == "abc-123"
         assert httpx_mock.get_requests()[0].url.path == "/v2/send-command"
 
@@ -123,14 +124,14 @@ class TestCommands:
         httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
         with NaasClient(BASE, username="x", password="x") as c:
             result = c.send_command_structured(host="10.0.0.1", commands=["show version"])
-        assert isinstance(result, JobSubmission)
+        assert isinstance(result, Job)
         assert httpx_mock.get_requests()[0].url.path == "/v2/send-command-structured"
 
     def test_send_config(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
         with NaasClient(BASE, username="x", password="x") as c:
             result = c.send_config(host="10.0.0.1", config=["interface Gi0/1", "shutdown"])
-        assert isinstance(result, JobSubmission)
+        assert isinstance(result, Job)
         assert httpx_mock.get_requests()[0].url.path == "/v2/send-config"
 
     def test_get_command_result(self, httpx_mock: HTTPXMock) -> None:

--- a/packages/naas-client/tests/test_job.py
+++ b/packages/naas-client/tests/test_job.py
@@ -1,0 +1,151 @@
+"""Tests for naas_client.job.Job."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from naas_client.exceptions import NaasJobError, NaasTimeoutError
+from naas_client.job import Job
+from naas_client.models import JobResult, JobSubmission
+
+
+def _mock_client() -> MagicMock:
+    return MagicMock(spec_set=["get_command_result", "get_config_result", "cancel_job", "replay_job"])
+
+
+def _job_result(status: str = "finished", **kwargs: object) -> JobResult:
+    return JobResult.model_validate({"job_id": "abc-123", "status": status, **kwargs})
+
+
+class TestPoll:
+    def test_poll_command(self) -> None:
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result()
+        job = Job(client, "abc-123", "command")
+        result = job.poll()
+        assert result.status == "finished"
+        client.get_command_result.assert_called_once_with("abc-123")
+
+    def test_poll_config(self) -> None:
+        client = _mock_client()
+        client.get_config_result.return_value = _job_result()
+        job = Job(client, "abc-123", "config")
+        job.poll()
+        client.get_config_result.assert_called_once_with("abc-123")
+
+
+class TestWait:
+    @patch("naas_client.job.time.sleep")
+    @patch("naas_client.job.time.monotonic")
+    def test_wait_returns_on_finished(self, mock_mono: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_mono.side_effect = [0.0, 0.5]  # start, first poll
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("finished")
+        job = Job(client, "abc-123", "command")
+        result = job.wait(timeout=10)
+        assert result.status == "finished"
+        mock_sleep.assert_not_called()
+
+    @patch("naas_client.job.time.sleep")
+    @patch("naas_client.job.time.monotonic")
+    def test_wait_polls_until_done(self, mock_mono: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_mono.side_effect = [0.0, 1.0, 2.0, 3.0]
+        client = _mock_client()
+        client.get_command_result.side_effect = [
+            _job_result("queued"),
+            _job_result("started"),
+            _job_result("finished", results={"show version": "Cisco"}),
+        ]
+        job = Job(client, "abc-123", "command")
+        result = job.wait(timeout=10)
+        assert result.status == "finished"
+        assert mock_sleep.call_count == 2
+
+    @patch("naas_client.job.time.sleep")
+    @patch("naas_client.job.time.monotonic")
+    def test_wait_raises_on_failure(self, mock_mono: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_mono.side_effect = [0.0, 0.5]
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("failed", error="Connection refused")
+        job = Job(client, "abc-123", "command")
+        with pytest.raises(NaasJobError) as exc_info:
+            job.wait(timeout=10)
+        assert exc_info.value.error == "Connection refused"
+
+    @patch("naas_client.job.time.sleep")
+    @patch("naas_client.job.time.monotonic")
+    def test_wait_raises_on_failure_no_error_msg(self, mock_mono: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_mono.side_effect = [0.0, 0.5]
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("failed")
+        job = Job(client, "abc-123", "command")
+        with pytest.raises(NaasJobError) as exc_info:
+            job.wait(timeout=10)
+        assert exc_info.value.error == "Unknown error"
+
+    @patch("naas_client.job.time.sleep")
+    @patch("naas_client.job.time.monotonic")
+    def test_wait_timeout(self, mock_mono: MagicMock, mock_sleep: MagicMock) -> None:
+        mock_mono.side_effect = [0.0, 5.0, 11.0]
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("queued")
+        job = Job(client, "abc-123", "command")
+        with pytest.raises(NaasTimeoutError, match="did not complete"):
+            job.wait(timeout=10)
+
+
+class TestProperties:
+    def test_is_complete_before_poll(self) -> None:
+        job = Job(_mock_client(), "abc-123", "command")
+        assert job.is_complete is False
+        assert job.is_failed is False
+        assert job.result is None
+
+    def test_is_complete_after_finished(self) -> None:
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("finished")
+        job = Job(client, "abc-123", "command")
+        job.poll()
+        assert job.is_complete is True
+        assert job.is_failed is False
+
+    def test_is_failed(self) -> None:
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("failed")
+        job = Job(client, "abc-123", "command")
+        job.poll()
+        assert job.is_complete is True
+        assert job.is_failed is True
+
+    def test_not_complete_while_running(self) -> None:
+        client = _mock_client()
+        client.get_command_result.return_value = _job_result("started")
+        job = Job(client, "abc-123", "command")
+        job.poll()
+        assert job.is_complete is False
+
+
+class TestActions:
+    def test_cancel(self) -> None:
+        client = _mock_client()
+        job = Job(client, "abc-123", "command")
+        job.cancel()
+        client.cancel_job.assert_called_once_with("abc-123")
+
+    def test_replay(self) -> None:
+        client = _mock_client()
+        client.replay_job.return_value = JobSubmission.model_validate(
+            {
+                "job_id": "new-456",
+                "message": "Replayed",
+                "queue_position": 0,
+                "enqueued_at": "2026-01-01T00:00:00Z",
+                "timeout": 300,
+            }
+        )
+        job = Job(client, "abc-123", "command")
+        new_job = job.replay()
+        assert new_job.job_id == "new-456"
+        assert isinstance(new_job, Job)

--- a/packages/naas/changes/372.feature.md
+++ b/packages/naas/changes/372.feature.md
@@ -1,0 +1,1 @@
+Add Job object with polling and wait support.


### PR DESCRIPTION
## Summary

Adds the `Job` class — returned by `send_command()`, `send_config()`, and `send_command_structured()` — with polling, waiting, and convenience methods.

## Usage

```python
from naas_client import NaasClient

with NaasClient("https://naas.example.com", username="admin", password="secret") as c:
    job = c.send_command(host="10.0.0.1", platform="cisco_ios", commands=["show version"])
    result = job.wait(timeout=30)
    print(result.results["show version"])
```

## Changes

- `Job` class with `poll()`, `wait(timeout, interval)`, `cancel()`, `replay()`
- Properties: `is_complete`, `is_failed`, `result`
- `NaasJobError` raised on job failure, `NaasTimeoutError` on wait timeout
- Client submit methods now return `Job` instead of `JobSubmission`
- 61 tests, 100% coverage

Closes #372