### PR TITLE
feat: add send-command and send-config CLI commands with --wait (#388)

### DIFF
--- a/packages/naas-client/naas_client/cli/__init__.py
+++ b/packages/naas-client/naas_client/cli/__init__.py
@@ -17,6 +17,11 @@ app = typer.Typer(
     no_args_is_help=True,
 )
 
+# Register subcommands
+from naas_client.cli.commands import commands_app  # noqa: E402
+
+app.registered_commands += commands_app.registered_commands
+
 _UrlOpt = Annotated[str | None, typer.Option("--url", envvar="NAAS_URL", help="NAAS server URL")]
 _UsernameOpt = Annotated[str | None, typer.Option("--username", envvar="NAAS_USERNAME", help="Basic auth username")]
 _PasswordOpt = Annotated[str | None, typer.Option("--password", envvar="NAAS_PASSWORD", help="Basic auth password")]

--- a/packages/naas-client/naas_client/cli/commands.py
+++ b/packages/naas-client/naas_client/cli/commands.py
@@ -1,0 +1,128 @@
+"""send-command and send-config CLI commands."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+import typer
+
+from naas_client.cli.output import auto_formatter
+from naas_client.exceptions import NaasApiError, NaasJobError, NaasTimeoutError
+
+if TYPE_CHECKING:
+    from naas_client.cli.config import CliConfig
+
+commands_app = typer.Typer()
+
+
+def _run_job(
+    ctx: typer.Context,
+    method: str,
+    host: str,
+    platform: str,
+    args: list[str],
+    port: int,
+    wait: bool,
+    timeout: float,
+    context: str,
+    save_config: bool = False,
+    commit: bool = False,
+    expect_string: str | None = None,
+) -> None:
+    """Submit a job and optionally wait for results."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    fmt = auto_formatter(cfg.format)
+
+    payload: dict[str, object] = {
+        "host": host,
+        "platform": platform,
+        "port": port,
+        "context": context,
+    }
+
+    if method == "send_config":
+        payload["config"] = args
+        if save_config:
+            payload["save_config"] = True
+        if commit:
+            payload["commit"] = True
+    else:
+        payload["commands"] = args
+        if expect_string:
+            payload["expect_string"] = expect_string
+
+    try:
+        job = client.send_config(**payload) if method == "send_config" else client.send_command(**payload)
+
+        if not wait:
+            typer.echo(fmt.job_submitted(job.job_id))
+            return
+
+        typer.echo(fmt.waiting(job.job_id), err=True)
+        result = job.wait(timeout=timeout)
+        typer.echo(fmt.job_result(result))
+
+    except NaasJobError as e:
+        typer.echo(fmt.job_error(e.job_id, e.error), err=True)
+        raise typer.Exit(1) from None
+    except NaasTimeoutError as e:
+        typer.echo(fmt.error(str(e)), err=True)
+        raise typer.Exit(4) from None
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+    finally:
+        client.close()
+
+
+@commands_app.command("send-command")
+def send_command(
+    ctx: typer.Context,
+    commands: Annotated[list[str], typer.Argument(help="Commands to execute on the device")],
+    host: Annotated[str, typer.Option("--host", "-h", help="Device hostname or IP")] = "",
+    platform: Annotated[str, typer.Option("--platform", "-p", help="Netmiko platform")] = "cisco_ios",
+    port: Annotated[int, typer.Option("--port", help="SSH port")] = 22,
+    wait: Annotated[bool, typer.Option("--wait", "-w", help="Wait for job to complete")] = False,
+    timeout: Annotated[float, typer.Option("--timeout", "-t", help="Wait timeout in seconds")] = 60.0,
+    context: Annotated[str, typer.Option("--context", help="Routing context")] = "default",
+    expect_string: Annotated[str | None, typer.Option("--expect-string", help="Regex to match in output")] = None,
+) -> None:
+    """Submit a send-command job to a network device."""
+    if not host:
+        typer.echo("Error: --host is required", err=True)
+        raise typer.Exit(2)
+    _run_job(ctx, "send_command", host, platform, commands, port, wait, timeout, context, expect_string=expect_string)
+
+
+@commands_app.command("send-config")
+def send_config(
+    ctx: typer.Context,
+    config_lines: Annotated[list[str], typer.Argument(help="Configuration lines to apply")],
+    host: Annotated[str, typer.Option("--host", "-h", help="Device hostname or IP")] = "",
+    platform: Annotated[str, typer.Option("--platform", "-p", help="Netmiko platform")] = "cisco_ios",
+    port: Annotated[int, typer.Option("--port", help="SSH port")] = 22,
+    wait: Annotated[bool, typer.Option("--wait", "-w", help="Wait for job to complete")] = False,
+    timeout: Annotated[float, typer.Option("--timeout", "-t", help="Wait timeout in seconds")] = 60.0,
+    context: Annotated[str, typer.Option("--context", help="Routing context")] = "default",
+    save_config: Annotated[bool, typer.Option("--save-config", help="Save config after applying")] = False,
+    commit: Annotated[bool, typer.Option("--commit", help="Commit config (Juniper)")] = False,
+) -> None:
+    """Submit a send-config job to a network device."""
+    if not host:
+        typer.echo("Error: --host is required", err=True)
+        raise typer.Exit(2)
+    _run_job(
+        ctx,
+        "send_config",
+        host,
+        platform,
+        config_lines,
+        port,
+        wait,
+        timeout,
+        context,
+        save_config=save_config,
+        commit=commit,
+    )

--- a/packages/naas-client/naas_client/cli/output.py
+++ b/packages/naas-client/naas_client/cli/output.py
@@ -7,7 +7,7 @@ import sys
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from naas_client.models import HealthCheckResponse
+    from naas_client.models import HealthCheckResponse, JobResult
 
 
 class Formatter(Protocol):
@@ -16,6 +16,10 @@ class Formatter(Protocol):
     def healthcheck(self, data: HealthCheckResponse) -> str: ...
     def error(self, message: str, status_code: int | None = None) -> str: ...
     def message(self, text: str) -> str: ...
+    def job_submitted(self, job_id: str) -> str: ...
+    def waiting(self, job_id: str) -> str: ...
+    def job_result(self, result: JobResult) -> str: ...
+    def job_error(self, job_id: str, error: str) -> str: ...
 
 
 class JsonFormatter:
@@ -32,6 +36,18 @@ class JsonFormatter:
 
     def message(self, text: str) -> str:
         return json.dumps({"message": text}, indent=2)
+
+    def job_submitted(self, job_id: str) -> str:
+        return json.dumps({"job_id": job_id}, indent=2)
+
+    def waiting(self, job_id: str) -> str:
+        return ""
+
+    def job_result(self, result: JobResult) -> str:
+        return result.model_dump_json(indent=2)
+
+    def job_error(self, job_id: str, error: str) -> str:
+        return json.dumps({"job_id": job_id, "status": "failed", "error": error}, indent=2)
 
 
 class HumanFormatter:
@@ -74,6 +90,27 @@ class HumanFormatter:
 
     def message(self, text: str) -> str:
         return text
+
+    def job_submitted(self, job_id: str) -> str:
+        return f"Job submitted: {job_id}"
+
+    def waiting(self, job_id: str) -> str:
+        return f"⠋ Waiting for job {job_id}..."
+
+    def job_result(self, result: JobResult) -> str:
+        from naas_client.models import JobStatus
+
+        icon = "✓" if result.status == JobStatus.FINISHED else "✗"
+        lines = [f"{icon} Job {result.job_id}: {result.status}"]
+        if result.results:
+            for cmd, output in result.results.items():
+                lines.append(f"\n{cmd}\n{'─' * len(cmd)}\n{output}")
+        if result.error:
+            lines.append(f"\nError: {result.error}")
+        return "\n".join(lines)
+
+    def job_error(self, job_id: str, error: str) -> str:
+        return f"✗ Job {job_id} failed: {error}"
 
 
 def auto_formatter(fmt: str | None = None) -> Formatter:

--- a/packages/naas-client/tests/test_cli_commands.py
+++ b/packages/naas-client/tests/test_cli_commands.py
@@ -1,0 +1,277 @@
+"""Tests for send-command and send-config CLI commands."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from naas_client.cli import app
+from naas_client.exceptions import NaasApiError, NaasJobError, NaasTimeoutError
+from naas_client.models import JobResult
+
+runner = CliRunner()
+
+FINISHED_RESULT = JobResult.model_validate(
+    {
+        "job_id": "abc-123",
+        "status": "finished",
+        "results": {"show version": "Cisco IOS 15.1"},
+    }
+)
+
+FAILED_RESULT = JobResult.model_validate(
+    {
+        "job_id": "abc-123",
+        "status": "failed",
+        "error": "Connection refused",
+    }
+)
+
+
+def _mock_client(job_result: JobResult | None = None) -> MagicMock:
+    mock = MagicMock()
+    mock_job = MagicMock()
+    mock_job.job_id = "abc-123"
+    mock_job.wait.return_value = job_result or FINISHED_RESULT
+    mock.send_command.return_value = mock_job
+    mock.send_config.return_value = mock_job
+    return mock
+
+
+class TestSendCommand:
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_no_wait_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _mock_client()
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "abc-123" in result.output
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_wait_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _mock_client()
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "--wait",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "finished" in result.output
+        assert "Cisco IOS" in result.output
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_wait_human(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _mock_client()
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "table",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "--wait",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "✓" in result.output
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_job_failed_exit_1(self, mock_cls: MagicMock) -> None:
+        mock = _mock_client()
+        mock.send_command.return_value.wait.side_effect = NaasJobError("abc-123", "Connection refused")
+        mock_cls.return_value = mock
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "--wait",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 1
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_timeout_exit_4(self, mock_cls: MagicMock) -> None:
+        mock = _mock_client()
+        mock.send_command.return_value.wait.side_effect = NaasTimeoutError("timed out")
+        mock_cls.return_value = mock
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "--wait",
+                "--timeout",
+                "1",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 4
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_api_error_exit_2(self, mock_cls: MagicMock) -> None:
+        mock = _mock_client()
+        mock.send_command.side_effect = NaasApiError(500, "ISE")
+        mock_cls.return_value = mock
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 2
+
+    def test_missing_host(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "send-command",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 2
+        assert "host" in result.output.lower()
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_expect_string(self, mock_cls: MagicMock) -> None:
+        mock = _mock_client()
+        mock_cls.return_value = mock
+        runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-command",
+                "--host",
+                "10.0.0.1",
+                "--expect-string",
+                "Router>",
+                "show version",
+            ],
+        )
+        call_kwargs = mock.send_command.call_args.kwargs
+        assert call_kwargs["expect_string"] == "Router>"
+
+
+class TestSendConfig:
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_no_wait(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _mock_client()
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-config",
+                "--host",
+                "10.0.0.1",
+                "interface Gi0/1",
+                "shutdown",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "abc-123" in result.output
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_wait(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = _mock_client()
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-config",
+                "--host",
+                "10.0.0.1",
+                "--wait",
+                "interface Gi0/1",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "finished" in result.output
+
+    @patch("naas_client.cli.NaasClient", autospec=True)
+    def test_save_config_and_commit(self, mock_cls: MagicMock) -> None:
+        mock = _mock_client()
+        mock_cls.return_value = mock
+        runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "send-config",
+                "--host",
+                "10.0.0.1",
+                "--save-config",
+                "--commit",
+                "set system hostname test",
+            ],
+        )
+        call_kwargs = mock.send_config.call_args.kwargs
+        assert call_kwargs["save_config"] is True
+        assert call_kwargs["commit"] is True
+
+    def test_missing_host(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "send-config",
+                "interface Gi0/1",
+            ],
+        )
+        assert result.exit_code == 2

--- a/packages/naas-client/tests/test_cli_output.py
+++ b/packages/naas-client/tests/test_cli_output.py
@@ -43,6 +43,23 @@ class TestJsonFormatter:
         out = JsonFormatter().message("hello")
         assert '"hello"' in out
 
+    def test_job_submitted(self) -> None:
+        assert "abc-123" in JsonFormatter().job_submitted("abc-123")
+
+    def test_waiting_empty(self) -> None:
+        assert JsonFormatter().waiting("abc-123") == ""
+
+    def test_job_result(self) -> None:
+        from naas_client.models import JobResult
+
+        r = JobResult.model_validate({"job_id": "abc-123", "status": "finished", "results": {"show version": "Cisco"}})
+        out = JsonFormatter().job_result(r)
+        assert "finished" in out
+
+    def test_job_error(self) -> None:
+        out = JsonFormatter().job_error("abc-123", "Connection refused")
+        assert "failed" in out
+
 
 class TestHumanFormatter:
     def test_healthcheck(self) -> None:
@@ -59,6 +76,32 @@ class TestHumanFormatter:
 
     def test_message(self) -> None:
         assert HumanFormatter().message("hello") == "hello"
+
+    def test_job_submitted(self) -> None:
+        assert "abc-123" in HumanFormatter().job_submitted("abc-123")
+
+    def test_waiting(self) -> None:
+        assert "abc-123" in HumanFormatter().waiting("abc-123")
+
+    def test_job_result_finished(self) -> None:
+        from naas_client.models import JobResult
+
+        r = JobResult.model_validate({"job_id": "abc-123", "status": "finished", "results": {"show version": "Cisco"}})
+        out = HumanFormatter().job_result(r)
+        assert "✓" in out
+        assert "Cisco" in out
+
+    def test_job_result_failed(self) -> None:
+        from naas_client.models import JobResult
+
+        r = JobResult.model_validate({"job_id": "abc-123", "status": "failed", "error": "timeout"})
+        out = HumanFormatter().job_result(r)
+        assert "✗" in out
+        assert "timeout" in out
+
+    def test_job_error(self) -> None:
+        out = HumanFormatter().job_error("abc-123", "Connection refused")
+        assert "failed" in out
 
 
 class TestAutoFormatter:

--- a/packages/naas/changes/388.feature.md
+++ b/packages/naas/changes/388.feature.md
@@ -1,0 +1,1 @@
+Add send-command and send-config CLI commands with --wait support.


### PR DESCRIPTION
## Summary

Adds `naas send-command` and `naas send-config` CLI commands.

## Usage

```bash
# Submit and get job_id immediately
naas send-command --host 10.0.0.1 --platform cisco_ios "show version"

# Submit and wait for results
naas send-command --host 10.0.0.1 --wait "show version" "show interfaces"

# JSON output for CI
naas --format json send-command --host 10.0.0.1 --wait "show version"

# Config with save
naas send-config --host 10.0.0.1 --wait --save-config "interface Gi0/1" "shutdown"
```

## Exit Codes

- 0: success/finished
- 1: job failed
- 2: API error / missing required option
- 3: auth error
- 4: timeout

## Changes

- `naas_client/cli/commands.py`: send-command and send-config with all options
- `naas_client/cli/output.py`: Added job_submitted, waiting, job_result, job_error to both formatters
- 140 tests, 100% coverage

Closes #388