### PR TITLE
docs: v2.0 documentation refresh (#409)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,5 +7,6 @@
     "siblings_only": true
   },
   "MD025": false,
-  "MD029": false
+  "MD029": false,
+  "MD046": false
 }

--- a/docs/api-usage.md
+++ b/docs/api-usage.md
@@ -50,7 +50,7 @@ Device credentials are provided in the request body instead of the Authorization
 
 ```bash
 # Send a command using an API key
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -H "Authorization: Bearer eyJhbG..." \
   -H "Content-Type: application/json" \
   -d '{
@@ -82,7 +82,7 @@ If `NAAS_ADMIN_SECRET` is not set, key management is disabled.
 ### Create a Key
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/api-keys \
+curl -k -X POST https://localhost:8443/v2/api-keys \
   -u "admin:$NAAS_ADMIN_SECRET" \
   -H "Content-Type: application/json" \
   -d '{"role": "admin", "ttl": 7776000}'
@@ -110,7 +110,7 @@ Response:
 ### List Keys
 
 ```bash
-curl -k -u "admin:$NAAS_ADMIN_SECRET" https://localhost:8443/v1/api-keys
+curl -k -u "admin:$NAAS_ADMIN_SECRET" https://localhost:8443/v2/api-keys
 ```
 
 Returns metadata only — tokens are never shown after creation.
@@ -119,7 +119,7 @@ Returns metadata only — tokens are never shown after creation.
 
 ```bash
 curl -k -X DELETE -u "admin:$NAAS_ADMIN_SECRET" \
-  https://localhost:8443/v1/api-keys/k-a1b2c3d4e5f6
+  https://localhost:8443/v2/api-keys/k-a1b2c3d4e5f6
 ```
 
 Revoked keys are immediately rejected on subsequent requests.
@@ -147,7 +147,7 @@ Execute show commands on network devices.
 ### Basic Example
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -160,7 +160,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 ### With Custom Port
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -174,7 +174,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 ### With Enable Password
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -190,7 +190,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 Track your requests with custom IDs:
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -H "X-Request-ID: my-custom-id-12345" \
@@ -206,7 +206,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 Use `expect_string` to override automatic prompt detection with a regex pattern:
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -230,7 +230,7 @@ curl -k -X POST https://localhost:8443/v1/send_command \
 Control the TCP connection timeout with `conn_timeout` (default: `10.0` seconds):
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -264,7 +264,7 @@ Push configuration changes to devices.
 ### Basic Configuration
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_config \
+curl -k -X POST https://localhost:8443/v2/send-config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -283,7 +283,7 @@ curl -k -X POST https://localhost:8443/v1/send_config \
 Automatically save configuration after changes:
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_config \
+curl -k -X POST https://localhost:8443/v2/send-config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -302,7 +302,7 @@ curl -k -X POST https://localhost:8443/v1/send_config \
 For platforms that require commit:
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_config \
+curl -k -X POST https://localhost:8443/v2/send-config \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{
@@ -345,7 +345,7 @@ Set `JOB_DEDUP_ENABLED=false` to disable deduplication globally. Useful for test
 For client-controlled deduplication (e.g., safe retries on network failure), use `X-Idempotency-Key`:
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -H "X-Idempotency-Key: my-unique-key-abc123" \
   -u "admin:password" \
   -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
@@ -358,7 +358,7 @@ Repeat requests with the same key within 24 hours return the original job_id wit
 Instead of polling for results, you can provide a `webhook_url` to receive a notification when the job completes.
 
 ```bash
-curl -k -u admin:admin -X POST https://naas.example.com/v1/send_command \
+curl -k -u admin:admin -X POST https://naas.example.com/v2/send-command \
   -H "Content-Type: application/json" \
   -d '{
     "host": "192.168.1.1",
@@ -379,7 +379,7 @@ When the job finishes (success or failure), NAAS POSTs a notification to your UR
 }
 ```
 
-Use `job_id` to fetch the full results from `GET /v1/jobs/{job_id}`.
+Use `job_id` to fetch the full results from `GET /v2/jobs/{job_id}`.
 
 ### Security
 
@@ -396,7 +396,7 @@ Failed jobs are retained in RQ's `FailedJobRegistry` for `JOB_TTL_FAILED` (7 day
 ### List Failed Jobs
 
 ```bash
