### PR TITLE
feat: add jobs CLI subcommand group (#389)

### DIFF
--- a/packages/naas-client/naas_client/cli/__init__.py
+++ b/packages/naas-client/naas_client/cli/__init__.py
@@ -22,6 +22,10 @@ from naas_client.cli.commands import commands_app  # noqa: E402
 
 app.registered_commands += commands_app.registered_commands
 
+from naas_client.cli.jobs import jobs_app  # noqa: E402
+
+app.add_typer(jobs_app)
+
 _UrlOpt = Annotated[str | None, typer.Option("--url", envvar="NAAS_URL", help="NAAS server URL")]
 _UsernameOpt = Annotated[str | None, typer.Option("--username", envvar="NAAS_USERNAME", help="Basic auth username")]
 _PasswordOpt = Annotated[str | None, typer.Option("--password", envvar="NAAS_PASSWORD", help="Basic auth password")]

--- a/packages/naas-client/naas_client/cli/jobs.py
+++ b/packages/naas-client/naas_client/cli/jobs.py
@@ -1,0 +1,131 @@
+"""Jobs CLI subcommand group."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+import typer
+
+from naas_client.cli.output import auto_formatter
+from naas_client.exceptions import NaasApiError
+from naas_client.models import JobStatus
+
+if TYPE_CHECKING:
+    from naas_client.cli.config import CliConfig
+
+jobs_app = typer.Typer(name="jobs", help="Job management commands")
+
+
+@jobs_app.command("list")
+def list_jobs(
+    ctx: typer.Context,
+    status: Annotated[
+        str | None, typer.Option("--status", "-s", help="Filter: queued, started, finished, failed")
+    ] = None,
+    tag: Annotated[str | None, typer.Option("--tag", help="Filter by tag (key:value)")] = None,
+    page: Annotated[int, typer.Option("--page", help="Page number")] = 1,
+    per_page: Annotated[int, typer.Option("--per-page", help="Results per page")] = 20,
+) -> None:
+    """List jobs with pagination and filtering."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        result = client.list_jobs(page=page, per_page=per_page, status=status, tag=tag)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.jobs_list(result))
+
+
+@jobs_app.command("get")
+def get_job(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Job ID")],
+) -> None:
+    """Get job status and results."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        result = client.get_command_result(job_id)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.job_result(result))
+
+    if result.status == JobStatus.FAILED:
+        raise typer.Exit(1)
+
+
+@jobs_app.command("cancel")
+def cancel_job(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Job ID")],
+) -> None:
+    """Cancel a queued or running job."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        client.cancel_job(job_id)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.message(f"Job {job_id} cancelled"))
+
+
+@jobs_app.command("replay")
+def replay_job(
+    ctx: typer.Context,
+    job_id: Annotated[str, typer.Argument(help="Job ID")],
+) -> None:
+    """Re-enqueue a failed job."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        submission = client.replay_job(job_id)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.job_submitted(submission.job_id))
+
+
+@jobs_app.command("failed")
+def failed_jobs(ctx: typer.Context) -> None:
+    """List failed jobs."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        result = client.failed_jobs()
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.failed_jobs(result))

--- a/packages/naas-client/naas_client/cli/output.py
+++ b/packages/naas-client/naas_client/cli/output.py
@@ -7,7 +7,7 @@ import sys
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from naas_client.models import HealthCheckResponse, JobResult
+    from naas_client.models import FailedJobsResponse, HealthCheckResponse, JobResult, ListJobsResponse
 
 
 class Formatter(Protocol):
@@ -20,6 +20,8 @@ class Formatter(Protocol):
     def waiting(self, job_id: str) -> str: ...
     def job_result(self, result: JobResult) -> str: ...
     def job_error(self, job_id: str, error: str) -> str: ...
+    def jobs_list(self, data: ListJobsResponse) -> str: ...
+    def failed_jobs(self, data: FailedJobsResponse) -> str: ...
 
 
 class JsonFormatter:
@@ -48,6 +50,12 @@ class JsonFormatter:
 
     def job_error(self, job_id: str, error: str) -> str:
         return json.dumps({"job_id": job_id, "status": "failed", "error": error}, indent=2)
+
+    def jobs_list(self, data: ListJobsResponse) -> str:
+        return data.model_dump_json(indent=2)
+
+    def failed_jobs(self, data: FailedJobsResponse) -> str:
+        return data.model_dump_json(indent=2)
 
 
 class HumanFormatter:
@@ -111,6 +119,42 @@ class HumanFormatter:
 
     def job_error(self, job_id: str, error: str) -> str:
         return f"✗ Job {job_id} failed: {error}"
+
+    def jobs_list(self, data: ListJobsResponse) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Job ID")
+        table.add_column("Status")
+        table.add_column("Created")
+        table.add_column("Tags")
+        for j in data.jobs:
+            table.add_row(j.job_id, j.status, j.created_at or "", str(j.tags or ""))
+        buf = StringIO()
+        Console(file=buf, force_terminal=True).print(table)
+        p = data.pagination
+        return f"{buf.getvalue().rstrip()}\nPage {p.page}/{p.pages} ({p.total} total)"
+
+    def failed_jobs(self, data: FailedJobsResponse) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Job ID")
+        table.add_column("Host")
+        table.add_column("Platform")
+        table.add_column("Failed At")
+        table.add_column("Error")
+        for j in data.jobs:
+            table.add_row(j.job_id, j.host or "", j.platform or "", j.failed_at or "", j.error or "")
+        buf = StringIO()
+        Console(file=buf, force_terminal=True).print(table)
+        return f"{buf.getvalue().rstrip()}\n{data.total} failed job(s)"
 
 
 def auto_formatter(fmt: str | None = None) -> Formatter:

--- a/packages/naas-client/tests/test_cli_jobs.py
+++ b/packages/naas-client/tests/test_cli_jobs.py
@@ -1,0 +1,174 @@
+"""Tests for jobs CLI subcommand group."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from naas_client.cli import app
+from naas_client.exceptions import NaasApiError
+from naas_client.models import (
+    FailedJobsResponse,
+    JobResult,
+    JobSubmission,
+    ListJobsResponse,
+)
+
+runner = CliRunner()
+
+JOBS_LIST = ListJobsResponse.model_validate(
+    {
+        "jobs": [{"job_id": "abc-123", "status": "finished", "created_at": "2026-04-10T00:00:00Z", "tags": None}],
+        "pagination": {"page": 1, "per_page": 20, "total": 1, "pages": 1},
+    }
+)
+
+FAILED_LIST = FailedJobsResponse.model_validate(
+    {
+        "jobs": [
+            {
+                "job_id": "def-456",
+                "host": "10.0.0.1",
+                "platform": "cisco_ios",
+                "failed_at": "2026-04-10T00:00:00Z",
+                "error": "timeout",
+            }
+        ],
+        "total": 1,
+    }
+)
+
+JOB_FINISHED = JobResult.model_validate(
+    {"job_id": "abc-123", "status": "finished", "results": {"show version": "Cisco"}}
+)
+JOB_FAILED = JobResult.model_validate({"job_id": "abc-123", "status": "failed", "error": "Connection refused"})
+JOB_SUBMISSION = JobSubmission.model_validate(
+    {
+        "job_id": "new-789",
+        "message": "Replayed",
+        "queue_position": 0,
+        "enqueued_at": "2026-04-10T00:00:00Z",
+        "timeout": 300,
+    }
+)
+
+
+class TestJobsList:
+    @patch("naas_client.cli.NaasClient")
+    def test_list_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_jobs=MagicMock(return_value=JOBS_LIST))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "list"])
+        assert result.exit_code == 0
+        assert "abc-123" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_list_table(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_jobs=MagicMock(return_value=JOBS_LIST))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "table", "jobs", "list"])
+        assert result.exit_code == 0
+        assert "abc-123" in result.output
+        assert "Page 1/1" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_list_with_filters(self, mock_cls: MagicMock) -> None:
+        mock = MagicMock(list_jobs=MagicMock(return_value=JOBS_LIST))
+        mock_cls.return_value = mock
+        runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "jobs",
+                "list",
+                "--status",
+                "failed",
+                "--tag",
+                "env:prod",
+                "--page",
+                "2",
+            ],
+        )
+        mock.list_jobs.assert_called_once_with(page=2, per_page=20, status="failed", tag="env:prod")
+
+    @patch("naas_client.cli.NaasClient")
+    def test_list_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_jobs=MagicMock(side_effect=NaasApiError(500, "ISE")))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "list"])
+        assert result.exit_code == 2
+
+
+class TestJobsGet:
+    @patch("naas_client.cli.NaasClient")
+    def test_get_finished(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(get_command_result=MagicMock(return_value=JOB_FINISHED))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "get", "abc-123"])
+        assert result.exit_code == 0
+        assert "finished" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_get_failed_exit_1(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(get_command_result=MagicMock(return_value=JOB_FAILED))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "get", "abc-123"])
+        assert result.exit_code == 1
+
+    @patch("naas_client.cli.NaasClient")
+    def test_get_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(get_command_result=MagicMock(side_effect=NaasApiError(404, "Not found")))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "get", "abc-123"])
+        assert result.exit_code == 2
+
+
+class TestJobsCancel:
+    @patch("naas_client.cli.NaasClient")
+    def test_cancel(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(cancel_job=MagicMock())
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "cancel", "abc-123"])
+        assert result.exit_code == 0
+        assert "cancelled" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_cancel_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(cancel_job=MagicMock(side_effect=NaasApiError(404, "Not found")))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "cancel", "abc-123"])
+        assert result.exit_code == 2
+
+
+class TestJobsReplay:
+    @patch("naas_client.cli.NaasClient")
+    def test_replay(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(replay_job=MagicMock(return_value=JOB_SUBMISSION))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "replay", "abc-123"])
+        assert result.exit_code == 0
+        assert "new-789" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_replay_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(replay_job=MagicMock(side_effect=NaasApiError(404, "Not found")))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "replay", "abc-123"])
+        assert result.exit_code == 2
+
+
+class TestJobsFailed:
+    @patch("naas_client.cli.NaasClient")
+    def test_failed_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(failed_jobs=MagicMock(return_value=FAILED_LIST))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "failed"])
+        assert result.exit_code == 0
+        assert "def-456" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_failed_table(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(failed_jobs=MagicMock(return_value=FAILED_LIST))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "table", "jobs", "failed"])
+        assert result.exit_code == 0
+        assert "timeout" in result.output
+        assert "1 failed" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_failed_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(failed_jobs=MagicMock(side_effect=NaasApiError(500, "ISE")))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "jobs", "failed"])
+        assert result.exit_code == 2

--- a/packages/naas/changes/389.feature.md
+++ b/packages/naas/changes/389.feature.md
@@ -1,0 +1,1 @@
+Add jobs CLI subcommand group (list, get, cancel, replay, failed).


### PR DESCRIPTION
## Summary

Adds the `naas jobs` subcommand group for job management from the CLI.

## Commands

```bash
naas jobs list [--status failed] [--tag env:prod] [--page 2]
naas jobs get abc-123          # exit 1 if job failed
naas jobs cancel abc-123
naas jobs replay abc-123
naas jobs failed
```

## Changes

- `naas_client/cli/jobs.py`: All 5 job management commands
- `naas_client/cli/output.py`: Added `jobs_list` and `failed_jobs` to both formatters
- Human output: Rich tables with pagination info and failure details
- JSON output: model dumps
- `jobs get` exits 1 if job status is failed (CI-friendly)
- 154 tests, 100% coverage

Closes #389