### PR TITLE
fix: release workflow and changelog paths broken by workspace restructure (#398)

### DIFF
--- a/.github/scripts/cleanup_released_fragments.py
+++ b/.github/scripts/cleanup_released_fragments.py
@@ -39,7 +39,9 @@ def extract_released_issues(changelog_path: Path) -> set[int]:
     return released_issues
 
 
-def extract_released_prefix_fragments(changelog_path: Path, changes_dir: Path) -> set[str]:
+def extract_released_prefix_fragments(
+    changelog_path: Path, changes_dir: Path
+) -> set[str]:
     """Extract +prefix fragment names that appear in released versions.
 
     Checks if the content of +prefix fragments appears in released CHANGELOG sections.
@@ -101,7 +103,9 @@ def find_fragments_to_delete(
     return fragments_to_delete
 
 
-def generate_pr_body(fragments: list[tuple[Path, int | str]], version: str, changelog_path: Path) -> str:
+def generate_pr_body(
+    fragments: list[tuple[Path, int | str]], version: str, changelog_path: Path
+) -> str:
     """Generate detailed PR body with table of deletions."""
     changelog_content = changelog_path.read_text()
 
@@ -163,7 +167,7 @@ def main() -> int:
     version = sys.argv[1]
     repo_root = Path(__file__).parent.parent.parent
     changelog_path = repo_root / "CHANGELOG.md"
-    changes_dir = repo_root / "changes"
+    changes_dir = repo_root / "packages" / "naas" / "changes"
 
     if not changelog_path.exists():
         print(f"Error: CHANGELOG.md not found at {changelog_path}")
@@ -184,7 +188,9 @@ def main() -> int:
 
     # Find fragments to delete
     print(f"Scanning {changes_dir}...")
-    fragments_to_delete = find_fragments_to_delete(changes_dir, released_issues, released_prefixes)
+    fragments_to_delete = find_fragments_to_delete(
+        changes_dir, released_issues, released_prefixes
+    )
 
     if not fragments_to_delete:
         print("No fragments to delete")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - main
       - 'release/**'
     paths:
-      - 'pyproject.toml'
+      - 'packages/naas/pyproject.toml'
 
 permissions:
   contents: write
@@ -26,7 +26,7 @@ jobs:
       - name: Extract version and determine release type
         id: version
         run: |
-          VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          VERSION=$(grep '^version = ' packages/naas/pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
           BRANCH="${GITHUB_REF#refs/heads/}"
@@ -95,18 +95,18 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync --package naas --extra dev
 
       - name: Build changelog
         run: |
           if [[ "${{ needs.check-version.outputs.is_prerelease }}" == "true" ]]; then
             # Pre-release: build changelog but keep fragments
-            uv run towncrier build --version ${{ needs.check-version.outputs.version }} --keep
+            uv run towncrier build --version ${{ needs.check-version.outputs.version }} --keep --dir packages/naas
             # Clean up old pre-releases but keep current one
             python3 .github/scripts/cleanup_changelog.py ${{ needs.check-version.outputs.version }} CHANGELOG.md
           else
             # Final release: build changelog and delete fragments
-            uv run towncrier build --version ${{ needs.check-version.outputs.version }} --yes
+            uv run towncrier build --version ${{ needs.check-version.outputs.version }} --yes --dir packages/naas
             # Clean up all pre-release entries for this version
             python3 .github/scripts/cleanup_changelog.py ${{ needs.check-version.outputs.version }} CHANGELOG.md
           fi
@@ -122,7 +122,7 @@ jobs:
           git add CHANGELOG.md uv.lock k8s/api/deployment.yaml k8s/worker/deployment.yaml
           if [[ "${{ needs.check-version.outputs.is_prerelease }}" == "false" ]]; then
             # Only commit fragment deletions on final release
-            git add changes/
+            git add packages/naas/changes/
           fi
           git commit -m "docs: update changelog for v${{ needs.check-version.outputs.version }}" || echo "No changes to commit"
           git push

--- a/.github/workflows/sync-release.yml
+++ b/.github/workflows/sync-release.yml
@@ -109,12 +109,12 @@ jobs:
 
           # Create branch, bump version, and open PR
           git checkout -b "$BRANCH"
-          sed -i "s/^version = \".*\"/version = \"${NEXT_VERSION}\"/" pyproject.toml
+          sed -i "s/^version = \".*\"/version = \"${NEXT_VERSION}\"/" packages/naas/pyproject.toml
           uv lock
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml uv.lock
+          git add packages/naas/pyproject.toml uv.lock
           git commit -m "chore: bump develop to v${NEXT_VERSION}"
           git push -u origin "$BRANCH"
 

--- a/packages/naas/changes/398.bugfix.md
+++ b/packages/naas/changes/398.bugfix.md
@@ -1,0 +1,1 @@
+Fix release workflow and changelog paths broken by workspace restructure.


### PR DESCRIPTION
## Summary

The workspace restructure (#367) moved `pyproject.toml` to `packages/naas/pyproject.toml` and `changes/` to `packages/naas/changes/`, but the release-related workflows and scripts still referenced the old root paths.

## Fixes

- **`release.yml`**: trigger path, version extraction, `uv sync --package naas`, `towncrier --dir packages/naas`, `git add packages/naas/changes/`
- **`cleanup_released_fragments.py`**: `changes_dir` → `packages/naas/changes`
- **`cleanup-changelog-fragments.yml`**: removed accidental duplicate step
- **`sync-release.yml`**: `sed` and `git add` now target `packages/naas/pyproject.toml`

## Note

`lint.yml` check-changelog was already correct (updated in #367).

Closes #398