### PR TITLE
test: add naas-client integration tests against docker-compose NAAS (#383)

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -53,11 +53,32 @@ jobs:
         run: uv run mypy --config-file packages/naas-client/pyproject.toml packages/naas-client/naas_client/
 
       - name: Run tests
-        run: uv run --package naas-client pytest packages/naas-client/tests --cov=naas_client --cov-report=xml --cov-config=packages/naas-client/pyproject.toml
+        run: uv run --package naas-client pytest packages/naas-client/tests --ignore=packages/naas-client/tests/integration --cov=naas_client --cov-report=xml --cov-config=packages/naas-client/pyproject.toml
+
+  client-integration:
+    needs: [changes]
+    if: needs.changes.outputs.client == 'true'
+    runs-on: ubuntu-latest
+    name: client-integration
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.14'
+
+      - name: Install dependencies
+        run: |
+          uv sync --package naas --extra dev
+          uv sync --package naas-client --extra dev
+
+      - name: Run integration tests
+        run: uv run --package naas-client pytest packages/naas-client/tests/integration -v
 
   Client:
     if: always()
-    needs: [changes, client-tests]
+    needs: [changes, client-tests, client-integration]
     runs-on: ubuntu-latest
     steps:
       - name: Check results
@@ -66,7 +87,7 @@ jobs:
             echo "No client changes detected, skipping"
             exit 0
           fi
-          if [[ "${{ needs.client-tests.result }}" != "success" ]]; then
+          if [[ "${{ needs.client-tests.result }}" != "success" || "${{ needs.client-integration.result }}" != "success" ]]; then
             echo "Client tests failed"
             exit 1
           fi

--- a/packages/naas-client/naas_client/async_client.py
+++ b/packages/naas-client/naas_client/async_client.py
@@ -56,12 +56,11 @@ class AsyncNaasClient:
         elif username and password:
             auth = httpx.BasicAuth(username, password)
 
-        transport = httpx.AsyncHTTPTransport(retries=max_retries)
+        transport = httpx.AsyncHTTPTransport(retries=max_retries, verify=verify)
         self._client = httpx.AsyncClient(
             base_url=self._base_url,
             auth=auth,
             headers=headers,
-            verify=verify,
             timeout=timeout,
             transport=transport,
         )

--- a/packages/naas-client/naas_client/client.py
+++ b/packages/naas-client/naas_client/client.py
@@ -57,12 +57,11 @@ class NaasClient:
         elif username and password:
             auth = httpx.BasicAuth(username, password)
 
-        transport = httpx.HTTPTransport(retries=max_retries)
+        transport = httpx.HTTPTransport(retries=max_retries, verify=verify)
         self._client = httpx.Client(
             base_url=self._base_url,
             auth=auth,
             headers=headers,
-            verify=verify,
             timeout=timeout,
             transport=transport,
         )

--- a/packages/naas-client/tests/integration/conftest.py
+++ b/packages/naas-client/tests/integration/conftest.py
@@ -1,0 +1,71 @@
+"""Pytest configuration for naas-client integration tests.
+
+Reuses the NAAS docker-compose stack. Start it before running:
+    docker compose -f packages/naas/tests/integration/docker-compose.test.yml up -d --build --wait
+"""
+
+from __future__ import annotations
+
+import subprocess
+import time
+
+import httpx
+import pytest
+import pytest_asyncio
+
+from naas_client.async_client import AsyncNaasClient
+from naas_client.client import NaasClient
+
+COMPOSE_FILE = "packages/naas/tests/integration/docker-compose.test.yml"
+BASE_URL = "https://localhost:18443"
+USERNAME = "admin"
+PASSWORD = "admin"
+
+
+def _wait_for_api(url: str, timeout: int = 60) -> None:
+    """Poll healthcheck until the API is ready with workers."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            r = httpx.get(f"{url}/healthcheck", verify=False, timeout=2)
+            if r.status_code == 200:
+                data = r.json()
+                workers = data.get("components", {}).get("workers", {}).get("count", 0)
+                if workers > 0:
+                    return
+        except httpx.TransportError:
+            pass
+        time.sleep(2)
+    raise RuntimeError(f"API at {url} did not become ready in {timeout}s")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def docker_compose() -> None:  # type: ignore[misc]
+    """Start Docker Compose stack for integration tests."""
+    result = subprocess.run(
+        ["docker", "compose", "-f", COMPOSE_FILE, "up", "-d", "--build", "--wait"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"docker compose up failed (exit {result.returncode})\n{result.stderr}")
+
+    _wait_for_api(BASE_URL)
+    yield
+    subprocess.run(["docker", "compose", "-f", COMPOSE_FILE, "down", "-v"], check=False)
+
+
+@pytest.fixture
+def client() -> NaasClient:  # type: ignore[misc]
+    """Sync client for integration tests."""
+    c = NaasClient(BASE_URL, username=USERNAME, password=PASSWORD, verify=False)
+    yield c  # type: ignore[misc]
+    c.close()
+
+
+@pytest_asyncio.fixture
+async def async_client() -> AsyncNaasClient:  # type: ignore[misc]
+    """Async client for integration tests."""
+    c = AsyncNaasClient(BASE_URL, username=USERNAME, password=PASSWORD, verify=False)
+    yield c  # type: ignore[misc]
+    await c.close()

--- a/packages/naas-client/tests/integration/test_client_integration.py
+++ b/packages/naas-client/tests/integration/test_client_integration.py
@@ -1,0 +1,94 @@
+"""Integration tests for NaasClient against a running NAAS server."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from naas_client.client import NaasClient
+from naas_client.exceptions import NaasApiError, NaasAuthError
+from naas_client.models import HealthCheckResponse, JobStatus
+
+if TYPE_CHECKING:
+    from naas_client.async_client import AsyncNaasClient
+
+
+class TestHealthcheck:
+    def test_healthcheck(self, client: NaasClient) -> None:
+        health = client.healthcheck()
+        assert isinstance(health, HealthCheckResponse)
+        assert health.status == "healthy"
+        assert health.components.workers.count is not None
+        assert health.components.workers.count > 0
+
+
+class TestAuth:
+    def test_bad_api_key_rejected(self) -> None:
+        c = NaasClient("https://localhost:18443", api_key="invalid-jwt", verify=False)
+        with pytest.raises(NaasAuthError):
+            c.list_jobs()
+        c.close()
+
+
+class TestContexts:
+    def test_list_contexts(self, client: NaasClient) -> None:
+        result = client.list_contexts()
+        assert len(result.contexts) >= 1
+        names = [c.name for c in result.contexts]
+        assert "default" in names
+
+
+class TestJobs:
+    def test_list_jobs(self, client: NaasClient) -> None:
+        result = client.list_jobs()
+        assert result.pagination.page == 1
+
+    def test_cancel_nonexistent_job(self, client: NaasClient) -> None:
+        with pytest.raises(NaasApiError) as exc_info:
+            client.cancel_job("00000000-0000-0000-0000-000000000000")
+        assert exc_info.value.status_code in {404, 403}
+
+
+class TestSendCommand:
+    """Test send_command against cisshgo (if available) or expect a connection error."""
+
+    def test_send_command_and_poll(self, client: NaasClient) -> None:
+        """Submit a job and poll until it finishes or fails.
+
+        Without cisshgo running, the job will fail with a connection error —
+        that's fine, we're testing the client round-trip, not the device.
+        """
+        job = client.send_command(
+            host="cisshgo",
+            platform="cisco_ios",
+            port=10022,
+            commands=["show version"],
+        )
+        assert job.job_id
+
+        # Poll until terminal state
+        result = job.poll()
+        # Job may still be queued/started, keep polling
+        import time
+
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            result = job.poll()
+            if result.status in (JobStatus.FINISHED, JobStatus.FAILED):
+                break
+            time.sleep(1)
+
+        assert result.status in (JobStatus.FINISHED, JobStatus.FAILED)
+
+
+class TestAsyncClient:
+    @pytest.mark.asyncio
+    async def test_healthcheck(self, async_client: AsyncNaasClient) -> None:
+        health = await async_client.healthcheck()
+        assert health.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_list_contexts(self, async_client: AsyncNaasClient) -> None:
+        result = await async_client.list_contexts()
+        assert len(result.contexts) >= 1

--- a/packages/naas/changes/383.testing.md
+++ b/packages/naas/changes/383.testing.md
@@ -1,0 +1,1 @@
+Add naas-client integration tests against docker-compose NAAS.


### PR DESCRIPTION
## Summary

Adds integration tests that validate `NaasClient` and `AsyncNaasClient` against a running NAAS docker-compose stack.

## Tests

- Healthcheck (sync + async)
- Bad credentials → `NaasAuthError`
- List contexts (sync + async)
- List jobs with pagination
- Cancel nonexistent job → `NaasApiError`
- Send command → poll until terminal state

## CI Changes

- `client-integration` job added to `client.yml` — starts docker-compose, runs integration tests
- Unit test job now `--ignore`s integration dir
- Summary job checks both unit + integration results

Closes #383