### PR TITLE
feat: add CLI with Typer, config file support, and healthcheck command (#387)

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --package naas-client --extra dev
+        run: uv sync --package naas-client --extra dev --extra cli
 
       - name: Run ruff linter
         run: uv run ruff check --config packages/naas-client/pyproject.toml packages/naas-client/naas_client/ packages/naas-client/tests/ --exclude packages/naas-client/naas_client/_generated.py
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --package naas --extra dev
-          uv sync --package naas-client --extra dev
+          uv sync --package naas-client --extra dev --extra cli
 
       - name: Run integration tests
         run: uv run --package naas-client pytest packages/naas-client/tests/integration -v

--- a/packages/naas-client/naas_client/cli/__init__.py
+++ b/packages/naas-client/naas_client/cli/__init__.py
@@ -1,0 +1,108 @@
+"""NAAS CLI — command-line interface for NAAS (Netmiko As A Service)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from naas_client.cli.config import CliConfig
+from naas_client.cli.output import auto_formatter
+from naas_client.client import NaasClient
+from naas_client.exceptions import NaasApiError, NaasAuthError
+
+app = typer.Typer(
+    name="naas",
+    help="CLI for NAAS (Netmiko As A Service)",
+    no_args_is_help=True,
+)
+
+_UrlOpt = Annotated[str | None, typer.Option("--url", envvar="NAAS_URL", help="NAAS server URL")]
+_UsernameOpt = Annotated[str | None, typer.Option("--username", envvar="NAAS_USERNAME", help="Basic auth username")]
+_PasswordOpt = Annotated[str | None, typer.Option("--password", envvar="NAAS_PASSWORD", help="Basic auth password")]
+_ApiKeyOpt = Annotated[str | None, typer.Option("--api-key", envvar="NAAS_API_KEY", help="JWT API key")]
+_NoVerifyOpt = Annotated[bool, typer.Option("--no-verify", help="Disable TLS verification")]
+_FormatOpt = Annotated[str | None, typer.Option("--format", "-f", help="Output format: json or table")]
+_QuietOpt = Annotated[bool, typer.Option("--quiet", "-q", help="Suppress non-essential output")]
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        from naas_client import __version__
+
+        typer.echo(f"naas-client {__version__}")
+        raise typer.Exit()
+
+
+def _get_client(ctx: typer.Context) -> NaasClient:
+    """Build a NaasClient from resolved config."""
+    cfg: CliConfig = ctx.obj
+    if not cfg.url:
+        typer.echo("Error: NAAS URL required. Set --url, NAAS_URL, or url in config file.", err=True)
+        raise typer.Exit(2)
+    return NaasClient(
+        cfg.url,
+        username=cfg.username,
+        password=cfg.password,
+        api_key=cfg.api_key,
+        verify=cfg.verify,
+        timeout=cfg.timeout,
+    )
+
+
+def _handle_error(e: NaasApiError, cfg: CliConfig) -> None:
+    """Print error and exit with appropriate code."""
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.error(str(e), e.status_code), err=True)
+    code = 3 if isinstance(e, NaasAuthError) else 2
+    raise typer.Exit(code)
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    url: _UrlOpt = None,
+    username: _UsernameOpt = None,
+    password: _PasswordOpt = None,
+    api_key: _ApiKeyOpt = None,
+    no_verify: _NoVerifyOpt = False,
+    fmt: _FormatOpt = None,
+    quiet: _QuietOpt = False,
+    version: Annotated[
+        bool, typer.Option("--version", callback=_version_callback, is_eager=True, help="Show version")
+    ] = False,
+) -> None:
+    """NAAS CLI — command-line interface for NAAS (Netmiko As A Service)."""
+    cfg = CliConfig.load()
+
+    if url is not None:
+        cfg.url = url
+    if username is not None:
+        cfg.username = username
+    if password is not None:
+        cfg.password = password
+    if api_key is not None:
+        cfg.api_key = api_key
+    if no_verify:
+        cfg.verify = False
+    if fmt is not None:
+        cfg.format = fmt  # type: ignore[assignment]
+
+    ctx.obj = cfg
+
+
+@app.command()
+def healthcheck(ctx: typer.Context) -> None:
+    """Check NAAS server health."""
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        health = client.healthcheck()
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.healthcheck(health))

--- a/packages/naas-client/naas_client/cli/config.py
+++ b/packages/naas-client/naas_client/cli/config.py
@@ -1,0 +1,55 @@
+"""CLI configuration with Pydantic validation."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".config" / "naas" / "config.toml"
+
+
+class CliConfig(BaseModel):
+    """CLI configuration loaded from file, env vars, and flags."""
+
+    url: str = ""
+    username: str | None = None
+    password: str | None = None
+    api_key: str | None = None
+    verify: bool = True
+    format: Literal["json", "table"] = "table"
+    timeout: float = 60.0
+
+    @classmethod
+    def load(cls) -> CliConfig:
+        """Load config from file, then overlay env vars."""
+        data: dict[str, object] = {}
+
+        config_path = Path(os.environ.get("NAAS_CONFIG", str(_DEFAULT_CONFIG_PATH)))
+        if config_path.exists():
+            import tomllib
+
+            data = tomllib.loads(config_path.read_text())
+
+        # Env vars override file
+        env_map = {
+            "NAAS_URL": "url",
+            "NAAS_USERNAME": "username",
+            "NAAS_PASSWORD": "password",
+            "NAAS_API_KEY": "api_key",
+            "NAAS_TIMEOUT": "timeout",
+        }
+        for env_key, field in env_map.items():
+            val = os.environ.get(env_key)
+            if val is not None:
+                data[field] = val
+
+        if os.environ.get("NAAS_VERIFY", "").lower() == "false":
+            data["verify"] = False
+
+        if fmt := os.environ.get("NAAS_FORMAT"):
+            data["format"] = fmt
+
+        return cls.model_validate(data)

--- a/packages/naas-client/naas_client/cli/output.py
+++ b/packages/naas-client/naas_client/cli/output.py
@@ -1,0 +1,88 @@
+"""Output formatters for human and JSON modes."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from naas_client.models import HealthCheckResponse
+
+
+class Formatter(Protocol):
+    """Output formatter protocol."""
+
+    def healthcheck(self, data: HealthCheckResponse) -> str: ...
+    def error(self, message: str, status_code: int | None = None) -> str: ...
+    def message(self, text: str) -> str: ...
+
+
+class JsonFormatter:
+    """Machine-readable JSON output."""
+
+    def healthcheck(self, data: HealthCheckResponse) -> str:
+        return data.model_dump_json(indent=2)
+
+    def error(self, message: str, status_code: int | None = None) -> str:
+        d: dict[str, Any] = {"error": message}
+        if status_code is not None:
+            d["status_code"] = status_code
+        return json.dumps(d, indent=2)
+
+    def message(self, text: str) -> str:
+        return json.dumps({"message": text}, indent=2)
+
+
+class HumanFormatter:
+    """Human-readable Rich output."""
+
+    def healthcheck(self, data: HealthCheckResponse) -> str:
+        from rich.table import Table
+
+        status_icon = "●" if data.status == "healthy" else "○"
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Status")
+        table.add_column("Version")
+        table.add_column("Uptime")
+        table.add_column("Workers")
+        table.add_column("Queue")
+        table.add_column("Failed")
+
+        workers = data.components.workers
+        queue = data.components.queue
+        table.add_row(
+            f"{status_icon} {data.status}",
+            data.version,
+            f"{data.uptime_seconds}s",
+            str(workers.count if workers.count is not None else "?"),
+            str(queue.depth if queue.depth is not None else "?"),
+            str(data.components.failed_jobs or 0),
+        )
+
+        from io import StringIO
+
+        from rich.console import Console
+
+        buf = StringIO()
+        Console(file=buf, force_terminal=True).print(table)
+        return buf.getvalue().rstrip()
+
+    def error(self, message: str, status_code: int | None = None) -> str:
+        prefix = f"Error ({status_code})" if status_code else "Error"
+        return f"✗ {prefix}: {message}"
+
+    def message(self, text: str) -> str:
+        return text
+
+
+def auto_formatter(fmt: str | None = None) -> Formatter:
+    """Select formatter based on explicit format or TTY detection."""
+    if fmt == "json":
+        return JsonFormatter()
+    if fmt == "table":
+        return HumanFormatter()
+    # Auto-detect: human for TTY, JSON for pipes
+    if sys.stdout.isatty():
+        return HumanFormatter()
+    return JsonFormatter()

--- a/packages/naas-client/pyproject.toml
+++ b/packages/naas-client/pyproject.toml
@@ -23,6 +23,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+cli = [
+    "typer>=0.15",
+    "rich>=13.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-httpx>=0.35",
@@ -31,6 +35,9 @@ dev = [
     "mypy>=1.15",
     "ruff>=0.11",
 ]
+
+[project.scripts]
+naas = "naas_client.cli:app"
 
 [build-system]
 requires = ["hatchling"]

--- a/packages/naas-client/tests/test_cli.py
+++ b/packages/naas-client/tests/test_cli.py
@@ -1,0 +1,121 @@
+"""Tests for CLI app and healthcheck command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from naas_client.cli import app
+from naas_client.exceptions import NaasApiError, NaasAuthError
+from naas_client.models import HealthCheckResponse
+
+runner = CliRunner()
+
+HEALTH_DATA = HealthCheckResponse.model_validate(
+    {
+        "status": "healthy",
+        "version": "2.0.0",
+        "uptime_seconds": 100,
+        "components": {
+            "redis": {"status": "healthy"},
+            "queue": {"status": "healthy", "depth": 0},
+            "workers": {"status": "healthy", "count": 4, "active_jobs": 0},
+            "failed_jobs": 0,
+        },
+    }
+)
+
+
+class TestVersion:
+    def test_version_flag(self) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "naas-client" in result.output
+
+
+class TestHealthcheck:
+    @patch("naas_client.cli.NaasClient")
+    def test_healthcheck_json(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.healthcheck.return_value = HEALTH_DATA
+        mock_cls.return_value = mock_client
+
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "healthcheck"])
+        assert result.exit_code == 0
+        assert '"healthy"' in result.output
+        assert '"version"' in result.output
+        mock_client.close.assert_called_once()
+
+    @patch("naas_client.cli.NaasClient")
+    def test_healthcheck_table(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.healthcheck.return_value = HEALTH_DATA
+        mock_cls.return_value = mock_client
+
+        result = runner.invoke(app, ["--url", "https://test", "--format", "table", "healthcheck"])
+        assert result.exit_code == 0
+        assert "healthy" in result.output
+        mock_client.close.assert_called_once()
+
+    def test_healthcheck_no_url(self) -> None:
+        result = runner.invoke(app, ["healthcheck"], env={"NAAS_CONFIG": "/nonexistent"})
+        assert result.exit_code == 2
+        assert "URL required" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_healthcheck_api_error(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.healthcheck.side_effect = NaasApiError(500, "Internal Server Error")
+        mock_cls.return_value = mock_client
+
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "healthcheck"])
+        assert result.exit_code == 2
+
+    @patch("naas_client.cli.NaasClient")
+    def test_healthcheck_auth_error(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.healthcheck.side_effect = NaasAuthError(401, "Unauthorized")
+        mock_cls.return_value = mock_client
+
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "healthcheck"])
+        assert result.exit_code == 3
+
+
+class TestGlobalOptions:
+    @patch("naas_client.cli.NaasClient")
+    def test_all_options_passed(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.healthcheck.return_value = HEALTH_DATA
+        mock_cls.return_value = mock_client
+
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--username",
+                "admin",
+                "--password",
+                "secret",
+                "--no-verify",
+                "--format",
+                "json",
+                "healthcheck",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_cls.assert_called_once()
+        call_kwargs = mock_cls.call_args
+        assert call_kwargs.kwargs["username"] == "admin"
+        assert call_kwargs.kwargs["verify"] is False
+
+    @patch("naas_client.cli.NaasClient")
+    def test_api_key_option(self, mock_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_client.healthcheck.return_value = HEALTH_DATA
+        mock_cls.return_value = mock_client
+
+        result = runner.invoke(app, ["--url", "https://test", "--api-key", "jwt", "--format", "json", "healthcheck"])
+        assert result.exit_code == 0
+        assert mock_cls.call_args.kwargs["api_key"] == "jwt"

--- a/packages/naas-client/tests/test_cli_config.py
+++ b/packages/naas-client/tests/test_cli_config.py
@@ -1,0 +1,73 @@
+"""Tests for CLI config loading."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from naas_client.cli.config import CliConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+_ENV_KEYS = ("NAAS_URL", "NAAS_API_KEY", "NAAS_USERNAME", "NAAS_PASSWORD", "NAAS_VERIFY", "NAAS_FORMAT", "NAAS_TIMEOUT")
+
+
+def _clear_naas_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestCliConfig:
+    def test_defaults(self) -> None:
+        cfg = CliConfig()
+        assert cfg.url == ""
+        assert cfg.verify is True
+        assert cfg.format == "table"
+        assert cfg.timeout == 60.0
+
+    def test_load_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NAAS_URL", "https://test.example.com")
+        monkeypatch.setenv("NAAS_API_KEY", "my-key")
+        monkeypatch.setenv("NAAS_VERIFY", "false")
+        monkeypatch.setenv("NAAS_FORMAT", "json")
+        monkeypatch.setenv("NAAS_TIMEOUT", "120")
+        monkeypatch.setenv("NAAS_CONFIG", "/nonexistent/path")
+
+        cfg = CliConfig.load()
+        assert cfg.url == "https://test.example.com"
+        assert cfg.api_key == "my-key"
+        assert cfg.verify is False
+        assert cfg.format == "json"
+        assert cfg.timeout == 120.0
+
+    def test_load_from_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text('url = "https://file.example.com"\nverify = false\nformat = "json"\n')
+        monkeypatch.setenv("NAAS_CONFIG", str(config_file))
+        _clear_naas_env(monkeypatch)
+        monkeypatch.setenv("NAAS_CONFIG", str(config_file))
+
+        cfg = CliConfig.load()
+        assert cfg.url == "https://file.example.com"
+        assert cfg.verify is False
+
+    def test_env_overrides_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text('url = "https://file.example.com"\n')
+        monkeypatch.setenv("NAAS_CONFIG", str(config_file))
+        _clear_naas_env(monkeypatch)
+        monkeypatch.setenv("NAAS_CONFIG", str(config_file))
+        monkeypatch.setenv("NAAS_URL", "https://env.example.com")
+
+        cfg = CliConfig.load()
+        assert cfg.url == "https://env.example.com"
+
+    def test_load_no_config_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NAAS_CONFIG", "/nonexistent")
+        _clear_naas_env(monkeypatch)
+        monkeypatch.setenv("NAAS_CONFIG", "/nonexistent")
+
+        cfg = CliConfig.load()
+        assert cfg.url == ""

--- a/packages/naas-client/tests/test_cli_output.py
+++ b/packages/naas-client/tests/test_cli_output.py
@@ -1,0 +1,77 @@
+"""Tests for output formatters."""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from naas_client.cli.output import HumanFormatter, JsonFormatter, auto_formatter
+from naas_client.models import HealthCheckResponse
+
+if TYPE_CHECKING:
+    import pytest
+
+HEALTH_DATA = HealthCheckResponse.model_validate(
+    {
+        "status": "healthy",
+        "version": "2.0.0",
+        "uptime_seconds": 100,
+        "components": {
+            "redis": {"status": "healthy"},
+            "queue": {"status": "healthy", "depth": 0},
+            "workers": {"status": "healthy", "count": 4, "active_jobs": 0},
+            "failed_jobs": 0,
+        },
+    }
+)
+
+
+class TestJsonFormatter:
+    def test_healthcheck(self) -> None:
+        out = JsonFormatter().healthcheck(HEALTH_DATA)
+        assert '"healthy"' in out
+
+    def test_error(self) -> None:
+        out = JsonFormatter().error("bad", 500)
+        assert "500" in out
+
+    def test_error_no_code(self) -> None:
+        out = JsonFormatter().error("bad")
+        assert "status_code" not in out
+
+    def test_message(self) -> None:
+        out = JsonFormatter().message("hello")
+        assert '"hello"' in out
+
+
+class TestHumanFormatter:
+    def test_healthcheck(self) -> None:
+        out = HumanFormatter().healthcheck(HEALTH_DATA)
+        assert "healthy" in out
+
+    def test_error(self) -> None:
+        out = HumanFormatter().error("bad", 500)
+        assert "500" in out
+
+    def test_error_no_code(self) -> None:
+        out = HumanFormatter().error("bad")
+        assert "Error" in out
+
+    def test_message(self) -> None:
+        assert HumanFormatter().message("hello") == "hello"
+
+
+class TestAutoFormatter:
+    def test_explicit_json(self) -> None:
+        assert isinstance(auto_formatter("json"), JsonFormatter)
+
+    def test_explicit_table(self) -> None:
+        assert isinstance(auto_formatter("table"), HumanFormatter)
+
+    def test_auto_non_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: False)
+        assert isinstance(auto_formatter(), JsonFormatter)
+
+    def test_auto_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True)
+        assert isinstance(auto_formatter(), HumanFormatter)

--- a/packages/naas/changes/387.feature.md
+++ b/packages/naas/changes/387.feature.md
@@ -1,0 +1,1 @@
+Add CLI tool with Typer, config file support, and healthcheck command.

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1417,6 +1426,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cli = [
+    { name = "rich" },
+    { name = "typer" },
+]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -1440,9 +1453,11 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.35" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.15" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["cli", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "datamodel-code-generator", specifier = ">=0.56.0" }]
@@ -2167,6 +2182,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2326,6 +2350,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2b/e8/66e25efcc18542d58706ce4e50415710593721aae26e794ab1dec34fb66f/typeguard-4.5.1.tar.gz", hash = "sha256:f6f8ecbbc819c9bc749983cc67c02391e16a9b43b8b27f15dc70ed7c4a007274", size = 80121, upload-time = "2026-02-19T16:09:03.392Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/88/b55b3117287a8540b76dbdd87733808d4d01c8067a3b339408c250bb3600/typeguard-4.5.1-py3-none-any.whl", hash = "sha256:44d2bf329d49a244110a090b55f5f91aa82d9a9834ebfd30bcc73651e4a8cc40", size = 36745, upload-time = "2026-02-19T16:09:01.6Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/24/cb09efec5cc954f7f9b930bf8279447d24618bb6758d4f6adf2574c41780/typer-0.24.1.tar.gz", hash = "sha256:e39b4732d65fbdcde189ae76cf7cd48aeae72919dea1fdfc16593be016256b45", size = 118613, upload-time = "2026-02-21T16:54:40.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl", hash = "sha256:112c1f0ce578bfb4cab9ffdabc68f031416ebcc216536611ba21f04e9aa84c9e", size = 56085, upload-time = "2026-02-21T16:54:41.616Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the `naas` CLI tool built with Typer, wrapping the naas-client library.

## Install

```bash
pip install naas-client[cli]
```

## Usage

```bash
# Config via env vars
export NAAS_URL=https://naas.example.com
export NAAS_API_KEY=eyJ...

# Or via config file (~/.config/naas/config.toml)
# Or via CLI flags

naas healthcheck                    # Human-readable table
naas healthcheck --format json      # JSON for CI
naas --version
```

## Changes

- **`naas_client/cli/__init__.py`**: Typer app with global options, healthcheck command
- **`naas_client/cli/config.py`**: `CliConfig` Pydantic model — loads from config file → env vars → CLI flags
- **`naas_client/cli/output.py`**: `Formatter` protocol with `HumanFormatter` (Rich) and `JsonFormatter`
- **TTY auto-detection**: human output for terminals, JSON for pipes
- **Exit codes**: 0=success, 2=API error, 3=auth error
- **`cli` optional extra**: typer + rich
- 119 tests, 100% coverage

Closes #387