-curl -k -u "admin:password" https://naas.example.com/v1/jobs/failed
+curl -k -u "admin:password" https://naas.example.com/v2/jobs/failed
 ```
 
 ```json
@@ -424,7 +424,7 @@ Re-enqueue a failed job using your current credentials (stored credentials are n
 
 ```bash
 curl -k -u "admin:password" -X POST \
-  https://naas.example.com/v1/jobs/abc-123/replay
+  https://naas.example.com/v2/jobs/abc-123/replay
 ```
 
 Returns a standard `202 Accepted` with a new `job_id`. The replayed job uses the caller's credentials, not the original submitter's.
@@ -444,7 +444,7 @@ Cancel running or queued jobs using DELETE.
 ### Cancel a Job
 
 ```bash
-curl -k -X DELETE https://localhost:8443/v1/send_command/{job_id} \
+curl -k -X DELETE https://localhost:8443/v2/send-command/{job_id} \
   -u "admin:password"
 ```
 
@@ -458,14 +458,14 @@ curl -k -X DELETE https://localhost:8443/v1/send_command/{job_id} \
 
 ```bash
 # Submit a job
-JOB_ID=$(curl -k -X POST https://localhost:8443/v1/send_command \
+JOB_ID=$(curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}' \
   | jq -r '.job_id')
 
 # Cancel it
-curl -k -X DELETE https://localhost:8443/v1/send_command/$JOB_ID \
+curl -k -X DELETE https://localhost:8443/v2/send-command/$JOB_ID \
   -u "admin:password"
 ```
 
@@ -485,7 +485,7 @@ curl -k -X DELETE https://localhost:8443/v1/send_command/$JOB_ID \
 ### Check Job Status
 
 ```bash
-curl -k https://localhost:8443/v1/send_command/550e8400-e29b-41d4-a716-446655440000 \
+curl -k https://localhost:8443/v2/send-command/550e8400-e29b-41d4-a716-446655440000 \
   -u "admin:password"
 ```
 
@@ -493,7 +493,7 @@ The `X-Request-ID` header in the 202 response contains the job ID:
 
 ```bash
 # Capture job ID from response header
-JOB_ID=$(curl -k -s -D - -X POST https://localhost:8443/v1/send_command \
+JOB_ID=$(curl -k -s -D - -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" -H "Content-Type: application/json" \
   -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}' \
   | grep -i x-request-id | awk '{print $2}' | tr -d '\r')
@@ -554,13 +554,13 @@ List all jobs with optional pagination and status filtering.
 
 ```bash
 # All jobs (default: page 1, 20 per page)
-curl -k -u "admin:password" https://localhost:8443/v1/jobs
+curl -k -u "admin:password" https://localhost:8443/v2/jobs
 
 # Filter by status
-curl -k -u "admin:password" "https://localhost:8443/v1/jobs?status=failed"
+curl -k -u "admin:password" "https://localhost:8443/v2/jobs?status=failed"
 
 # Paginate
-curl -k -u "admin:password" "https://localhost:8443/v1/jobs?page=2&per_page=50"
+curl -k -u "admin:password" "https://localhost:8443/v2/jobs?page=2&per_page=50"
 ```
 
 Valid `status` values: `queued`, `started`, `finished`, `failed`.
@@ -593,7 +593,7 @@ Attach key-value metadata to any job for filtering and auditing. Tags are stored
 ### Submitting Tags
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -d '{
     "host": "192.168.1.1",
@@ -615,10 +615,10 @@ Use `?tag=key:value` on the list jobs endpoint:
 
 ```bash
 # All jobs tagged team:network-ops
-curl -k -u "admin:password" "https://localhost:8443/v1/jobs?tag=team:network-ops"
+curl -k -u "admin:password" "https://localhost:8443/v2/jobs?tag=team:network-ops"
 
 # Combine with status and pagination
-curl -k -u "admin:password" "https://localhost:8443/v1/jobs?tag=env:prod&status=failed&per_page=50"
+curl -k -u "admin:password" "https://localhost:8443/v2/jobs?tag=env:prod&status=failed&per_page=50"
 ```
 
 Tags are included in each job object in the response:
@@ -659,7 +659,7 @@ NAAS automatically reuses SSH connections to improve performance and reduce load
 Connection pooling is automatically disabled for:
 
 - **Platform autodetect** (`platform: "autodetect"`) - requires clean connection state
-- **Structured commands** (`/v1/send_command_structured`) - TextFSM state makes pooling unreliable
+- **Structured commands** (`/v2/send-command_structured`) - TextFSM state makes pooling unreliable
 
 ### Configuration
 
@@ -741,7 +741,7 @@ from aiohttp import BasicAuth
 async def send_command(session, device_ip, commands):
     """Send command to device via NAAS."""
     async with session.post(
-        "https://localhost:8443/v1/send_command",
+        "https://localhost:8443/v2/send-command",
         json={
             "host": device_ip,
             "platform": "cisco_ios",
@@ -756,7 +756,7 @@ async def get_results(session, job_id):
     """Poll for job results."""
     while True:
         async with session.get(
-            f"https://localhost:8443/v1/send_command/{job_id}",
+            f"https://localhost:8443/v2/send-command/{job_id}",
             ssl=False
         ) as response:
             data = await response.json()
@@ -845,7 +845,7 @@ def send_command_safe(ip, commands):
     """Send command with error handling."""
     try:
         response = requests.post(
-            "https://localhost:8443/v1/send_command",
+            "https://localhost:8443/v2/send-command",
             auth=HTTPBasicAuth("admin", "password"),
             verify=False,
             json={

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,52 +6,73 @@ Welcome to the NAAS documentation! NAAS is a REST API wrapper for [Netmiko](http
 
 NAAS provides a production-ready API for executing commands and configurations on network devices. It handles:
 
-- **Asynchronous job processing** - Commands run in background workers
-- **Multiple device platforms** - Supports all Netmiko-compatible devices (Cisco, Arista, Juniper, etc.)
-- **Secure authentication** - HTTPS with TLS and HTTP Basic Auth
-- **Job tracking** - Query job status and retrieve results
-- **Production features** - Health checks, logging, error handling
+- **Asynchronous job processing** — Commands run in background workers
+- **Multiple device platforms** — Supports all Netmiko-compatible devices (Cisco, Arista, Juniper, etc.)
+- **Python client & CLI** — `pip install naas-client[cli]` for typed API access and terminal usage
+- **Secure authentication** — HTTPS, Basic Auth, JWT API keys with RBAC
+- **Context routing** — Isolate workloads across dedicated worker pools
+- **Job tracking** — Query status, wait for completion, cancel, replay
+- **Production features** — Prometheus metrics, audit logging, circuit breakers, connection pooling
 
 ## Quick Example
 
-```bash
-# Send a command
-curl -X POST https://naas.example.com/v1/send_command \
-  -u admin:password \
-  -H "Content-Type: application/json" \
-  -d '{
-    "host": "192.168.1.1",
-    "platform": "cisco_ios",
-    "commands": ["show version", "show interfaces"]
-  }'
+=== "Python Client"
 
