### PR TITLE
feat: add Helm chart for Kubernetes deployment (#401)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,23 @@ jobs:
           filters: |
             k8s:
               - 'k8s/**'
+              - 'charts/**'
               - 'packages/naas/Dockerfile'
               - 'packages/naas/tests/k8s/**'
               - '.github/workflows/build.yml'
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Lint chart
+        run: helm lint charts/naas
+      - name: Template dry-run
+        run: helm template test charts/naas --set secrets.redisPassword=ci-test
 
   k8s-tests:
     runs-on: ubuntu-latest
@@ -174,7 +188,7 @@ jobs:
   build-and-k8s-summary:
     name: Build and K8s Tests
     runs-on: ubuntu-latest
-    needs: [changes, build, k8s-tests]
+    needs: [changes, build, k8s-tests, helm-lint]
     if: always()
     steps:
       - name: Check results
@@ -189,6 +203,10 @@ jobs:
           fi
           if [[ "${{ needs.k8s-tests.result }}" == "failure" || "${{ needs.k8s-tests.result }}" == "cancelled" ]]; then
             echo "K8s tests failed or were cancelled"
+            exit 1
+          fi
+          if [[ "${{ needs.helm-lint.result }}" == "failure" || "${{ needs.helm-lint.result }}" == "cancelled" ]]; then
+            echo "Helm lint failed or was cancelled"
             exit 1
           fi
           # skipped is acceptable for k8s-tests (path filter didn't match)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
       - id: check-yaml
         args: [--unsafe]
+        exclude: ^charts/
       - id: check-toml
       - id: end-of-file-fixer
       - id: trailing-whitespace

--- a/charts/naas/Chart.yaml
+++ b/charts/naas/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: naas
+description: Netmiko As A Service — REST API for network device automation
+type: application
+version: 0.1.0
+appVersion: "2.0.0"
+keywords:
+  - naas
+  - netmiko
+  - network-automation
+home: https://github.com/lykinsbd/naas
+sources:
+  - https://github.com/lykinsbd/naas
+maintainers:
+  - name: Brett Lykins
+    url: https://github.com/lykinsbd

--- a/charts/naas/templates/_helpers.tpl
+++ b/charts/naas/templates/_helpers.tpl
@@ -1,0 +1,50 @@
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "naas.labels" -}}
+app.kubernetes.io/name: naas
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end }}
+
+{{/*
+Container image with tag defaulting to appVersion.
+*/}}
+{{- define "naas.image" -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{/*
+Secret name — use existing or generated.
+*/}}
+{{- define "naas.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{ .Values.secrets.existingSecret }}
+{{- else -}}
+naas-secret
+{{- end -}}
+{{- end }}
+
+{{/*
+Redis host — bundled service name or external.
+*/}}
+{{- define "naas.redisHost" -}}
+{{- if .Values.redis.enabled -}}
+redis
+{{- else -}}
+{{ .Values.redis.external.host }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Redis port.
+*/}}
+{{- define "naas.redisPort" -}}
+{{- if .Values.redis.enabled -}}
+{{ .Values.redis.port | quote }}
+{{- else -}}
+{{ .Values.redis.external.port | quote }}
+{{- end -}}
+{{- end }}

--- a/charts/naas/templates/api-deployment.yaml
+++ b/charts/naas/templates/api-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: naas-api
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: naas-api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app: naas-api
+  template:
+    metadata:
+      labels:
+        app: naas-api
+        {{- include "naas.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: naas-api
+          image: {{ include "naas.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.api.port }}
+          envFrom:
+            - configMapRef:
+                name: naas-config
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: REDIS_PASSWORD
+            - name: NAAS_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: NAAS_ENCRYPTION_KEY
+                  optional: true
+            - name: NAAS_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: NAAS_CERT
+                  optional: true
+            - name: NAAS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: NAAS_KEY
+                  optional: true
+            - name: NAAS_CA_BUNDLE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: NAAS_CA_BUNDLE
+                  optional: true
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: {{ .Values.api.port }}
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.api.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.livenessProbe.periodSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: {{ .Values.api.port }}
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.api.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.api.readinessProbe.periodSeconds }}
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/naas/templates/api-service.yaml
+++ b/charts/naas/templates/api-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: naas-api
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: naas-api
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: naas-api
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.api.port }}

--- a/charts/naas/templates/configmap.yaml
+++ b/charts/naas/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: naas-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+data:
+  REDIS_HOST: {{ include "naas.redisHost" . | quote }}
+  REDIS_PORT: {{ include "naas.redisPort" . }}
+  NAAS_WORKER_PROCESSES: {{ .Values.worker.processes | quote }}
+  {{- range $key, $val := .Values.config }}
+  {{ $key }}: {{ $val | quote }}
+  {{- end }}

--- a/charts/naas/templates/ingress.yaml
+++ b/charts/naas/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: naas
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: naas-api
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/naas/templates/namespace.yaml
+++ b/charts/naas/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.createNamespace }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/naas/templates/redis.yaml
+++ b/charts/naas/templates/redis.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        {{- include "naas.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
+          args:
+            - --requirepass
+            - $(REDIS_PASSWORD)
+            - --port
+            - {{ .Values.redis.port | quote }}
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: REDIS_PASSWORD
+          ports:
+            - containerPort: {{ .Values.redis.port }}
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: {{ .Values.redis.port }}
+      targetPort: {{ .Values.redis.port }}
+{{- end }}

--- a/charts/naas/templates/secret.yaml
+++ b/charts/naas/templates/secret.yaml
@@ -1,0 +1,24 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: naas-secret
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+type: Opaque
+data:
+  REDIS_PASSWORD: {{ .Values.secrets.redisPassword | b64enc | quote }}
+  {{- if .Values.secrets.encryptionKey }}
+  NAAS_ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.tlsCert }}
+  NAAS_CERT: {{ .Values.secrets.tlsCert | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.tlsKey }}
+  NAAS_KEY: {{ .Values.secrets.tlsKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.tlsCaBundle }}
+  NAAS_CA_BUNDLE: {{ .Values.secrets.tlsCaBundle | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/naas/templates/worker-deployment.yaml
+++ b/charts/naas/templates/worker-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: naas-worker
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: naas-worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: naas-worker
+  template:
+    metadata:
+      labels:
+        app: naas-worker
+        {{- include "naas.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: naas-worker
+          image: {{ include "naas.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - python
+            - worker.py
+            - --redis
+            - $(REDIS_HOST)
+            - --port
+            - $(REDIS_PORT)
+            - --auth_password
+            - $(REDIS_PASSWORD)
+            - $(NAAS_WORKER_PROCESSES)
+          envFrom:
+            - configMapRef:
+                name: naas-config
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: REDIS_PASSWORD
+            - name: NAAS_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: NAAS_ENCRYPTION_KEY
+                  optional: true
+          resources:
+            {{- toYaml .Values.worker.resources | nindent 12 }}
+          livenessProbe:
+            exec:
+              command:
+                - find
+                - /tmp/worker_heartbeat
+                - -mmin
+                - "-2"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/naas/values.yaml
+++ b/charts/naas/values.yaml
@@ -1,0 +1,107 @@
+# NAAS Helm Chart — values.yaml
+# Override these values for your deployment.
+
+# -- Container image configuration
+image:
+  repository: ghcr.io/lykinsbd/naas
+  tag: ""  # Defaults to Chart.appVersion
+  pullPolicy: IfNotPresent
+
+# -- Namespace to deploy into (created if createNamespace is true)
+namespace: naas
+createNamespace: true
+
+# -- API server configuration
+api:
+  replicas: 2
+  port: 443
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "768Mi"
+      cpu: "500m"
+  livenessProbe:
+    initialDelaySeconds: 15
+    periodSeconds: 20
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+
+# -- Worker configuration
+worker:
+  replicas: 2
+  processes: 10
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+# -- NAAS application configuration (injected as ConfigMap)
+config:
+  APP_ENVIRONMENT: "production"
+  LOG_LEVEL: "INFO"
+  CIRCUIT_BREAKER_ENABLED: "true"
+  CIRCUIT_BREAKER_THRESHOLD: "5"
+  CIRCUIT_BREAKER_TIMEOUT: "300"
+  CONNECTION_POOL_ENABLED: "true"
+  CONNECTION_POOL_MAX_SIZE: "10"
+  CONNECTION_POOL_IDLE_TIMEOUT: "300"
+  CONNECTION_POOL_MAX_AGE: "3600"
+  CONNECTION_POOL_KEEPALIVE: "60"
+  # CONNECTION_POOL_EXCLUDE: ""
+
+# -- Secrets (provide values or reference an existing secret)
+secrets:
+  # -- Use an existing Secret instead of creating one
+  existingSecret: ""
+  # -- Values for the created Secret (ignored if existingSecret is set)
+  redisPassword: ""
+  encryptionKey: ""
+  # -- Optional TLS (omit for self-signed)
+  tlsCert: ""
+  tlsKey: ""
+  tlsCaBundle: ""
+
+# -- Bundled Redis (disable to use an external Redis)
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+  port: 6379
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+  # -- External Redis (used when redis.enabled is false)
+  external:
+    host: ""
+    port: "6379"
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: naas.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: naas-tls
+  #    hosts:
+  #      - naas.example.com
+
+# -- Service configuration
+service:
+  type: ClusterIP
+  port: 443

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -167,3 +167,50 @@ use a `ServiceMonitor` if running the Prometheus Operator.
 | `naas_http_request_duration_seconds` | Histogram | Request latency by endpoint |
 | `naas_queue_depth` | Gauge | Number of jobs waiting in the RQ queue |
 | `naas_workers_active` | Gauge | Number of active RQ worker processes (cached, 10s TTL) |
+
+## Helm Chart
+
+A Helm chart is available in `charts/naas/` for parameterized deployments.
+
+### Quickstart
+
+```bash
+helm install naas charts/naas \
+  --set secrets.redisPassword=changeme \
+  --set secrets.encryptionKey=my-32-byte-key
+```
+
+### Key values
+
+| Value | Default | Description |
+| ----- | ------- | ----------- |
+| `api.replicas` | `2` | API pod replicas |
+| `worker.replicas` | `2` | Worker pod replicas |
+| `worker.processes` | `10` | RQ worker processes per pod |
+| `redis.enabled` | `true` | Deploy bundled Redis |
+| `redis.external.host` | `""` | External Redis host (when `redis.enabled=false`) |
+| `ingress.enabled` | `false` | Create Ingress resource |
+| `secrets.existingSecret` | `""` | Use an existing Secret instead of creating one |
+| `image.tag` | `appVersion` | Container image tag |
+
+### External Redis
+
+```bash
+helm install naas charts/naas \
+  --set redis.enabled=false \
+  --set redis.external.host=redis.prod.internal \
+  --set secrets.redisPassword=changeme
+```
+
+### Ingress
+
+```bash
+helm install naas charts/naas \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set ingress.hosts[0].host=naas.example.com \
+  --set ingress.hosts[0].paths[0].path=/ \
+  --set ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+See `charts/naas/values.yaml` for the full list of configurable values.

--- a/packages/naas/changes/401.feature.md
+++ b/packages/naas/changes/401.feature.md
@@ -1,0 +1,1 @@
+Add Helm chart for Kubernetes deployment.


### PR DESCRIPTION
## Summary

Adds a Helm chart under `charts/naas/` for parameterized Kubernetes deployments.

## Chart features

- API and worker deployments with configurable replicas and resources
- Bundled Redis (default) or external Redis via `redis.enabled=false`
- Optional Ingress resource
- TLS via existing secrets or Helm-managed
- All NAAS config exposed as `values.yaml` entries
- `existingSecret` support for pre-provisioned secrets
- Standard Kubernetes labels on all resources

## CI

- `helm-lint` job added to `build.yml` — runs `helm lint` and `helm template` dry-run
- `charts/**` added to k8s-changes path filter
- Pre-commit `check-yaml` excludes `charts/` (Go templates aren't valid YAML)

## Docs

- Helm chart section added to `docs/kubernetes.md` with quickstart, key values, external Redis, and ingress examples

## Validation

```bash
helm lint charts/naas                    # ✅ 0 failures
helm template test charts/naas           # ✅ all resources render
# redis.enabled=false → no redis resources
# ingress.enabled=true → ingress resource created
```

Closes #401