### PR TITLE
feat: add AsyncNaasClient and AsyncJob (#373)

### DIFF
--- a/packages/naas-client/naas_client/__init__.py
+++ b/packages/naas-client/naas_client/__init__.py
@@ -2,6 +2,8 @@
 
 __version__ = "1.0.0a1"
 
+from naas_client.async_client import AsyncNaasClient
+from naas_client.async_job import AsyncJob
 from naas_client.client import NaasClient
 from naas_client.exceptions import (
     NaasApiError,
@@ -23,6 +25,8 @@ from naas_client.models import (
 
 __all__ = [
     "ApiKeyCreateResponse",
+    "AsyncJob",
+    "AsyncNaasClient",
     "ContextInfo",
     "ContextsResponse",
     "HealthCheckResponse",

--- a/packages/naas-client/naas_client/async_client.py
+++ b/packages/naas-client/naas_client/async_client.py
@@ -1,0 +1,183 @@
+"""Asynchronous NAAS client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from naas_client.async_job import AsyncJob
+from naas_client.exceptions import NaasApiError, NaasAuthError, NaasTimeoutError
+from naas_client.models import (
+    ApiKeyCreateResponse,
+    ApiKeyListItem,
+    ApiKeyListResponse,
+    ContextsResponse,
+    FailedJobsResponse,
+    HealthCheckResponse,
+    JobResult,
+    JobSubmission,
+    ListJobsResponse,
+)
+
+_AUTH_ERROR_CODES = {401, 403}
+
+
+class AsyncNaasClient:
+    """Asynchronous Python client for the NAAS v2 API.
+
+    Args:
+        base_url: NAAS server URL.
+        username: Basic auth username (mutually exclusive with api_key).
+        password: Basic auth password.
+        api_key: JWT API key (mutually exclusive with username/password).
+        verify: TLS certificate verification. Defaults to True.
+        timeout: Request timeout in seconds. Defaults to 30.
+        max_retries: Retries on transient failures. Defaults to 3.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        username: str | None = None,
+        password: str | None = None,
+        api_key: str | None = None,
+        verify: bool = True,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+
+        headers: dict[str, str] = {}
+        auth: httpx.BasicAuth | None = None
+        if api_key:
+            headers["X-API-Key"] = api_key
+        elif username and password:
+            auth = httpx.BasicAuth(username, password)
+
+        transport = httpx.AsyncHTTPTransport(retries=max_retries)
+        self._client = httpx.AsyncClient(
+            base_url=self._base_url,
+            auth=auth,
+            headers=headers,
+            verify=verify,
+            timeout=timeout,
+            transport=transport,
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> AsyncNaasClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        try:
+            resp = await self._client.request(method, path, **kwargs)
+        except httpx.TimeoutException as exc:
+            raise NaasTimeoutError(str(exc)) from exc
+
+        if resp.status_code >= 400:
+            cls = NaasAuthError if resp.status_code in _AUTH_ERROR_CODES else NaasApiError
+            raise cls(resp.status_code, resp.reason_phrase or "Error", body=resp.text)
+
+        return resp
+
+    # -- Commands / Config ---------------------------------------------------
+
+    async def send_command(self, **kwargs: Any) -> AsyncJob:
+        resp = await self._request("POST", "/v2/send-command", json=kwargs)
+        sub = JobSubmission.model_validate(resp.json())
+        return AsyncJob(self, sub.job_id, "command")
+
+    async def send_command_structured(self, **kwargs: Any) -> AsyncJob:
+        resp = await self._request("POST", "/v2/send-command-structured", json=kwargs)
+        sub = JobSubmission.model_validate(resp.json())
+        return AsyncJob(self, sub.job_id, "command")
+
+    async def send_config(self, **kwargs: Any) -> AsyncJob:
+        resp = await self._request("POST", "/v2/send-config", json=kwargs)
+        sub = JobSubmission.model_validate(resp.json())
+        return AsyncJob(self, sub.job_id, "config")
+
+    async def get_command_result(self, job_id: str) -> JobResult:
+        resp = await self._request("GET", f"/v2/send-command/{job_id}")
+        return JobResult.model_validate(resp.json())
+
+    async def get_config_result(self, job_id: str) -> JobResult:
+        resp = await self._request("GET", f"/v2/send-config/{job_id}")
+        return JobResult.model_validate(resp.json())
+
+    # -- Job management ------------------------------------------------------
+
+    async def list_jobs(
+        self,
+        *,
+        page: int = 1,
+        per_page: int = 20,
+        status: str | None = None,
+        tag: str | None = None,
+    ) -> ListJobsResponse:
+        params: dict[str, Any] = {"page": page, "per_page": per_page}
+        if status:
+            params["status"] = status
+        if tag:
+            params["tag"] = tag
+        resp = await self._request("GET", "/v2/jobs", params=params)
+        return ListJobsResponse.model_validate(resp.json())
+
+    async def cancel_job(self, job_id: str) -> None:
+        await self._request("DELETE", f"/v2/jobs/{job_id}")
+
+    async def replay_job(self, job_id: str) -> JobSubmission:
+        resp = await self._request("POST", f"/v2/jobs/{job_id}/replay")
+        return JobSubmission.model_validate(resp.json())
+
+    async def failed_jobs(self) -> FailedJobsResponse:
+        resp = await self._request("GET", "/v2/jobs/failed")
+        return FailedJobsResponse.model_validate(resp.json())
+
+    # -- Contexts ------------------------------------------------------------
+
+    async def list_contexts(self) -> ContextsResponse:
+        resp = await self._request("GET", "/v2/contexts")
+        return ContextsResponse.model_validate(resp.json())
+
+    # -- API keys ------------------------------------------------------------
+
+    async def list_api_keys(self) -> list[ApiKeyListItem]:
+        resp = await self._request("GET", "/v2/api-keys")
+        return ApiKeyListResponse.model_validate(resp.json()).keys
+
+    async def create_api_key(
+        self,
+        *,
+        role: str = "admin",
+        contexts: list[str] | None = None,
+        ttl: int | None = None,
+    ) -> ApiKeyCreateResponse:
+        payload: dict[str, Any] = {"role": role}
+        if contexts is not None:
+            payload["contexts"] = contexts
+        if ttl is not None:
+            payload["ttl"] = ttl
+        resp = await self._request("POST", "/v2/api-keys", json=payload)
+        return ApiKeyCreateResponse.model_validate(resp.json())
+
+    async def delete_api_key(self, key_id: str) -> None:
+        await self._request("DELETE", f"/v2/api-keys/{key_id}")
+
+    async def rotate_api_key(self, key_id: str) -> ApiKeyCreateResponse:
+        resp = await self._request("POST", f"/v2/api-keys/{key_id}/rotate")
+        return ApiKeyCreateResponse.model_validate(resp.json())
+
+    # -- Health --------------------------------------------------------------
+
+    async def healthcheck(self) -> HealthCheckResponse:
+        resp = await self._request("GET", "/healthcheck")
+        return HealthCheckResponse.model_validate(resp.json())

--- a/packages/naas-client/naas_client/async_job.py
+++ b/packages/naas-client/naas_client/async_job.py
@@ -1,0 +1,66 @@
+"""Async Job object with polling and wait support."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from naas_client.exceptions import NaasJobError, NaasTimeoutError
+from naas_client.models import JobResult, JobStatus
+
+if TYPE_CHECKING:
+    from naas_client.async_client import AsyncNaasClient
+
+
+class AsyncJob:
+    """An async submitted NAAS job with polling and wait capabilities."""
+
+    def __init__(self, client: AsyncNaasClient, job_id: str, job_type: str) -> None:
+        self._client = client
+        self.job_id = job_id
+        self._job_type = job_type
+        self._result: JobResult | None = None
+
+    async def poll(self) -> JobResult:
+        """Fetch current job status (single request)."""
+        if self._job_type == "config":
+            self._result = await self._client.get_config_result(self.job_id)
+        else:
+            self._result = await self._client.get_command_result(self.job_id)
+        return self._result
+
+    async def wait(self, *, timeout: float = 60, interval: float = 1.0) -> JobResult:
+        """Await until job completes or timeout.
+
+        Raises:
+            NaasTimeoutError: If timeout exceeded.
+            NaasJobError: If job failed.
+        """
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            result = await self.poll()
+            if result.status in (JobStatus.FINISHED, JobStatus.FAILED):
+                if result.status == JobStatus.FAILED:
+                    raise NaasJobError(self.job_id, result.error or "Unknown error")
+                return result
+            await asyncio.sleep(interval)
+        raise NaasTimeoutError(f"Job {self.job_id} did not complete within {timeout}s")
+
+    @property
+    def is_complete(self) -> bool:
+        return self._result is not None and self._result.status in (JobStatus.FINISHED, JobStatus.FAILED)
+
+    @property
+    def is_failed(self) -> bool:
+        return self._result is not None and self._result.status == JobStatus.FAILED
+
+    @property
+    def result(self) -> JobResult | None:
+        return self._result
+
+    async def cancel(self) -> None:
+        await self._client.cancel_job(self.job_id)
+
+    async def replay(self) -> AsyncJob:
+        submission = await self._client.replay_job(self.job_id)
+        return AsyncJob(self._client, submission.job_id, self._job_type)

--- a/packages/naas-client/tests/test_async.py
+++ b/packages/naas-client/tests/test_async.py
@@ -1,0 +1,332 @@
+"""Tests for AsyncNaasClient and AsyncJob."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from naas_client.async_client import AsyncNaasClient
+from naas_client.async_job import AsyncJob
+from naas_client.exceptions import NaasApiError, NaasAuthError, NaasJobError, NaasTimeoutError
+from naas_client.models import (
+    ApiKeyCreateResponse,
+    ContextsResponse,
+    FailedJobsResponse,
+    HealthCheckResponse,
+    JobResult,
+    JobSubmission,
+    ListJobsResponse,
+)
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+BASE = "https://naas.test"
+
+JOB_SUBMISSION = {
+    "job_id": "abc-123",
+    "message": "Job enqueued",
+    "queue_position": 1,
+    "enqueued_at": "2026-04-09T12:00:00Z",
+    "timeout": 300,
+}
+
+JOB_RESULT = {"job_id": "abc-123", "status": "finished", "results": {"show version": "Cisco IOS"}}
+
+HEALTH_RESPONSE = {
+    "status": "healthy",
+    "version": "2.0.0",
+    "uptime_seconds": 0,
+    "components": {
+        "redis": {"status": "healthy"},
+        "queue": {"status": "healthy", "depth": 0},
+        "workers": {"status": "healthy", "count": 1, "active_jobs": 0},
+        "failed_jobs": 0,
+    },
+}
+
+API_KEY_RESPONSE = {
+    "key_id": "k-1",
+    "token": "eyJ...",
+    "role": "admin",
+    "contexts": ["*"],
+    "expires_at": "2026-07-01T00:00:00Z",
+}
+
+API_KEY_LIST_ITEM = {
+    "key_id": "k-1",
+    "role": "admin",
+    "contexts": ["*"],
+    "created_at": "2026-01-01T00:00:00Z",
+    "expires_at": "2026-07-01T00:00:00Z",
+    "created_by": "admin",
+}
+
+
+class TestAsyncAuth:
+    @pytest.mark.asyncio
+    async def test_basic_auth(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=HEALTH_RESPONSE)
+        async with AsyncNaasClient(BASE, username="admin", password="secret") as c:
+            await c.healthcheck()
+        assert httpx_mock.get_requests()[0].headers.get("authorization", "").startswith("Basic ")
+
+    @pytest.mark.asyncio
+    async def test_api_key_auth(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=HEALTH_RESPONSE)
+        async with AsyncNaasClient(BASE, api_key="my-jwt") as c:
+            await c.healthcheck()
+        assert httpx_mock.get_requests()[0].headers["x-api-key"] == "my-jwt"
+
+
+class TestAsyncErrors:
+    @pytest.mark.asyncio
+    async def test_401(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=401, text="Unauthorized")
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            with pytest.raises(NaasAuthError):
+                await c.healthcheck()
+
+    @pytest.mark.asyncio
+    async def test_500(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=500, text="ISE")
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            with pytest.raises(NaasApiError):
+                await c.healthcheck()
+
+    @pytest.mark.asyncio
+    async def test_timeout(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_exception(httpx.ReadTimeout("timed out"))
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            with pytest.raises(NaasTimeoutError):
+                await c.healthcheck()
+
+
+class TestAsyncCommands:
+    @pytest.mark.asyncio
+    async def test_send_command(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            job = await c.send_command(host="10.0.0.1", commands=["show version"])
+        assert isinstance(job, AsyncJob)
+        assert job.job_id == "abc-123"
+
+    @pytest.mark.asyncio
+    async def test_send_command_structured(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            job = await c.send_command_structured(host="10.0.0.1", commands=["show version"])
+        assert isinstance(job, AsyncJob)
+
+    @pytest.mark.asyncio
+    async def test_send_config(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            job = await c.send_config(host="10.0.0.1", config=["interface Gi0/1"])
+        assert isinstance(job, AsyncJob)
+
+    @pytest.mark.asyncio
+    async def test_get_command_result(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=JOB_RESULT)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.get_command_result("abc-123")
+        assert isinstance(result, JobResult)
+
+    @pytest.mark.asyncio
+    async def test_get_config_result(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=JOB_RESULT)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            await c.get_config_result("abc-123")
+        assert httpx_mock.get_requests()[0].url.path == "/v2/send-config/abc-123"
+
+
+class TestAsyncJobManagement:
+    @pytest.mark.asyncio
+    async def test_list_jobs(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"jobs": [], "pagination": {"page": 1, "per_page": 20, "total": 0, "pages": 0}})
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.list_jobs()
+        assert isinstance(result, ListJobsResponse)
+
+    @pytest.mark.asyncio
+    async def test_list_jobs_with_filters(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"jobs": [], "pagination": {"page": 2, "per_page": 10, "total": 0, "pages": 0}})
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            await c.list_jobs(page=2, per_page=10, status="failed", tag="env:prod")
+        params = httpx_mock.get_requests()[0].url.params
+        assert params["status"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_cancel_job(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=204)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            await c.cancel_job("abc-123")
+
+    @pytest.mark.asyncio
+    async def test_replay_job(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=202, json=JOB_SUBMISSION)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.replay_job("abc-123")
+        assert isinstance(result, JobSubmission)
+
+    @pytest.mark.asyncio
+    async def test_failed_jobs(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"jobs": [], "total": 0})
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.failed_jobs()
+        assert isinstance(result, FailedJobsResponse)
+
+
+class TestAsyncContextsAndKeys:
+    @pytest.mark.asyncio
+    async def test_list_contexts(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"contexts": [{"name": "default", "workers": 4, "queue_depth": 0}]})
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.list_contexts()
+        assert isinstance(result, ContextsResponse)
+
+    @pytest.mark.asyncio
+    async def test_list_api_keys(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json={"keys": [API_KEY_LIST_ITEM]})
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            keys = await c.list_api_keys()
+        assert len(keys) == 1
+
+    @pytest.mark.asyncio
+    async def test_create_api_key(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=201, json=API_KEY_RESPONSE)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.create_api_key(role="admin", contexts=["*"], ttl=3600)
+        assert isinstance(result, ApiKeyCreateResponse)
+        payload = json.loads(httpx_mock.get_requests()[0].read())
+        assert payload["ttl"] == 3600
+
+    @pytest.mark.asyncio
+    async def test_create_api_key_defaults(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=201, json=API_KEY_RESPONSE)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            await c.create_api_key()
+        payload = json.loads(httpx_mock.get_requests()[0].read())
+        assert payload == {"role": "admin"}
+
+    @pytest.mark.asyncio
+    async def test_delete_api_key(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=204)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            await c.delete_api_key("k-1")
+
+    @pytest.mark.asyncio
+    async def test_rotate_api_key(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=201, json={**API_KEY_RESPONSE, "token": "new"})
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.rotate_api_key("k-1")
+        assert result.token == "new"
+
+    @pytest.mark.asyncio
+    async def test_healthcheck(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(json=HEALTH_RESPONSE)
+        async with AsyncNaasClient(BASE, username="x", password="x") as c:
+            result = await c.healthcheck()
+        assert isinstance(result, HealthCheckResponse)
+
+
+class TestAsyncJob:
+    @pytest.mark.asyncio
+    async def test_poll_command(self) -> None:
+        client = AsyncMock()
+        client.get_command_result.return_value = JobResult.model_validate(JOB_RESULT)
+        job = AsyncJob(client, "abc-123", "command")
+        result = await job.poll()
+        assert result.status == "finished"
+
+    @pytest.mark.asyncio
+    async def test_poll_config(self) -> None:
+        client = AsyncMock()
+        client.get_config_result.return_value = JobResult.model_validate(JOB_RESULT)
+        job = AsyncJob(client, "abc-123", "config")
+        await job.poll()
+        client.get_config_result.assert_called_once_with("abc-123")
+
+    @pytest.mark.asyncio
+    @patch("naas_client.async_job.asyncio.sleep", new_callable=AsyncMock)
+    @patch("naas_client.async_job.asyncio.get_event_loop")
+    async def test_wait_returns_on_finished(self, mock_loop: AsyncMock, mock_sleep: AsyncMock) -> None:
+        mock_loop.return_value.time.side_effect = [0.0, 0.5]
+        client = AsyncMock()
+        client.get_command_result.return_value = JobResult.model_validate(JOB_RESULT)
+        job = AsyncJob(client, "abc-123", "command")
+        result = await job.wait(timeout=10)
+        assert result.status == "finished"
+
+    @pytest.mark.asyncio
+    @patch("naas_client.async_job.asyncio.sleep", new_callable=AsyncMock)
+    @patch("naas_client.async_job.asyncio.get_event_loop")
+    async def test_wait_raises_on_failure(self, mock_loop: AsyncMock, mock_sleep: AsyncMock) -> None:
+        mock_loop.return_value.time.side_effect = [0.0, 0.5]
+        client = AsyncMock()
+        client.get_command_result.return_value = JobResult.model_validate(
+            {"job_id": "abc-123", "status": "failed", "error": "Connection refused"}
+        )
+        job = AsyncJob(client, "abc-123", "command")
+        with pytest.raises(NaasJobError):
+            await job.wait(timeout=10)
+
+    @pytest.mark.asyncio
+    @patch("naas_client.async_job.asyncio.sleep", new_callable=AsyncMock)
+    @patch("naas_client.async_job.asyncio.get_event_loop")
+    async def test_wait_raises_on_failure_no_msg(self, mock_loop: AsyncMock, mock_sleep: AsyncMock) -> None:
+        mock_loop.return_value.time.side_effect = [0.0, 0.5]
+        client = AsyncMock()
+        client.get_command_result.return_value = JobResult.model_validate({"job_id": "abc-123", "status": "failed"})
+        job = AsyncJob(client, "abc-123", "command")
+        with pytest.raises(NaasJobError, match="Unknown error"):
+            await job.wait(timeout=10)
+
+    @pytest.mark.asyncio
+    @patch("naas_client.async_job.asyncio.sleep", new_callable=AsyncMock)
+    @patch("naas_client.async_job.asyncio.get_event_loop")
+    async def test_wait_timeout(self, mock_loop: AsyncMock, mock_sleep: AsyncMock) -> None:
+        mock_loop.return_value.time.side_effect = [0.0, 5.0, 11.0]
+        client = AsyncMock()
+        client.get_command_result.return_value = JobResult.model_validate({"job_id": "abc-123", "status": "queued"})
+        job = AsyncJob(client, "abc-123", "command")
+        with pytest.raises(NaasTimeoutError):
+            await job.wait(timeout=10)
+
+    @pytest.mark.asyncio
+    async def test_properties(self) -> None:
+        job = AsyncJob(AsyncMock(), "abc-123", "command")
+        assert job.is_complete is False
+        assert job.is_failed is False
+        assert job.result is None
+
+    @pytest.mark.asyncio
+    async def test_cancel(self) -> None:
+        client = AsyncMock()
+        job = AsyncJob(client, "abc-123", "command")
+        await job.cancel()
+        client.cancel_job.assert_called_once_with("abc-123")
+
+    @pytest.mark.asyncio
+    async def test_replay(self) -> None:
+        client = AsyncMock()
+        client.replay_job.return_value = JobSubmission.model_validate(JOB_SUBMISSION)
+        job = AsyncJob(client, "abc-123", "command")
+        new_job = await job.replay()
+        assert isinstance(new_job, AsyncJob)
+        assert new_job.job_id == "abc-123"
+
+
+class TestAsyncContextManager:
+    @pytest.mark.asyncio
+    async def test_close(self) -> None:
+        c = AsyncNaasClient(BASE, username="x", password="x")
+        await c.close()
+
+    def test_trailing_slash_stripped(self) -> None:
+        c = AsyncNaasClient("https://naas.test/", username="x", password="x")
+        assert c._base_url == "https://naas.test"

--- a/packages/naas/changes/373.feature.md
+++ b/packages/naas/changes/373.feature.md
@@ -1,0 +1,1 @@
+Add async client (AsyncNaasClient) and AsyncJob.


### PR DESCRIPTION
## Summary

Adds the async counterparts to the sync client — `AsyncNaasClient` and `AsyncJob`.

## Usage

```python
from naas_client import AsyncNaasClient

async with AsyncNaasClient("https://naas.example.com", api_key="my-key") as c:
    job = await c.send_command(host="10.0.0.1", platform="cisco_ios", commands=["show version"])
    result = await job.wait(timeout=30)
    print(result.results["show version"])
```

## Changes

- `AsyncNaasClient` — mirrors all sync client methods as `async`
- `AsyncJob` — `await job.wait()`, `await job.poll()`, `await job.cancel()`, `await job.replay()`
- Shared models, exceptions, and auth handling with sync client
- 94 total tests, 100% coverage

Closes #373