### PR TITLE
docs: add CLI docs, shell completion, and integration tests (#391)

### DIFF
--- a/docs/client.md
+++ b/docs/client.md
@@ -148,6 +148,80 @@ client = NaasClient(
 )
 ```
 
+## CLI Tool
+
+Install with the `cli` extra:
+
+```bash
+pip install naas-client[cli]
+```
+
+### Configuration
+
+The CLI reads settings from (highest precedence first):
+
+1. CLI flags (`--url`, `--api-key`, etc.)
+2. Environment variables (`NAAS_URL`, `NAAS_API_KEY`, `NAAS_USERNAME`, `NAAS_PASSWORD`, `NAAS_VERIFY`)
+3. Config file (`~/.config/naas/config.toml` or `NAAS_CONFIG=/path`)
+
+Config file example:
+
+```toml
+url = "https://naas.prod.example.com"
+api_key = "eyJ..."
+verify = true
+format = "json"
+timeout = 120
+```
+
+### Commands
+
+```bash
+# Health check
+naas healthcheck
+
+# Send commands (--wait blocks until complete)
+naas send-command --host 10.0.0.1 --platform cisco_ios --wait "show version"
+naas send-config --host 10.0.0.1 --wait --save-config "interface Gi0/1" "shutdown"
+
+# Job management
+naas jobs list [--status failed] [--tag env:prod]
+naas jobs get JOB_ID
+naas jobs cancel JOB_ID
+naas jobs replay JOB_ID
+naas jobs failed
+
+# Contexts
+naas contexts list
+
+# API keys
+naas api-keys list
+naas api-keys create --role operator --contexts default,oob
+naas api-keys delete KEY_ID
+naas api-keys rotate KEY_ID
+```
+
+### Output Formats
+
+- **Human** (default on terminal): Rich tables, colored status, icons
+- **JSON** (default when piped, or `--format json`): Structured JSON matching API models
+
+### Exit Codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0 | Success |
+| 1 | Job failed |
+| 2 | API error or missing required option |
+| 3 | Authentication error |
+| 4 | Timeout |
+
+### Shell Completion
+
+```bash
+naas --install-completion bash  # or zsh, fish
+```
+
 ## Compatibility
 
 - **Python**: 3.11+

--- a/packages/naas-client/tests/integration/test_cli_e2e.py
+++ b/packages/naas-client/tests/integration/test_cli_e2e.py
@@ -1,0 +1,141 @@
+"""End-to-end CLI integration tests against a running NAAS + cisshgo stack."""
+
+from __future__ import annotations
+
+import json
+import socket
+import time
+
+import pytest
+from typer.testing import CliRunner
+
+from naas_client.cli import app
+
+runner = CliRunner()
+
+CISSHGO_HOST = "240.11.2.100"
+CISSHGO_PORT = 10022
+
+BASE_OPTS = [
+    "--url",
+    "https://localhost:18443",
+    "--username",
+    "admin",
+    "--password",
+    "admin",
+    "--no-verify",
+    "--format",
+    "json",
+]
+
+
+@pytest.fixture(scope="session")
+def wait_for_cisshgo() -> None:
+    """Wait for cisshgo SSH port to be ready."""
+    for _ in range(30):
+        try:
+            with socket.create_connection(("localhost", CISSHGO_PORT), timeout=2):
+                return
+        except OSError:
+            pass
+        time.sleep(1)
+    pytest.fail("cisshgo did not become ready in 30s")
+
+
+class TestCliEndToEnd:
+    def test_send_command_wait(self, docker_compose: None, wait_for_cisshgo: None) -> None:
+        """Submit a command via CLI, wait for result, verify output."""
+        result = runner.invoke(
+            app,
+            [
+                *BASE_OPTS,
+                "send-command",
+                "--host",
+                CISSHGO_HOST,
+                "--platform",
+                "cisco_ios",
+                "--port",
+                str(CISSHGO_PORT),
+                "--wait",
+                "--timeout",
+                "30",
+                "show version",
+            ],
+        )
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        data = json.loads(result.output)
+        assert data["status"] == "finished"
+        assert "Cisco IOS" in data["results"]["show version"]
+
+    def test_jobs_list_shows_job(self, docker_compose: None, wait_for_cisshgo: None) -> None:
+        """After submitting a job, jobs list should return results."""
+        result = runner.invoke(app, [*BASE_OPTS, "jobs", "list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["pagination"]["total"] >= 1
+
+    def test_jobs_get(self, docker_compose: None, wait_for_cisshgo: None) -> None:
+        """Submit a job, then get it by ID."""
+        # Submit
+        submit = runner.invoke(
+            app,
+            [
+                *BASE_OPTS,
+                "send-command",
+                "--host",
+                CISSHGO_HOST,
+                "--platform",
+                "cisco_ios",
+                "--port",
+                str(CISSHGO_PORT),
+                "show version",
+            ],
+        )
+        assert submit.exit_code == 0
+        job_id = json.loads(submit.output)["job_id"]
+
+        # Wait for completion
+        import time as _time
+
+        deadline = _time.time() + 30
+        while _time.time() < deadline:
+            get_result = runner.invoke(app, [*BASE_OPTS, "jobs", "get", job_id])
+            assert get_result.exit_code in (0, 1)
+            data = json.loads(get_result.output)
+            if data["status"] in ("finished", "failed"):
+                break
+            _time.sleep(1)
+
+        assert data["status"] == "finished"
+
+    def test_send_config_wait(self, docker_compose: None, wait_for_cisshgo: None) -> None:
+        """Submit a config via CLI, wait for result."""
+        result = runner.invoke(
+            app,
+            [
+                *BASE_OPTS,
+                "send-config",
+                "--host",
+                CISSHGO_HOST,
+                "--platform",
+                "cisco_ios",
+                "--port",
+                str(CISSHGO_PORT),
+                "--wait",
+                "--timeout",
+                "30",
+                "interface Loopback0",
+                "description cli-test",
+            ],
+        )
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+        data = json.loads(result.output)
+        assert data["status"] == "finished"
+
+    def test_contexts_list(self, docker_compose: None) -> None:
+        """Contexts list returns at least default."""
+        result = runner.invoke(app, [*BASE_OPTS, "contexts", "list"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        names = [c["name"] for c in data["contexts"]]
+        assert "default" in names

--- a/packages/naas-client/tests/integration/test_cli_integration.py
+++ b/packages/naas-client/tests/integration/test_cli_integration.py
@@ -1,0 +1,96 @@
+"""CLI integration tests against a running NAAS docker-compose stack."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from naas_client.cli import app
+
+runner = CliRunner()
+
+
+class TestCliIntegration:
+    """These tests require docker-compose to be running (conftest handles this)."""
+
+    def test_healthcheck_json(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://localhost:18443",
+                "--username",
+                "admin",
+                "--password",
+                "admin",
+                "--no-verify",
+                "--format",
+                "json",
+                "healthcheck",
+            ],
+        )
+        assert result.exit_code == 0
+        assert '"healthy"' in result.output
+
+    def test_healthcheck_table(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://localhost:18443",
+                "--username",
+                "admin",
+                "--password",
+                "admin",
+                "--no-verify",
+                "--format",
+                "table",
+                "healthcheck",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "healthy" in result.output
+
+    def test_version(self) -> None:
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert "naas-client" in result.output
+
+    def test_contexts_list(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://localhost:18443",
+                "--username",
+                "admin",
+                "--password",
+                "admin",
+                "--no-verify",
+                "--format",
+                "json",
+                "contexts",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "default" in result.output
+
+    def test_jobs_list(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "--url",
+                "https://localhost:18443",
+                "--username",
+                "admin",
+                "--password",
+                "admin",
+                "--no-verify",
+                "--format",
+                "json",
+                "jobs",
+                "list",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "pagination" in result.output

--- a/packages/naas/changes/391.doc.md
+++ b/packages/naas/changes/391.doc.md
@@ -1,0 +1,1 @@
+Add CLI shell completion, --version, and RTD documentation.


### PR DESCRIPTION
## Summary

Final CLI polish — documentation, integration tests, and shell completion.

## Changes

- **docs/client.md**: Added full CLI section — config file, all commands, output formats, exit codes, shell completion
- **CLI integration tests**: healthcheck (json + table), contexts list, jobs list — all against docker-compose
- **Shell completion**: Already provided by Typer (`naas --install-completion`)
- **`--version`**: Already implemented

## CLI is now complete

All 5 phases done:
- ✅ #387 Scaffolding, config, healthcheck
- ✅ #388 send-command, send-config with --wait
- ✅ #389 jobs subcommand group
- ✅ #390 contexts and api-keys subcommands
- ✅ #391 Shell completion, docs, integration tests (this PR)

Closes #391