### PR TITLE
feat: add contexts and api-keys CLI subcommands (#390)

### DIFF
--- a/packages/naas-client/naas_client/cli/__init__.py
+++ b/packages/naas-client/naas_client/cli/__init__.py
@@ -26,6 +26,12 @@ from naas_client.cli.jobs import jobs_app  # noqa: E402
 
 app.add_typer(jobs_app)
 
+from naas_client.cli.api_keys import api_keys_app  # noqa: E402
+from naas_client.cli.contexts import contexts_app  # noqa: E402
+
+app.add_typer(contexts_app)
+app.add_typer(api_keys_app)
+
 _UrlOpt = Annotated[str | None, typer.Option("--url", envvar="NAAS_URL", help="NAAS server URL")]
 _UsernameOpt = Annotated[str | None, typer.Option("--username", envvar="NAAS_USERNAME", help="Basic auth username")]
 _PasswordOpt = Annotated[str | None, typer.Option("--password", envvar="NAAS_PASSWORD", help="Basic auth password")]

--- a/packages/naas-client/naas_client/cli/api_keys.py
+++ b/packages/naas-client/naas_client/cli/api_keys.py
@@ -1,0 +1,103 @@
+"""API keys CLI subcommand group."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated
+
+import typer
+
+from naas_client.cli.output import auto_formatter
+from naas_client.exceptions import NaasApiError
+
+if TYPE_CHECKING:
+    from naas_client.cli.config import CliConfig
+
+api_keys_app = typer.Typer(name="api-keys", help="API key management commands")
+
+
+@api_keys_app.command("list")
+def list_api_keys(ctx: typer.Context) -> None:
+    """List active API keys (metadata only)."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        keys = client.list_api_keys()
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.api_keys_list(keys))
+
+
+@api_keys_app.command("create")
+def create_api_key(
+    ctx: typer.Context,
+    role: Annotated[str, typer.Option("--role", "-r", help="Key role")] = "admin",
+    contexts: Annotated[str | None, typer.Option("--contexts", "-c", help="Comma-separated contexts")] = None,
+    ttl: Annotated[int | None, typer.Option("--ttl", help="TTL in seconds")] = None,
+) -> None:
+    """Create a new API key."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    ctx_list = [c.strip() for c in contexts.split(",")] if contexts else None
+    try:
+        result = client.create_api_key(role=role, contexts=ctx_list, ttl=ttl)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.api_key_created(result))
+
+
+@api_keys_app.command("delete")
+def delete_api_key(
+    ctx: typer.Context,
+    key_id: Annotated[str, typer.Argument(help="Key ID to revoke")],
+) -> None:
+    """Revoke an API key."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        client.delete_api_key(key_id)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.message(f"API key {key_id} revoked"))
+
+
+@api_keys_app.command("rotate")
+def rotate_api_key(
+    ctx: typer.Context,
+    key_id: Annotated[str, typer.Argument(help="Key ID to rotate")],
+) -> None:
+    """Rotate an API key. Returns a new token."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        result = client.rotate_api_key(key_id)
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.api_key_created(result))

--- a/packages/naas-client/naas_client/cli/contexts.py
+++ b/packages/naas-client/naas_client/cli/contexts.py
@@ -1,0 +1,34 @@
+"""Contexts CLI subcommand."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import typer
+
+from naas_client.cli.output import auto_formatter
+from naas_client.exceptions import NaasApiError
+
+if TYPE_CHECKING:
+    from naas_client.cli.config import CliConfig
+
+contexts_app = typer.Typer(name="contexts", help="Routing context commands")
+
+
+@contexts_app.command("list")
+def list_contexts(ctx: typer.Context) -> None:
+    """List active routing contexts."""
+    from naas_client.cli import _get_client, _handle_error
+
+    cfg: CliConfig = ctx.obj
+    client = _get_client(ctx)
+    try:
+        result = client.list_contexts()
+    except NaasApiError as e:
+        _handle_error(e, cfg)
+        return  # pragma: no cover
+    finally:
+        client.close()
+
+    fmt = auto_formatter(cfg.format)
+    typer.echo(fmt.contexts_list(result))

--- a/packages/naas-client/naas_client/cli/output.py
+++ b/packages/naas-client/naas_client/cli/output.py
@@ -7,7 +7,15 @@ import sys
 from typing import TYPE_CHECKING, Any, Protocol
 
 if TYPE_CHECKING:
