### PR TITLE
test(client): add retry/backoff to healthcheck integration tests

### DIFF
--- a/packages/naas-client/tests/integration/test_client_integration.py
+++ b/packages/naas-client/tests/integration/test_client_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,12 +14,21 @@ from naas_client.models import HealthCheckResponse, JobStatus
 if TYPE_CHECKING:
     from naas_client.async_client import AsyncNaasClient
 
+HEALTHCHECK_TIMEOUT = 30
+HEALTHCHECK_INTERVAL = 2
+
 
 class TestHealthcheck:
     def test_healthcheck(self, client: NaasClient) -> None:
-        health = client.healthcheck()
-        assert isinstance(health, HealthCheckResponse)
-        assert health.status == "healthy"
+        deadline = time.monotonic() + HEALTHCHECK_TIMEOUT
+        while True:
+            health = client.healthcheck()
+            assert isinstance(health, HealthCheckResponse)
+            if health.status == "healthy":
+                break
+            if time.monotonic() > deadline:
+                pytest.fail(f"Healthcheck not healthy after {HEALTHCHECK_TIMEOUT}s: status={health.status}")
+            time.sleep(HEALTHCHECK_INTERVAL)
         assert health.components.workers.count is not None
         assert health.components.workers.count > 0
 
@@ -85,8 +95,16 @@ class TestSendCommand:
 class TestAsyncClient:
     @pytest.mark.asyncio
     async def test_healthcheck(self, async_client: AsyncNaasClient) -> None:
-        health = await async_client.healthcheck()
-        assert health.status == "healthy"
+        import asyncio
+
+        deadline = time.monotonic() + HEALTHCHECK_TIMEOUT
+        while True:
+            health = await async_client.healthcheck()
+            if health.status == "healthy":
+                break
+            if time.monotonic() > deadline:
+                pytest.fail(f"Healthcheck not healthy after {HEALTHCHECK_TIMEOUT}s: status={health.status}")
+            await asyncio.sleep(HEALTHCHECK_INTERVAL)
 
     @pytest.mark.asyncio
     async def test_list_contexts(self, async_client: AsyncNaasClient) -> None:

--- a/packages/naas/changes/437.testing.md
+++ b/packages/naas/changes/437.testing.md
@@ -1,0 +1,1 @@
+Add retry/backoff to healthcheck integration tests to handle worker startup timing.


### PR DESCRIPTION
## Summary

Add retry/backoff logic to the healthcheck integration tests so they tolerate workers being slow to register after the Docker Compose stack starts.

Closes #437

## Changes

Both `TestHealthcheck::test_healthcheck` (sync) and `TestAsyncClient::test_healthcheck` (async) now poll the healthcheck endpoint for up to 30 seconds at 2-second intervals before failing, instead of asserting immediately on the first response.

## Testing

- `uv run invoke check` passes
- The fix addresses the flaky `no_workers` failures observed in PR #435 CI ([client-integration job](https://github.com/lykinsbd/naas/actions/runs/24527978751/job/71703321615))