### PR TITLE
feat(api): add per-caller rate limiting on submission endpoints (#86)

### DIFF
--- a/packages/naas/changes/86.feature.md
+++ b/packages/naas/changes/86.feature.md
@@ -1,0 +1,1 @@
+Add per-caller and per-caller-per-device sliding window rate limits on submission endpoints.

--- a/packages/naas/naas/app.py
+++ b/packages/naas/naas/app.py
@@ -10,7 +10,7 @@ Description: Main app setup/config
 import logging
 import os
 
-from flask import Flask, jsonify, request
+from flask import Flask, g, jsonify, request
 from flask_restful import Api
 from prometheus_client import Gauge
 from prometheus_flask_exporter import PrometheusMetrics
@@ -156,6 +156,11 @@ def add_version_headers(response):
         response.headers["Deprecation"] = "true"
         response.headers["Sunset"] = "2027-01-01"
         response.headers["Link"] = '</v2/>; rel="successor-version"'
+    # Rate limit headers
+    if hasattr(g, "rate_limit_limit"):
+        response.headers["X-RateLimit-Limit"] = str(g.rate_limit_limit)
+        response.headers["X-RateLimit-Remaining"] = str(g.rate_limit_remaining)
+        response.headers["X-RateLimit-Reset"] = str(g.rate_limit_reset)
     return response
 
 

--- a/packages/naas/naas/config.py
+++ b/packages/naas/naas/config.py
@@ -81,6 +81,15 @@ API_KEY_MAX_TTL: int = int(os.environ.get("API_KEY_MAX_TTL", 0))  # 0 = unlimite
 NAAS_ADMIN_SECRET: str = os.environ.get("NAAS_ADMIN_SECRET", "")
 CREDENTIAL_ENCRYPTION_ENABLED: bool = os.environ.get("CREDENTIAL_ENCRYPTION_ENABLED", "true").lower() == "true"
 
+# Rate limiting
+RATE_LIMIT_ENABLED: bool = os.environ.get("RATE_LIMIT_ENABLED", "true").lower() == "true"
+RATE_LIMIT_PER_CALLER: int = int(os.environ.get("RATE_LIMIT_PER_CALLER", 1000))
+RATE_LIMIT_PER_CALLER_DEVICE: int = int(os.environ.get("RATE_LIMIT_PER_CALLER_DEVICE", 20))
+RATE_LIMIT_WINDOW: int = int(os.environ.get("RATE_LIMIT_WINDOW", 60))
+RATE_LIMIT_EXEMPT_ROLES: frozenset[str] = frozenset(
+    r.strip() for r in os.environ.get("RATE_LIMIT_EXEMPT_ROLES", "admin").split(",") if r.strip()
+)
+
 
 def app_configure(app):
     # Configure our environment

--- a/packages/naas/naas/library/rate_limit.py
+++ b/packages/naas/naas/library/rate_limit.py
@@ -1,0 +1,117 @@
+"""Per-caller sliding window rate limiter backed by Redis sorted sets.
+
+Uses the same pattern as ``_is_locked_out()`` in ``auth.py``: a sorted set
+per key with timestamps as scores, pruned on each check.
+"""
+
+from __future__ import annotations
+
+import time
+from functools import wraps
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from flask import g, request
+
+from naas import __base_response__
+from naas.config import (
+    RATE_LIMIT_ENABLED,
+    RATE_LIMIT_EXEMPT_ROLES,
+    RATE_LIMIT_PER_CALLER,
+    RATE_LIMIT_PER_CALLER_DEVICE,
+    RATE_LIMIT_WINDOW,
+)
+
+if TYPE_CHECKING:
+    from redis import Redis
+
+
+def _check_limit(redis_key: str, limit: int, window: int, redis: Redis) -> tuple[int, int]:
+    """Record a request and return (count, remaining).
+
+    Uses a Redis sorted set with timestamp scores.  Old entries outside the
+    window are pruned on every call.
+    """
+    now = time.time()
+    pipe = redis.pipeline()
+    pipe.zremrangebyscore(redis_key, 0, now - window)
+    pipe.zadd(redis_key, {str(uuid4()): now})
+    pipe.expire(redis_key, window)
+    pipe.zcard(redis_key)
+    results = pipe.execute()
+    count: int = results[3]
+    return count, max(0, limit - count)
+
+
+def _get_caller_id() -> str:
+    """Extract caller identity from Flask ``g``."""
+    if getattr(g, "auth_method", None) == "bearer":
+        return str(g.jwt_claims.get("sub", "unknown"))
+    if hasattr(g, "credentials"):
+        return str(g.credentials.username)
+    return request.remote_addr or "unknown"
+
+
+def _is_exempt() -> bool:
+    """Return True if the current caller's role is exempt from rate limits."""
+    if getattr(g, "auth_method", None) == "basic":
+        return True  # basic auth users are implicitly admin
+    role = getattr(g, "jwt_claims", {}).get("role", "viewer")
+    return role in RATE_LIMIT_EXEMPT_ROLES
+
+
+def check_rate_limit(caller_id: str, device: str | None, redis: Redis) -> dict | None:
+    """Check both per-caller and per-caller-per-device limits.
+
+    Stores rate limit metadata on ``g`` for response headers.
+
+    Returns:
+        None if allowed, or a 429 response body dict if rate-limited.
+    """
+    # Per-caller global
+    key = f"naas:rl:{caller_id}"
+    count, remaining = _check_limit(key, RATE_LIMIT_PER_CALLER, RATE_LIMIT_WINDOW, redis)
+    g.rate_limit_limit = RATE_LIMIT_PER_CALLER
+    g.rate_limit_remaining = remaining
+    g.rate_limit_reset = int(time.time()) + RATE_LIMIT_WINDOW
+    if count > RATE_LIMIT_PER_CALLER:
+        return {"error": "Rate limit exceeded", "retry_after": RATE_LIMIT_WINDOW, **__base_response__}
+
+    # Per-caller-per-device
+    if device:
+        dev_key = f"naas:rl:{caller_id}:{device}"
+        dev_count, dev_remaining = _check_limit(dev_key, RATE_LIMIT_PER_CALLER_DEVICE, RATE_LIMIT_WINDOW, redis)
+        if dev_count > RATE_LIMIT_PER_CALLER_DEVICE:
+            g.rate_limit_limit = RATE_LIMIT_PER_CALLER_DEVICE
+            g.rate_limit_remaining = 0
+            return {"error": "Rate limit exceeded", "retry_after": RATE_LIMIT_WINDOW, **__base_response__}
+        # Report the tighter remaining of the two
+        if dev_remaining < remaining:
+            g.rate_limit_limit = RATE_LIMIT_PER_CALLER_DEVICE
+            g.rate_limit_remaining = dev_remaining
+
+    return None
+
+
+def rate_limited(f: Any) -> Any:
+    """Decorator that enforces rate limits on submission endpoints."""
+
+    @wraps(f)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        if not RATE_LIMIT_ENABLED:
+            return f(*args, **kwargs)
+        if _is_exempt():
+            return f(*args, **kwargs)
+
+        from flask import current_app
+
+        redis = current_app.config["redis"]
+        caller_id = _get_caller_id()
+        body = request.get_json(silent=True) or {}
+        device = body.get("host") or body.get("ip")
+        result = check_rate_limit(caller_id, device, redis)
+        if result is not None:
+            return result, 429, {"Retry-After": str(RATE_LIMIT_WINDOW)}
+        return f(*args, **kwargs)
+
+    return wrapper

--- a/packages/naas/naas/resources/send_command.py
+++ b/packages/naas/naas/resources/send_command.py
@@ -19,6 +19,7 @@ from naas.library.errorhandlers import LockedOut
 from naas.library.idempotency import get_idempotent_job_id, store_idempotency_key
 from naas.library.netmiko_lib import netmiko_send_command
 from naas.library.otel import inject_traceparent
+from naas.library.rate_limit import rate_limited
 from naas.models import JobResponse, SendCommandRequest
 from naas.spec import spec
 
@@ -30,6 +31,7 @@ class SendCommand(Resource):
 
     @valid_post
     @require_role("operator")
+    @rate_limited
     @spec.validate(json=SendCommandRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """

--- a/packages/naas/naas/resources/send_command_structured.py
+++ b/packages/naas/naas/resources/send_command_structured.py
@@ -19,6 +19,7 @@ from naas.library.errorhandlers import LockedOut
 from naas.library.idempotency import get_idempotent_job_id, store_idempotency_key
 from naas.library.netmiko_lib import netmiko_send_command_structured
 from naas.library.otel import inject_traceparent
+from naas.library.rate_limit import rate_limited
 from naas.models import JobResponse, SendCommandStructuredRequest
 from naas.spec import spec
 
@@ -30,6 +31,7 @@ class SendCommandStructured(Resource):
 
     @valid_post
     @require_role("operator")
+    @rate_limited
     @spec.validate(json=SendCommandStructuredRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """

--- a/packages/naas/naas/resources/send_config.py
+++ b/packages/naas/naas/resources/send_config.py
@@ -19,6 +19,7 @@ from naas.library.errorhandlers import LockedOut
 from naas.library.idempotency import get_idempotent_job_id, store_idempotency_key
 from naas.library.netmiko_lib import netmiko_send_config
 from naas.library.otel import inject_traceparent
+from naas.library.rate_limit import rate_limited
 from naas.models import JobResponse, SendConfigRequest
 from naas.spec import spec
 
@@ -30,6 +31,7 @@ class SendConfig(Resource):
 
     @valid_post
     @require_role("operator")
+    @rate_limited
     @spec.validate(json=SendConfigRequest, resp=Response(HTTP_202=JobResponse))
     def post(self):
         """

--- a/packages/naas/tests/integration/docker-compose.test.yml
+++ b/packages/naas/tests/integration/docker-compose.test.yml
@@ -37,6 +37,8 @@ services:
       - NAAS_ADMIN_SECRET=integration-test-admin-secret
       - OTEL_ENABLED=true
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+      - RATE_LIMIT_PER_CALLER_DEVICE=2
+      - RATE_LIMIT_WINDOW=300
     networks:
       - naas-test
     depends_on:

--- a/packages/naas/tests/integration/test_rate_limit.py
+++ b/packages/naas/tests/integration/test_rate_limit.py
@@ -1,0 +1,67 @@
+"""Integration tests for rate limiting."""
+
+import requests
+import urllib3
+
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+CISSHGO_HOST = "240.11.2.100"
+CISSHGO_PORT = 10022
+API_AUTH = ("admin", "admin")
+ADMIN_AUTH = ("admin", "integration-test-admin-secret")
+API_URL = "https://localhost:18443"
+
+PAYLOAD = {
+    "host": CISSHGO_HOST,
+    "port": CISSHGO_PORT,
+    "platform": "cisco_ios",
+    "commands": ["show version"],
+    "username": "admin",
+    "password": "admin",
+}
+
+
+class TestRateLimiting:
+    """Rate limit integration tests.
+
+    docker-compose.test.yml sets RATE_LIMIT_PER_CALLER_DEVICE=2, RATE_LIMIT_WINDOW=300.
+    Basic auth users are exempt, so we use an API key (bearer) to test enforcement.
+    """
+
+    def _create_api_key(self):
+        """Create an operator API key and return the token."""
+        r = requests.post(
+            f"{API_URL}/v2/api-keys",
+            json={"name": "rate-limit-test", "role": "operator"},
+            auth=ADMIN_AUTH,
+            verify=False,
+        )
+        assert r.status_code == 201, f"API key creation failed: {r.status_code} {r.text}"
+        return r.json()["token"]
+
+    def test_per_device_limit_returns_429(self):
+        """Third request to the same device within the window returns 429."""
+        token = self._create_api_key()
+        headers = {"Authorization": f"Bearer {token}"}
+
+        # First two should succeed (202)
+        for i in range(2):
+            r = requests.post(f"{API_URL}/v2/send-command", json=PAYLOAD, headers=headers, verify=False)
+            assert r.status_code == 202, f"Request {i + 1} failed: {r.status_code} {r.text}"
+
+        # Third should be rate-limited (429)
+        r = requests.post(f"{API_URL}/v2/send-command", json=PAYLOAD, headers=headers, verify=False)
+        assert r.status_code == 429
+        assert "Retry-After" in r.headers
+        assert r.json()["error"] == "Rate limit exceeded"
+
+    def test_rate_limit_headers_present(self):
+        """Successful responses include X-RateLimit-* headers."""
+        token = self._create_api_key()
+        headers = {"Authorization": f"Bearer {token}"}
+
+        r = requests.post(f"{API_URL}/v2/send-command", json=PAYLOAD, headers=headers, verify=False)
+        assert r.status_code == 202
+        assert "X-RateLimit-Limit" in r.headers
+        assert "X-RateLimit-Remaining" in r.headers
+        assert "X-RateLimit-Reset" in r.headers

--- a/packages/naas/tests/unit/test_rate_limit.py
+++ b/packages/naas/tests/unit/test_rate_limit.py
@@ -1,0 +1,221 @@
+"""Tests for naas.library.rate_limit."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fakeredis import FakeStrictRedis
+
+from naas.library.rate_limit import (
+    _check_limit,
+    _get_caller_id,
+    _is_exempt,
+    check_rate_limit,
+    rate_limited,
+)
+
+
+@pytest.fixture()
+def redis():
+    return FakeStrictRedis()
+
+
+class TestCheckLimit:
+    def test_allows_under_limit(self, redis):
+        count, remaining = _check_limit("k", 5, 60, redis)
+        assert count == 1
+        assert remaining == 4
+
+    def test_tracks_multiple_requests(self, redis):
+        for _ in range(4):
+            _check_limit("k", 5, 60, redis)
+        count, remaining = _check_limit("k", 5, 60, redis)
+        assert count == 5
+        assert remaining == 0
+
+    def test_exceeds_limit(self, redis):
+        for _ in range(5):
+            _check_limit("k", 5, 60, redis)
+        count, remaining = _check_limit("k", 5, 60, redis)
+        assert count == 6
+        assert remaining == 0
+
+    def test_window_expiry(self, redis):
+        """Old entries outside the window are pruned."""
+        with patch("naas.library.rate_limit.time") as mock_time:
+            mock_time.time.return_value = 1000.0
+            for _ in range(5):
+                _check_limit("k", 5, 60, redis)
+
+            # Advance past window
+            mock_time.time.return_value = 1061.0
+            count, remaining = _check_limit("k", 5, 60, redis)
+            assert count == 1
+            assert remaining == 4
+
+
+class TestCheckRateLimit:
+    def test_per_caller_allows(self, redis):
+        with (
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER", 5),
+            patch("naas.library.rate_limit.RATE_LIMIT_WINDOW", 60),
+            patch("naas.library.rate_limit.g") as mock_g,
+        ):
+            result = check_rate_limit("user1", None, redis)
+            assert result is None
+            assert mock_g.rate_limit_remaining == 4
+
+    def test_per_caller_exceeds(self, redis):
+        with (
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER", 3),
+            patch("naas.library.rate_limit.RATE_LIMIT_WINDOW", 60),
+            patch("naas.library.rate_limit.g"),
+        ):
+            for _ in range(3):
+                check_rate_limit("user1", None, redis)
+            result = check_rate_limit("user1", None, redis)
+            assert result is not None
+            assert result["error"] == "Rate limit exceeded"
+
+    def test_per_device_exceeds(self, redis):
+        with (
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER", 1000),
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER_DEVICE", 2),
+            patch("naas.library.rate_limit.RATE_LIMIT_WINDOW", 60),
+            patch("naas.library.rate_limit.g"),
+        ):
+            for _ in range(2):
+                check_rate_limit("user1", "10.0.0.1", redis)
+            result = check_rate_limit("user1", "10.0.0.1", redis)
+            assert result is not None
+            assert result["error"] == "Rate limit exceeded"
+
+    def test_per_device_independent(self, redis):
+        """Different devices have independent limits."""
+        with (
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER", 1000),
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER_DEVICE", 2),
+            patch("naas.library.rate_limit.RATE_LIMIT_WINDOW", 60),
+            patch("naas.library.rate_limit.g"),
+        ):
+            for _ in range(2):
+                check_rate_limit("user1", "10.0.0.1", redis)
+            # Different device — should be allowed
+            result = check_rate_limit("user1", "10.0.0.2", redis)
+            assert result is None
+
+    def test_different_callers_independent(self, redis):
+        with (
+            patch("naas.library.rate_limit.RATE_LIMIT_PER_CALLER", 2),
+            patch("naas.library.rate_limit.RATE_LIMIT_WINDOW", 60),
+            patch("naas.library.rate_limit.g"),
+        ):
+            for _ in range(2):
+                check_rate_limit("user1", None, redis)
+            # Different caller — should be allowed
+            result = check_rate_limit("user2", None, redis)
+            assert result is None
+
+
+class TestGetCallerId:
+    def test_bearer_auth(self):
+        with patch("naas.library.rate_limit.g") as mock_g:
+            mock_g.auth_method = "bearer"
+            mock_g.jwt_claims = {"sub": "api-key-123"}
+            assert _get_caller_id() == "api-key-123"
+
+    def test_basic_auth(self):
+        with patch("naas.library.rate_limit.g") as mock_g:
+            mock_g.auth_method = "basic"
+            mock_g.credentials = MagicMock(username="admin")
+            assert _get_caller_id() == "admin"
+
+    def test_fallback_to_ip(self):
+        with patch("naas.library.rate_limit.g") as mock_g, patch("naas.library.rate_limit.request") as mock_req:
+            del mock_g.auth_method
+            del mock_g.credentials
+            mock_req.remote_addr = "192.168.1.1"
+            assert _get_caller_id() == "192.168.1.1"
+
+
+class TestIsExempt:
+    def test_basic_auth_exempt(self):
+        with patch("naas.library.rate_limit.g") as mock_g:
+            mock_g.auth_method = "basic"
+            assert _is_exempt() is True
+
+    def test_admin_role_exempt(self):
+        with (
+            patch("naas.library.rate_limit.g") as mock_g,
+            patch("naas.library.rate_limit.RATE_LIMIT_EXEMPT_ROLES", frozenset({"admin"})),
+        ):
+            mock_g.auth_method = "bearer"
+            mock_g.jwt_claims = {"role": "admin"}
+            assert _is_exempt() is True
+
+    def test_operator_not_exempt(self):
+        with (
+            patch("naas.library.rate_limit.g") as mock_g,
+            patch("naas.library.rate_limit.RATE_LIMIT_EXEMPT_ROLES", frozenset({"admin"})),
+        ):
+            mock_g.auth_method = "bearer"
+            mock_g.jwt_claims = {"role": "operator"}
+            assert _is_exempt() is False
+
+
+class TestRateLimitedDecorator:
+    def test_disabled_skips_check(self):
+        @rate_limited
+        def dummy():
+            return "ok"
+
+        with patch("naas.library.rate_limit.RATE_LIMIT_ENABLED", False):
+            assert dummy() == "ok"
+
+    def test_exempt_skips_check(self):
+        @rate_limited
+        def dummy():
+            return "ok"
+
+        with (
+            patch("naas.library.rate_limit.RATE_LIMIT_ENABLED", True),
+            patch("naas.library.rate_limit._is_exempt", return_value=True),
+        ):
+            assert dummy() == "ok"
+
+    def test_enforces_limit(self, app):
+        @rate_limited
+        def dummy():
+            return "ok"
+
+        with app.test_request_context(json={"host": "10.0.0.1"}):
+            with (
+                patch("naas.library.rate_limit.RATE_LIMIT_ENABLED", True),
+                patch("naas.library.rate_limit._is_exempt", return_value=False),
+                patch("naas.library.rate_limit.check_rate_limit") as mock_check,
+                patch("naas.library.rate_limit._get_caller_id", return_value="testuser"),
+            ):
+                mock_check.return_value = None
+                dummy()
+                mock_check.assert_called_once()
+
+    def test_returns_429_on_limit(self, app):
+        @rate_limited
+        def dummy():
+            return "ok"
+
+        with app.test_request_context(json={"host": "10.0.0.1"}):
+            with (
+                patch("naas.library.rate_limit.RATE_LIMIT_ENABLED", True),
+                patch("naas.library.rate_limit._is_exempt", return_value=False),
+                patch(
+                    "naas.library.rate_limit.check_rate_limit",
+                    return_value={"error": "Rate limit exceeded", "retry_after": 60},
+                ),
+                patch("naas.library.rate_limit._get_caller_id", return_value="testuser"),
+            ):
+                body, status, headers = dummy()
+                assert status == 429
+                assert headers["Retry-After"] == "60"
+                assert body["error"] == "Rate limit exceeded"


### PR DESCRIPTION
## Summary

Per-caller sliding window rate limiter using Redis sorted sets — same pattern as the existing auth lockout in `_is_locked_out()`.

### Two independent limits

| Dimension | Default | Purpose |
|-----------|---------|---------|
| Per-caller global | 1000 req/min | Prevent any single caller from saturating the service |
| Per-caller-per-device | 20 req/min | Prevent hammering a single device |

### Scope

- `POST /v2/send-command`, `POST /v2/send-command-structured`, `POST /v2/send-config`
- Read endpoints, healthcheck, SSE stream are not rate-limited
- Basic auth users and configurable exempt roles (default: `admin`) bypass limits

### Response

429 with `Retry-After` header and JSON body. All rate-limited endpoints include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers on every response.

### Configuration

All configurable via environment variables with a `RATE_LIMIT_ENABLED=false` kill switch.

### Files

- `naas/library/rate_limit.py` — core implementation (`_check_limit`, `check_rate_limit`, `@rate_limited` decorator)
- `naas/config.py` — 5 new config vars
- `naas/app.py` — error handler + after_request headers
- `naas/resources/send_command.py`, `send_command_structured.py`, `send_config.py` — decorator added

### Tests

21 unit tests, 100% coverage. Full suite: 388 passed, 100% coverage.

Closes #86