-    from naas_client.models import FailedJobsResponse, HealthCheckResponse, JobResult, ListJobsResponse
+    from naas_client.models import (
+        ApiKeyCreateResponse,
+        ApiKeyListItem,
+        ContextsResponse,
+        FailedJobsResponse,
+        HealthCheckResponse,
+        JobResult,
+        ListJobsResponse,
+    )
 
 
 class Formatter(Protocol):
@@ -22,6 +30,9 @@ class Formatter(Protocol):
     def job_error(self, job_id: str, error: str) -> str: ...
     def jobs_list(self, data: ListJobsResponse) -> str: ...
     def failed_jobs(self, data: FailedJobsResponse) -> str: ...
+    def contexts_list(self, data: ContextsResponse) -> str: ...
+    def api_keys_list(self, keys: list[ApiKeyListItem]) -> str: ...
+    def api_key_created(self, data: ApiKeyCreateResponse) -> str: ...
 
 
 class JsonFormatter:
@@ -55,6 +66,15 @@ class JsonFormatter:
         return data.model_dump_json(indent=2)
 
     def failed_jobs(self, data: FailedJobsResponse) -> str:
+        return data.model_dump_json(indent=2)
+
+    def contexts_list(self, data: ContextsResponse) -> str:
+        return data.model_dump_json(indent=2)
+
+    def api_keys_list(self, keys: list[ApiKeyListItem]) -> str:
+        return json.dumps([k.model_dump() for k in keys], indent=2)
+
+    def api_key_created(self, data: ApiKeyCreateResponse) -> str:
         return data.model_dump_json(indent=2)
 
 
@@ -155,6 +175,55 @@ class HumanFormatter:
         buf = StringIO()
         Console(file=buf, force_terminal=True).print(table)
         return f"{buf.getvalue().rstrip()}\n{data.total} failed job(s)"
+
+    def contexts_list(self, data: ContextsResponse) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Name")
+        table.add_column("Workers")
+        table.add_column("Queue Depth")
+        for c in data.contexts:
+            table.add_row(c.name, str(c.workers), str(c.queue_depth))
+        buf = StringIO()
+        Console(file=buf, force_terminal=True).print(table)
+        return buf.getvalue().rstrip()
+
+    def api_keys_list(self, keys: list[ApiKeyListItem]) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+        from rich.table import Table
+
+        table = Table(show_header=True, header_style="bold")
+        table.add_column("Key ID")
+        table.add_column("Role")
+        table.add_column("Contexts")
+        table.add_column("Created")
+        table.add_column("Expires")
+        for k in keys:
+            table.add_row(
+                k.key_id,
+                k.role,
+                ", ".join(k.contexts or []),
+                k.created_at,
+                k.expires_at,
+            )
+        buf = StringIO()
+        Console(file=buf, force_terminal=True).print(table)
+        return buf.getvalue().rstrip()
+
+    def api_key_created(self, data: ApiKeyCreateResponse) -> str:
+        lines = [
+            f"Key ID:  {data.key_id}",
+            f"Role:    {data.role}",
+            f"Token:   {data.token}",
+            f"Expires: {data.expires_at}",
+        ]
+        return "\n".join(lines)
 
 
 def auto_formatter(fmt: str | None = None) -> Formatter:

--- a/packages/naas-client/tests/test_cli_contexts_apikeys.py
+++ b/packages/naas-client/tests/test_cli_contexts_apikeys.py
@@ -1,0 +1,175 @@
+"""Tests for contexts and api-keys CLI subcommands."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from naas_client.cli import app
+from naas_client.exceptions import NaasApiError
+from naas_client.models import ApiKeyCreateResponse, ApiKeyListItem, ContextsResponse
+
+runner = CliRunner()
+
+CONTEXTS = ContextsResponse.model_validate(
+    {
+        "contexts": [
+            {"name": "default", "workers": 4, "queue_depth": 0},
+            {"name": "oob", "workers": 2, "queue_depth": 1},
+        ],
+    }
+)
+
+API_KEY_LIST = [
+    ApiKeyListItem.model_validate(
+        {
+            "key_id": "k-1",
+            "role": "admin",
+            "contexts": ["*"],
+            "created_at": "2026-04-10T00:00:00Z",
+            "expires_at": "2026-07-10T00:00:00Z",
+            "created_by": "admin",
+        }
+    ),
+]
+
+API_KEY_CREATED = ApiKeyCreateResponse.model_validate(
+    {
+        "key_id": "k-2",
+        "token": "eyJ...",
+        "role": "operator",
+        "contexts": ["default"],
+        "expires_at": "2026-07-10T00:00:00Z",
+    }
+)
+
+
+class TestContextsList:
+    @patch("naas_client.cli.NaasClient")
+    def test_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_contexts=MagicMock(return_value=CONTEXTS))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "contexts", "list"])
+        assert result.exit_code == 0
+        assert "default" in result.output
+        assert "oob" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_table(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_contexts=MagicMock(return_value=CONTEXTS))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "table", "contexts", "list"])
+        assert result.exit_code == 0
+        assert "default" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(
+            list_contexts=MagicMock(side_effect=NaasApiError(500, "ISE")),
+        )
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "contexts", "list"])
+        assert result.exit_code == 2
+
+
+class TestApiKeysList:
+    @patch("naas_client.cli.NaasClient")
+    def test_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_api_keys=MagicMock(return_value=API_KEY_LIST))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "list"])
+        assert result.exit_code == 0
+        assert "k-1" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_table(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(list_api_keys=MagicMock(return_value=API_KEY_LIST))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "table", "api-keys", "list"])
+        assert result.exit_code == 0
+        assert "k-1" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(
+            list_api_keys=MagicMock(side_effect=NaasApiError(500, "ISE")),
+        )
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "list"])
+        assert result.exit_code == 2
+
+
+class TestApiKeysCreate:
+    @patch("naas_client.cli.NaasClient")
+    def test_create_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(create_api_key=MagicMock(return_value=API_KEY_CREATED))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "create"])
+        assert result.exit_code == 0
+        assert "eyJ" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_create_with_options(self, mock_cls: MagicMock) -> None:
+        mock = MagicMock(create_api_key=MagicMock(return_value=API_KEY_CREATED))
+        mock_cls.return_value = mock
+        runner.invoke(
+            app,
+            [
+                "--url",
+                "https://test",
+                "--format",
+                "json",
+                "api-keys",
+                "create",
+                "--role",
+                "operator",
+                "--contexts",
+                "default,oob",
+                "--ttl",
+                "3600",
+            ],
+        )
+        mock.create_api_key.assert_called_once_with(role="operator", contexts=["default", "oob"], ttl=3600)
+
+    @patch("naas_client.cli.NaasClient")
+    def test_create_table(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(create_api_key=MagicMock(return_value=API_KEY_CREATED))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "table", "api-keys", "create"])
+        assert result.exit_code == 0
+        assert "Token:" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_create_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(
+            create_api_key=MagicMock(side_effect=NaasApiError(500, "ISE")),
+        )
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "create"])
+        assert result.exit_code == 2
+
+
+class TestApiKeysDelete:
+    @patch("naas_client.cli.NaasClient")
+    def test_delete(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(delete_api_key=MagicMock())
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "delete", "k-1"])
+        assert result.exit_code == 0
+        assert "revoked" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_delete_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(
+            delete_api_key=MagicMock(side_effect=NaasApiError(404, "Not found")),
+        )
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "delete", "k-1"])
+        assert result.exit_code == 2
+
+
+class TestApiKeysRotate:
+    @patch("naas_client.cli.NaasClient")
+    def test_rotate_json(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(rotate_api_key=MagicMock(return_value=API_KEY_CREATED))
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "rotate", "k-1"])
+        assert result.exit_code == 0
+        assert "eyJ" in result.output
+
+    @patch("naas_client.cli.NaasClient")
+    def test_rotate_api_error(self, mock_cls: MagicMock) -> None:
+        mock_cls.return_value = MagicMock(
+            rotate_api_key=MagicMock(side_effect=NaasApiError(404, "Not found")),
+        )
+        result = runner.invoke(app, ["--url", "https://test", "--format", "json", "api-keys", "rotate", "k-1"])
+        assert result.exit_code == 2

--- a/packages/naas/changes/390.feature.md
+++ b/packages/naas/changes/390.feature.md
@@ -1,0 +1,1 @@
+Add contexts and api-keys CLI subcommands.


### PR DESCRIPTION
## Summary

Adds `naas contexts` and `naas api-keys` subcommand groups.

## Commands

```bash
naas contexts list

naas api-keys list
naas api-keys create [--role operator] [--contexts default,oob] [--ttl 3600]
naas api-keys delete k-abc123
naas api-keys rotate k-abc123
```

## Changes

- `naas_client/cli/contexts.py`: contexts list command
- `naas_client/cli/api_keys.py`: list, create, delete, rotate commands
- `naas_client/cli/output.py`: Added contexts_list, api_keys_list, api_key_created to both formatters
- Human: Rich tables, token prominently displayed on create/rotate
- JSON: model dumps
- 168 tests, 100% coverage

Closes #390