-# Response
-{
-  "job_id": "abc123",
-  "message": "Job enqueued"
-}
+    ```python
+    from naas_client import NaasClient
 
-# Get results
-curl https://naas.example.com/v1/send_command/abc123 \
-  -u admin:password
-```
+    with NaasClient("https://naas.example.com", api_key="eyJ...") as client:
+        job = client.send_command(
+            host="192.168.1.1",
+            platform="cisco_ios",
+            commands=["show version"],
+        )
+        result = job.wait(timeout=30)
+        print(result.results["show version"])
+    ```
+
+=== "CLI"
+
+    ```bash
+    naas --url https://naas.example.com --api-key eyJ... \
+      send-command --host 192.168.1.1 --platform cisco_ios --wait "show version"
+    ```
+
+=== "curl"
+
+    ```bash
+    # Submit job
+    curl -X POST https://naas.example.com/v2/send-command \
+      -H "Authorization: Bearer eyJ..." \
+      -H "Content-Type: application/json" \
+      -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
+
+    # Get results
+    curl https://naas.example.com/v2/send-command/<job_id> \
+      -H "Authorization: Bearer eyJ..."
+    ```
 
 ## Features
 
-- ✅ REST API for network device automation
+- ✅ REST API for network device automation (v2 with hyphenated routes)
+- ✅ Python client library with sync and async support
+- ✅ CLI tool with human and JSON output modes
 - ✅ Asynchronous job processing with Redis Queue (RQ)
 - ✅ Support for 100+ device platforms via Netmiko
-- ✅ HTTPS with TLS encryption
-- ✅ HTTP Basic Authentication
-- ✅ Docker Compose deployment
-- ✅ Comprehensive test coverage
-- ✅ Production-ready logging and error handling
+- ✅ JWT API key authentication with RBAC (admin/operator/viewer)
+- ✅ Context-based routing and worker isolation
+- ✅ Prometheus metrics (API and worker)
+- ✅ Helm chart for Kubernetes deployment
+- ✅ Structured audit logging
+- ✅ Circuit breakers and SSH connection pooling
+- ✅ Credential encryption at rest
 
 ## Getting Started
 
-- [Quick Start](quickstart.md) - Get NAAS running in 5 minutes
-- [API Usage](api-usage.md) - Learn how to use the API
-- [Security](security.md) - Secure your deployment
+- [Quick Start](quickstart.md) — Get NAAS running in 5 minutes
+- [Python Client](client.md) — Library and CLI usage
+- [API Usage](api-usage.md) — REST API examples
+- [Upgrading to v2.0](upgrading.md) — Migration guide from v1.x
 
 ## Project Links
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# Quick start guide
+# Quick Start Guide
 
 Get NAAS up and running in 5 minutes.
 
@@ -10,14 +10,9 @@ Get NAAS up and running in 5 minutes.
 ## 1. Clone and start
 
 ```bash
