### PR TITLE
feat(api): add SSE job streaming endpoint (#404)

### DIFF
--- a/docs/swagger/openapi.json
+++ b/docs/swagger/openapi.json
@@ -2606,6 +2606,26 @@
         "tags": []
       }
     },
+    "/v2/jobs/{job_id}/stream": {
+      "get": {
+        "description": "Args:     job_id: The job UUID to stream.\n\nReturns:     A streaming ``text/event-stream`` response.",
+        "operationId": "get__v2_jobs_{job_id}_stream",
+        "parameters": [
+          {
+            "description": "",
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {},
+        "summary": "Open an SSE stream for the given job.",
+        "tags": []
+      }
+    },
     "/v2/send-command": {
       "get": {
         "description": "",

--- a/packages/naas-client/naas_client/client.py
+++ b/packages/naas-client/naas_client/client.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 import httpx
 
@@ -151,6 +155,31 @@ class NaasClient:
         """List jobs in the failed (dead letter) registry."""
         resp = self._request("GET", "/v2/jobs/failed")
         return FailedJobsResponse.model_validate(resp.json())
+
+    def stream_job(self, job_id: str) -> Generator[dict[str, Any], None, None]:
+        """Stream real-time job status updates via SSE.
+
+        Yields dicts with ``event`` (str) and ``data`` (dict) keys.
+        The stream closes after a terminal event (result/timeout).
+        """
+        with self._client.stream("GET", f"/v2/jobs/{job_id}/stream") as resp:
+            if resp.status_code >= 400:
+                resp.read()
+                cls = NaasAuthError if resp.status_code in _AUTH_ERROR_CODES else NaasApiError
+                raise cls(resp.status_code, resp.reason_phrase or "Error", body=resp.text)
+            buf = ""
+            for chunk in resp.iter_text():
+                buf += chunk
+                while "\n\n" in buf:
+                    block, buf = buf.split("\n\n", 1)
+                    event: dict[str, Any] = {}
+                    for line in block.split("\n"):
+                        if line.startswith("event: "):
+                            event["event"] = line[7:]
+                        elif line.startswith("data: "):
+                            event["data"] = json.loads(line[6:])
+                    if event:
+                        yield event
 
     # -- Contexts ------------------------------------------------------------
 

--- a/packages/naas-client/tests/test_client.py
+++ b/packages/naas-client/tests/test_client.py
@@ -251,3 +251,38 @@ class TestContextManager:
         c = NaasClient("https://naas.test/", username="x", password="x")
         assert c._base_url == "https://naas.test"
         c.close()
+
+
+class TestStreamJob:
+    def test_stream_job_yields_events(self, httpx_mock: HTTPXMock) -> None:
+        sse_body = (
+            b'event: status\ndata: {"job_id": "j1", "status": "queued"}\n\n'
+            b'event: status\ndata: {"job_id": "j1", "status": "started"}\n\n'
+            b'event: result\ndata: {"job_id": "j1", "status": "finished", "results": {"show version": "ok"}}\n\n'
+        )
+        httpx_mock.add_response(
+            stream=httpx.ByteStream(sse_body),
+            headers={"content-type": "text/event-stream"},
+        )
+        c = NaasClient(BASE, username="x", password="x")
+        events = list(c.stream_job("j1"))
+        c.close()
+
+        assert len(events) == 3
+        assert events[0] == {"event": "status", "data": {"job_id": "j1", "status": "queued"}}
+        assert events[2]["event"] == "result"
+        assert events[2]["data"]["status"] == "finished"
+
+    def test_stream_job_auth_error(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=403, text="Forbidden")
+        c = NaasClient(BASE, username="x", password="x")
+        with pytest.raises(NaasAuthError):
+            list(c.stream_job("j1"))
+        c.close()
+
+    def test_stream_job_not_found(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(status_code=404, text="Not Found")
+        c = NaasClient(BASE, username="x", password="x")
+        with pytest.raises(NaasApiError):
+            list(c.stream_job("j1"))
+        c.close()

--- a/packages/naas/changes/404.feature.md
+++ b/packages/naas/changes/404.feature.md
@@ -1,0 +1,1 @@
+Add SSE streaming endpoint for real-time job status updates.

--- a/packages/naas/naas/app.py
+++ b/packages/naas/naas/app.py
@@ -32,6 +32,7 @@ from naas.resources.list_jobs import ListJobs
 from naas.resources.send_command import SendCommand
 from naas.resources.send_command_structured import SendCommandStructured
 from naas.resources.send_config import SendConfig
+from naas.resources.stream_job import StreamJob
 from naas.spec import spec
 
 app = Flask(__name__)
@@ -133,6 +134,7 @@ api.add_resource(ListJobs, "/v2/jobs", endpoint="list_jobs_v2")
 api.add_resource(FailedJobs, "/v2/jobs/failed", endpoint="failed_jobs_v2")
 api.add_resource(CancelJob, "/v2/jobs/<string:job_id>", endpoint="cancel_job_v2")
 api.add_resource(ReplayJob, "/v2/jobs/<string:job_id>/replay", endpoint="replay_job_v2")
+api.add_resource(StreamJob, "/v2/jobs/<string:job_id>/stream", endpoint="stream_job_v2")
 api.add_resource(Contexts, "/v2/contexts", endpoint="contexts_v2")
 api.add_resource(ApiKeys, "/v2/api-keys", endpoint="api_keys_v2")
 api.add_resource(ApiKey, "/v2/api-keys/<string:key_id>", endpoint="api_key_v2")

--- a/packages/naas/naas/resources/stream_job.py
+++ b/packages/naas/naas/resources/stream_job.py
@@ -1,0 +1,129 @@
+"""SSE streaming endpoint for real-time job status updates."""
+
+import json
+import threading
+import time
+from collections.abc import Generator
+
+from flask import Response, current_app, request
+from flask_restful import Resource
+from rq.exceptions import NoSuchJobError
+from rq.job import Job
+from werkzeug.exceptions import Forbidden, NotFound, TooManyRequests
+
+from naas.library.auth import Credentials, job_unlocker, require_role
+
+#: Maximum concurrent SSE connections across all workers in this process.
+MAX_SSE_CONNECTIONS = 100
+
+#: Server-side timeout for SSE connections in seconds (5 minutes).
+SSE_TIMEOUT = 300
+
+#: Interval between Redis polls in seconds.
+POLL_INTERVAL = 1.0
+
+_active_connections = 0
+_connections_lock = threading.Lock()
+
+#: Terminal job statuses that close the SSE stream.
+_TERMINAL = frozenset({"finished", "failed", "canceled", "cancelled"})
+
+
+def _format_sse(event: str, data: dict) -> str:
+    """Format a single SSE message."""
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
+
+def _build_event(job_id: str, job: Job | None, status: str) -> tuple[str, dict]:
+    """Build an SSE event tuple (event_type, data) from job state."""
+    data: dict = {"job_id": job_id, "status": status}
+
+    if status == "finished" and job is not None and job.result is not None:
+        results = job.result
+        data["results"] = results[0]
+        data["error"] = results[1]
+        if results[0] and "_detected_platform" in results[0]:
+            data["detected_platform"] = results[0].pop("_detected_platform")
+        return "result", data
+
+    if status == "failed" and job is not None:
+        data["error"] = str(job.exc_info).strip() if job.exc_info else "Job failed"
+        return "result", data
+
+    return "status", data
+
+
+class StreamJob(Resource):
+    """Stream job status updates via Server-Sent Events."""
+
+    @require_role("viewer")
+    def get(self, job_id: str) -> Response:
+        """Open an SSE stream for the given job.
+
+        Args:
+            job_id: The job UUID to stream.
+
+        Returns:
+            A streaming ``text/event-stream`` response.
+        """
+        # --- verify job exists ---
+        redis = current_app.config["redis"]
+        try:
+            Job.fetch(job_id, connection=redis)
+        except NoSuchJobError:
+            raise NotFound(f"Job {job_id} not found")
+
+        # --- auth (same as GetResults) ---
+        auth = request.authorization
+        if not auth or not auth.username or not auth.password:  # pragma: no cover
+            raise Forbidden
+
+        creds = Credentials(username=auth.username, password=auth.password)
+        if not job_unlocker(salted_creds=creds.salted_hash(), job_id=job_id):
+            raise Forbidden
+
+        # --- connection limit ---
+        global _active_connections  # noqa: PLW0603
+        with _connections_lock:
+            if _active_connections >= MAX_SSE_CONNECTIONS:
+                raise TooManyRequests("SSE connection limit reached")
+            _active_connections += 1
+
+        # Capture redis ref outside request context for the generator
+        redis_conn = redis
+
+        def generate() -> Generator[str, None, None]:
+            global _active_connections  # noqa: PLW0603
+            try:
+                last_status = None
+                deadline = time.monotonic() + SSE_TIMEOUT
+
+                while time.monotonic() < deadline:
+                    try:
+                        job = Job.fetch(job_id, connection=redis_conn)
+                        status = job.get_status()
+                    except NoSuchJobError:
+                        yield _format_sse("result", {"job_id": job_id, "status": "not_found"})
+                        return
+
+                    if status != last_status:
+                        event_type, data = _build_event(job_id, job, status)
+                        yield _format_sse(event_type, data)
+                        last_status = status
+
+                        if status in _TERMINAL:
+                            return
+
+                    time.sleep(POLL_INTERVAL)
+
+                # Timeout reached
+                yield _format_sse("timeout", {"job_id": job_id, "message": "Stream timeout"})
+            finally:
+                with _connections_lock:
+                    _active_connections -= 1
+
+        return Response(
+            generate(),
+            mimetype="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )

--- a/packages/naas/tests/conftest.py
+++ b/packages/naas/tests/conftest.py
@@ -49,7 +49,8 @@ def app():
             with patch("naas.resources.get_results.Job.fetch", side_effect=_mock_job_fetch):
                 with patch("naas.library.auth.Job.fetch", side_effect=_mock_job_fetch):
                     with patch("naas.resources.cancel_job.Job.fetch", side_effect=_mock_job_fetch):
-                        yield flask_app
+                        with patch("naas.resources.stream_job.Job.fetch", side_effect=_mock_job_fetch):
+                            yield flask_app
 
 
 @pytest.fixture

--- a/packages/naas/tests/unit/test_spectree_coverage.py
+++ b/packages/naas/tests/unit/test_spectree_coverage.py
@@ -15,6 +15,7 @@ from naas.resources.list_jobs import ListJobs
 from naas.resources.send_command import SendCommand
 from naas.resources.send_command_structured import SendCommandStructured
 from naas.resources.send_config import SendConfig
+from naas.resources.stream_job import StreamJob
 
 # Every Resource class and the HTTP methods that MUST have spec.validate
 _RESOURCE_METHODS: list[tuple[type, list[str]]] = [
@@ -31,6 +32,7 @@ _RESOURCE_METHODS: list[tuple[type, list[str]]] = [
     (ApiKeys, ["get", "post"]),
     (ApiKey, ["delete"]),
     (ApiKeyRotate, ["post"]),
+    (StreamJob, []),  # SSE streaming — returns raw text/event-stream, no spectree model
 ]
 
 

--- a/packages/naas/tests/unit/test_stream_job.py
+++ b/packages/naas/tests/unit/test_stream_job.py
@@ -1,0 +1,250 @@
+"""Unit tests for SSE job streaming endpoint."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from rq.exceptions import NoSuchJobError
+
+from naas.library.auth import Credentials
+from naas.resources.stream_job import (
+    MAX_SSE_CONNECTIONS,
+    _connections_lock,
+    _format_sse,
+)
+
+
+@pytest.fixture
+def auth():
+    """Basic auth tuple matching the test app's mock job hash."""
+    return ("admin", "admin")
+
+
+def _set_job_hash(job, username, password):
+    """Set the mock job's hash to match the given credentials."""
+    creds = Credentials(username=username, password=password)
+    job.meta["hash"] = creds.salted_hash()
+
+
+def _make_job(status="queued", result=None, exc_info=None):
+    """Create a mock RQ job."""
+    job = MagicMock()
+    job.id = "test-job-id"
+    job.meta = {"hash": ""}
+    job.get_status.return_value = status
+    job.result = result
+    job.exc_info = exc_info
+    return job
+
+
+def _collect_events(response) -> list[dict]:
+    """Parse SSE events from a streaming response."""
+    events = []
+    for chunk in response.response:
+        if isinstance(chunk, bytes):
+            chunk = chunk.decode()
+        for block in chunk.strip().split("\n\n"):
+            if not block:
+                continue
+            event = {}
+            for line in block.split("\n"):
+                if line.startswith("event: "):
+                    event["event"] = line[7:]
+                elif line.startswith("data: "):
+                    event["data"] = json.loads(line[6:])
+            if event:
+                events.append(event)
+    return events
+
+
+def _patch_job(job):
+    """Context manager that patches Job.fetch everywhere to return the given job."""
+
+    def side_effect(job_id, connection=None):
+        if job is None:
+            raise NoSuchJobError(job_id)
+        return job
+
+    return (
+        patch("naas.resources.stream_job.Job.fetch", side_effect=side_effect),
+        patch("naas.library.auth.Job.fetch", side_effect=side_effect),
+    )
+
+
+class TestStreamJob:
+    """Tests for GET /v2/jobs/{id}/stream."""
+
+    def test_streams_queued_to_finished(self, app, auth):
+        """Job transitions queued → started → finished emit correct events."""
+        job = _make_job()
+        _set_job_hash(job, *auth)
+        statuses = iter(["queued", "queued", "started", "started", "finished"])
+        job.get_status.side_effect = lambda: next(statuses)
+        job.result = [{"show version": "output"}, None]
+
+        p1, p2 = _patch_job(job)
+        with p1, p2, patch("naas.resources.stream_job.POLL_INTERVAL", 0):
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                events = _collect_events(resp)
+
+        assert resp.status_code == 200
+        assert resp.content_type == "text/event-stream; charset=utf-8"
+        assert len(events) == 3
+        assert events[0] == {"event": "status", "data": {"job_id": "test-job-id", "status": "queued"}}
+        assert events[1] == {"event": "status", "data": {"job_id": "test-job-id", "status": "started"}}
+        assert events[2]["event"] == "result"
+        assert events[2]["data"]["status"] == "finished"
+        assert events[2]["data"]["results"] == {"show version": "output"}
+
+    def test_streams_failed_job(self, app, auth):
+        """Failed job emits result event with error."""
+        job = _make_job(status="failed", exc_info="ConnectionError: timed out")
+        _set_job_hash(job, *auth)
+
+        p1, p2 = _patch_job(job)
+        with p1, p2, patch("naas.resources.stream_job.POLL_INTERVAL", 0):
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                events = _collect_events(resp)
+
+        assert len(events) == 1
+        assert events[0]["event"] == "result"
+        assert events[0]["data"]["status"] == "failed"
+        assert "timed out" in events[0]["data"]["error"]
+
+    def test_job_not_found_returns_404(self, app, auth):
+        """Non-existent job returns 404."""
+        p1, p2 = _patch_job(None)
+        with p1, p2:
+            with app.test_client() as c:
+                resp = c.get("/v2/jobs/no-such-id/stream", auth=auth)
+
+        assert resp.status_code == 404
+
+    def test_job_disappears_mid_stream(self, app, auth):
+        """Job deleted from Redis mid-stream emits not_found event."""
+        job = _make_job(status="queued")
+        _set_job_hash(job, *auth)
+        call_count = 0
+
+        def fetch_side_effect(job_id, connection=None):
+            nonlocal call_count
+            call_count += 1
+            # First two calls: existence check + auth check
+            if call_count <= 2:
+                return job
+            # Generator's first fetch returns job (emits queued)
+            if call_count == 3:
+                return job
+            raise NoSuchJobError(job_id)
+
+        with (
+            patch("naas.resources.stream_job.Job.fetch", side_effect=fetch_side_effect),
+            patch("naas.library.auth.Job.fetch", side_effect=fetch_side_effect),
+            patch("naas.resources.stream_job.POLL_INTERVAL", 0),
+        ):
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                events = _collect_events(resp)
+
+        assert events[-1]["event"] == "result"
+        assert events[-1]["data"]["status"] == "not_found"
+
+    def test_wrong_credentials_returns_403(self, app):
+        """Wrong credentials are rejected."""
+        job = _make_job()
+        _set_job_hash(job, "admin", "admin")
+
+        p1, p2 = _patch_job(job)
+        with p1, p2:
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=("admin", "wrong"))
+
+        assert resp.status_code == 403
+
+    def test_no_auth_returns_401(self, app):
+        """Missing auth returns 401."""
+        with app.test_client() as c:
+            resp = c.get("/v2/jobs/some-id/stream")
+        assert resp.status_code == 401
+
+    def test_timeout_emits_timeout_event(self, app, auth):
+        """Stream that exceeds timeout emits timeout event."""
+        job = _make_job(status="started")
+        _set_job_hash(job, *auth)
+
+        p1, p2 = _patch_job(job)
+        with (
+            p1,
+            p2,
+            patch("naas.resources.stream_job.SSE_TIMEOUT", 0),
+            patch("naas.resources.stream_job.POLL_INTERVAL", 0),
+        ):
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                events = _collect_events(resp)
+
+        assert events[-1]["event"] == "timeout"
+
+    def test_connection_limit_returns_429(self, app, auth):
+        """Exceeding connection limit returns 429."""
+        import naas.resources.stream_job as mod
+
+        job = _make_job()
+        _set_job_hash(job, *auth)
+
+        p1, p2 = _patch_job(job)
+        with p1, p2:
+            with _connections_lock:
+                original = mod._active_connections
+                mod._active_connections = MAX_SSE_CONNECTIONS
+            try:
+                with app.test_client() as c:
+                    resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                assert resp.status_code == 429
+            finally:
+                with _connections_lock:
+                    mod._active_connections = original
+
+    def test_connection_counter_decrements(self, app, auth):
+        """Active connection counter decrements after stream completes."""
+        import naas.resources.stream_job as mod
+
+        job = _make_job(status="finished", result=[{"output": "ok"}, None])
+        _set_job_hash(job, *auth)
+
+        before = mod._active_connections
+        p1, p2 = _patch_job(job)
+        with p1, p2, patch("naas.resources.stream_job.POLL_INTERVAL", 0):
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                _collect_events(resp)
+
+        assert mod._active_connections == before
+
+    def test_detected_platform_extracted(self, app, auth):
+        """Detected platform is extracted from results."""
+        job = _make_job(
+            status="finished",
+            result=[{"show ver": "out", "_detected_platform": "cisco_ios"}, None],
+        )
+        _set_job_hash(job, *auth)
+
+        p1, p2 = _patch_job(job)
+        with p1, p2, patch("naas.resources.stream_job.POLL_INTERVAL", 0):
+            with app.test_client() as c:
+                resp = c.get(f"/v2/jobs/{job.id}/stream", auth=auth)
+                events = _collect_events(resp)
+
+        assert events[0]["data"]["detected_platform"] == "cisco_ios"
+        assert "_detected_platform" not in events[0]["data"]["results"]
+
+
+class TestFormatSse:
+    """Tests for SSE message formatting."""
+
+    def test_format_sse(self):
+        data = {"job_id": "abc", "status": "queued"}
+        result = _format_sse("status", data)
+        assert result == f"event: status\ndata: {json.dumps(data)}\n\n"


### PR DESCRIPTION
## Summary

Add `GET /v2/jobs/{id}/stream` for real-time job status updates via Server-Sent Events, replacing the need to poll for job completion.

### SSE endpoint (`stream_job.py`)
- Polls Redis internally (1s interval), pushes `status` events for queued/started and `result` events for finished/failed
- Connection closes on terminal state
- Server-side timeout: 5 minutes
- Concurrent connection limit: 100 (returns 429 when exceeded)
- Auth mirrors `GetResults` (require_role + job_unlocker)

### Concurrency
No Gunicorn changes needed — already running `gthread` with 8 workers × 32 threads = 256 concurrent slots. See [analysis comment](https://github.com/lykinsbd/naas/issues/404#issuecomment-4245615124).

### Client library
- `NaasClient.stream_job(job_id)` yields parsed SSE event dicts via httpx streaming

### Tests
- 11 unit tests, 100% coverage on `stream_job.py`
- Full suite: 367 passed, 100% coverage

Closes #404