### PR TITLE
test(mcp): add retry to integration healthcheck and register new components

### DIFF
--- a/packages/naas-mcp/tests/integration/conftest.py
+++ b/packages/naas-mcp/tests/integration/conftest.py
@@ -69,14 +69,33 @@ async def integration_mcp_client():
 
     server = FastMCP(name="naas-integration", lifespan=real_lifespan)
 
-    from naas_mcp.resources import contexts, failed_jobs, health
-    from naas_mcp.tools import cancel_job, get_job_result, list_jobs, send_command, send_config
+    from naas_mcp.resources import contexts, failed_jobs, health, jobs
+    from naas_mcp.tools import (
+        cancel_job,
+        create_api_key,
+        get_job_result,
+        list_jobs,
+        revoke_api_key,
+        send_command,
+        send_command_structured,
+        send_config,
+    )
 
-    for fn in (send_command, send_config, get_job_result, cancel_job, list_jobs):
+    for fn in (
+        send_command,
+        send_command_structured,
+        send_config,
+        get_job_result,
+        cancel_job,
+        list_jobs,
+        create_api_key,
+        revoke_api_key,
+    ):
         server.add_tool(fn)
     server.resource("naas://health", name="Health")(health)
     server.resource("naas://contexts", name="Contexts")(contexts)
     server.resource("naas://jobs/failed", name="Failed Jobs")(failed_jobs)
+    server.resource("naas://jobs", name="Jobs")(jobs)
 
     async with Client(transport=server) as client:
         yield client

--- a/packages/naas-mcp/tests/integration/test_mcp_integration.py
+++ b/packages/naas-mcp/tests/integration/test_mcp_integration.py
@@ -7,7 +7,10 @@ Run with: uv run pytest packages/naas-mcp/tests/integration -v
 from __future__ import annotations
 
 import json
+import time
 from typing import TYPE_CHECKING
+
+import pytest
 
 if TYPE_CHECKING:
     from fastmcp.client import Client
@@ -47,10 +50,17 @@ async def test_list_jobs(integration_mcp_client: Client):
 
 async def test_health_resource(integration_mcp_client: Client):
     """Read health resource from live API."""
-    contents = await integration_mcp_client.read_resource("naas://health")
+    import asyncio
 
-    data = json.loads(contents[0].text)  # type: ignore[union-attr]
-    assert data["status"] == "healthy"
+    deadline = time.monotonic() + 30
+    while True:
+        contents = await integration_mcp_client.read_resource("naas://health")
+        data = json.loads(contents[0].text)  # type: ignore[union-attr]
+        if data["status"] == "healthy":
+            break
+        if time.monotonic() > deadline:
+            pytest.fail(f"Healthcheck not healthy after 30s: status={data['status']}")
+        await asyncio.sleep(2)
 
 
 async def test_contexts_resource(integration_mcp_client: Client):

--- a/packages/naas/changes/+mcp-healthcheck-retry.testing.md
+++ b/packages/naas/changes/+mcp-healthcheck-retry.testing.md
@@ -1,0 +1,1 @@
+Add retry/backoff to MCP integration healthcheck test to handle worker startup timing.


### PR DESCRIPTION
## Summary

Apply the same healthcheck retry/backoff fix from PR #438 (client tests) to the MCP integration tests. Also update the MCP integration conftest to register the new tools and resources added in PR #441.

Relates to #437

## Changes

- `packages/naas-mcp/tests/integration/test_mcp_integration.py` — `test_health_resource` now polls for up to 30s instead of asserting immediately
- `packages/naas-mcp/tests/integration/conftest.py` — registers all 8 tools and 4 resources (was only 5 tools and 3 resources)