-# Clone the repository
 git clone https://github.com/lykinsbd/naas.git
 cd naas
-
-# Start NAAS with default configuration
 docker compose up -d
-
-# Verify it's running
 curl -k https://localhost:8443/healthcheck
 ```
 
@@ -26,7 +21,7 @@ Expected response:
 ```json
 {
   "status": "healthy",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "uptime_seconds": 42,
   "components": {
     "redis": { "status": "healthy" },
@@ -37,74 +32,104 @@ Expected response:
 
 ## 2. Send a command
 
-Send a command to a network device:
+=== "Python Client"
 
-```bash
-# Send command (replace with your device credentials)
-curl -k -X POST https://localhost:8443/v1/send_command \
-  -u "device_username:device_password" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "host": "192.168.1.1",
-    "platform": "cisco_ios",
-    "commands": ["show version"]
-  }'
-```
+    ```bash
+    pip install naas-client
+    ```
 
-Response:
+    ```python
+    from naas_client import NaasClient
 
-```json
-{
-  "job_id": "550e8400-e29b-41d4-a716-446655440000",
-  "message": "Job enqueued"
-}
-```
+    with NaasClient("https://localhost:8443", username="admin", password="admin", verify=False) as client:
+        job = client.send_command(
+            host="192.168.1.1",
+            platform="cisco_ios",
+            commands=["show version"],
+        )
+        result = job.wait(timeout=30)
+        print(result.results["show version"])
+    ```
 
-## 3. Get results
+=== "CLI"
 
-Check the job status and retrieve results:
+    ```bash
+    pip install naas-client[cli]
 
-```bash
-# Get results (use the job_id from previous response)
-curl -k https://localhost:8443/v1/send_command/550e8400-e29b-41d4-a716-446655440000 \
-  -u "device_username:device_password"
-```
+    naas --url https://localhost:8443 --username admin --password admin --no-verify \
+      send-command --host 192.168.1.1 --platform cisco_ios --wait "show version"
+    ```
 
-Response when complete:
+=== "curl"
 
-```json
-{
-  "job_id": "550e8400-e29b-41d4-a716-446655440000",
-  "status": "finished",
-  "result": "Cisco IOS Software, C2960 Software...",
-  "enqueued_at": "2026-02-22T19:00:00Z",
-  "started_at": "2026-02-22T19:00:01Z",
-  "ended_at": "2026-02-22T19:00:05Z"
-}
-```
+    ```bash
+    curl -k -X POST https://localhost:8443/v2/send-command \
+      -u "admin:admin" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "host": "192.168.1.1",
+        "platform": "cisco_ios",
+        "commands": ["show version"]
+      }'
+    ```
 
-## 4. Send configuration
+    Response:
 
-Push configuration changes:
+    ```json
+    {
+      "job_id": "550e8400-e29b-41d4-a716-446655440000",
+      "message": "Job enqueued"
+    }
+    ```
 
-```bash
-curl -k -X POST https://localhost:8443/v1/send_config \
-  -u "device_username:device_password" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "host": "192.168.1.1",
-    "platform": "cisco_ios",
-    "commands": [
-      "interface GigabitEthernet0/1",
-      "description Configured via NAAS"
-    ],
-    "save_config": true
-  }'
-```
+    ```bash
+    curl -k https://localhost:8443/v2/send-command/550e8400-e29b-41d4-a716-446655440000 \
+      -u "admin:admin"
+    ```
+
+## 3. Send configuration
+
+=== "CLI"
+
+    ```bash
+    naas --url https://localhost:8443 --username admin --password admin --no-verify \
+      send-config --host 192.168.1.1 --platform cisco_ios --wait --save-config \
+      "interface GigabitEthernet0/1" "description Configured via NAAS"
+    ```
+
+=== "curl"
+
+    ```bash
+    curl -k -X POST https://localhost:8443/v2/send-config \
+      -u "admin:admin" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "host": "192.168.1.1",
+        "platform": "cisco_ios",
+        "commands": ["interface GigabitEthernet0/1", "description Configured via NAAS"],
+        "save_config": true
+      }'
+    ```
+
+## 4. Check job status
+
+=== "CLI"
+
+    ```bash
+    naas --url https://localhost:8443 --username admin --password admin --no-verify \
+      jobs list
+    ```
+
+=== "curl"
+
+    ```bash
+    curl -k https://localhost:8443/v2/jobs -u "admin:admin"
+    ```
 
 ## Next steps
 
-- [API Usage Examples](api-usage.md) - More detailed examples
-- [Security Best Practices](security.md) - Secure your deployment
-- [Troubleshooting](troubleshooting.md) - Common issues and solutions
-- [API Documentation](https://naas.readthedocs.io/en/latest/api-reference/) - Full API reference
+- [Python Client & CLI](client.md) — Full client library and CLI reference
+- [API Usage Examples](api-usage.md) — Detailed REST API examples
+- [Upgrading to v2.0](upgrading.md) — Migration guide from v1.x
+- [Security](security.md) — API keys, RBAC, and TLS configuration
+- [Kubernetes Deployment](kubernetes.md) — Helm chart and k8s manifests

--- a/docs/release-notes/v2.0.md
+++ b/docs/release-notes/v2.0.md
@@ -1,0 +1,97 @@
+# NAAS v2.0 Release Notes
+
+NAAS v2.0 is a major release introducing a new API version, Python client library, CLI tool, Helm chart, and significant security and operational improvements.
+
+## Highlights
+
+- **v2 API** — New hyphenated routes (`/v2/send-command`), standardized field names (`host`/`platform`), full OpenAPI spec
+- **Python client library** — `pip install naas-client` for typed, ergonomic API access with sync and async support
+- **CLI tool** — `pip install naas-client[cli]` for terminal-based network operations with human and JSON output
+- **Helm chart** — Parameterized Kubernetes deployment under `charts/naas/`
+- **JWT API keys with RBAC** — Role-based access control (admin/operator/viewer) with context-scoped authorization
+- **Worker Prometheus metrics** — `naas_worker_jobs_total`, `naas_worker_job_duration_seconds`, `naas_worker_active_jobs`
+
+## Breaking Changes
+
+- v2 routes use hyphenated paths (`send-command` not `send_command`)
+- v2 routes require `host` and `platform` fields (reject deprecated `ip` and `device_type`)
+- RBAC enforced on v2 routes — API keys must have appropriate role
+- Context authorization enforced on v2 routes — API keys scoped to allowed contexts
+
+See [Upgrading to v2.0](../upgrading.md) for the full migration guide.
+
+## New Features
+
+### Python Client Library
+
+```python
+from naas_client import NaasClient
+
+with NaasClient("https://naas.example.com", api_key="eyJ...") as client:
+    job = client.send_command(host="10.0.0.1", platform="cisco_ios", commands=["show version"])
+    result = job.wait(timeout=30)
+```
+
+- Synchronous and async clients (`NaasClient`, `AsyncNaasClient`)
+- `Job` and `AsyncJob` objects with `wait()`, `poll()`, `cancel()`, `replay()`
+- Auto-generated models from OpenAPI spec
+- Typed exceptions: `NaasApiError`, `NaasAuthError`, `NaasTimeoutError`
+
+### CLI Tool
+
+```bash
+naas send-command --host 10.0.0.1 --platform cisco_ios --wait "show version"
+naas jobs list --status failed
+naas api-keys create --role operator --contexts prod
+```
+
+- Human-readable tables (terminal) or JSON (pipes/CI)
+- Exit codes for CI: 0=success, 1=job failed, 2=API error, 3=auth error, 4=timeout
+- Config file support (`~/.config/naas/config.toml`)
+- Shell completion for bash, zsh, fish
+
+### Helm Chart
+
+```bash
+helm install naas charts/naas --set secrets.redisPassword=changeme
+```
+
+- Configurable API/worker replicas, resources, and metrics ports
+- Bundled or external Redis
+- Optional Ingress resource
+- Existing secret support
+
+### Security
+
+- JWT API key authentication with create/revoke/rotate lifecycle
+- RBAC: admin, operator, viewer roles
+- Context-scoped authorization (restrict API keys to specific routing contexts)
+- Credential encryption at rest in Redis
+- HMAC-signed webhook payloads
+- Structured audit event logging
+
+### Operational
+
+- Worker Prometheus metrics (jobs counter, duration histogram, active gauge)
+- Circuit breakers with per-device tracking
+- SSH connection pooling with idle eviction
+- Orphaned job reaper
+- Idempotency key support
+
+## v1 Deprecation
+
+v1 routes remain available but are deprecated. All v1 responses include:
+
+```http
+X-API-Deprecated: true
+Sunset: 2027-01-01
+```
+
+v1 routes will be removed in v3.0.
+
+## Compatibility
+
+- Python 3.11+
+- Netmiko 4.x
+- Redis 7+
+- Kubernetes 1.27+ (Helm chart)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
       - Reliability: reliability.md
       - Security: security.md
       - Troubleshooting: troubleshooting.md
+      - Upgrading to v2.0: upgrading.md
   - Deployment:
       - Docker Compose: deployment/docker-compose.md
       - Kubernetes: kubernetes.md
@@ -86,8 +87,15 @@ nav:
       - Architecture Decisions:
           - ADR Index: adr/README.md
           - "0001: Python Client Integration": adr/0001-python-client-library-integration.md
+          - "0002: Secrets Backend Abstraction": adr/0002-secrets-backend-abstraction.md
+          - "0003: API Key Authentication": adr/0003-api-key-authentication.md
+          - "0004: Role-Based Access Control": adr/0004-role-based-access-control.md
+          - "0005: Structured Audit Logging": adr/0005-structured-audit-event-logging.md
+          - "0006: Credential Encryption at Rest": adr/0006-credential-encryption-at-rest.md
+          - "0007: API Versioning Strategy": adr/0007-api-versioning-strategy.md
       - Changelog: changelog.md
       - Release Notes:
+          - v2.0: release-notes/v2.0.md
           - v1.4: release-notes/v1.4.md
           - v1.3: release-notes/v1.3.md
           - v1.2: release-notes/v1.2.md

--- a/packages/naas/changes/409.doc.md
+++ b/packages/naas/changes/409.doc.md
@@ -1,0 +1,1 @@
+Update documentation for v2.0 release.


### PR DESCRIPTION
## Summary

Updates all entry-point documentation for the v2.0 release.

## Changes

- **index.md**: v2 examples with tabbed Python client / CLI / curl; updated feature list to include client, CLI, Helm, RBAC, metrics
- **quickstart.md**: v2 routes, client + CLI examples alongside curl, v2 field names
- **api-usage.md**: all 35 v1 route references replaced with v2 hyphenated routes
- **release-notes/v2.0.md**: comprehensive release notes covering all v2.0 features
- **mkdocs.yml**: added upgrading.md to User Guide nav, all 7 ADRs to Reference, v2.0 release notes
- **.markdownlint.json**: disabled MD046 for tabbed code block compatibility

## Previously missing

- `upgrading.md` existed but wasn't in the nav — now discoverable
- No v2.0 release notes — now created
- Only ADR 0001 in nav — now all 7 listed

Closes #409