### PR TITLE
docs: restructure deployment docs as Helm-first, remove Docker Compose bias

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ sequenceDiagram
     participant Worker as RQ Worker
     participant Device as Network Device
 
-    Client->>API: POST /v1/send_command
+    Client->>API: POST /v2/send-command
     API->>Queue: enqueue job (job_id = X-Request-ID)
     API-->>Client: 202 Accepted { job_id }
 
@@ -21,7 +21,7 @@ sequenceDiagram
     Device-->>Worker: command output
     Worker->>Queue: store result
 
-    Client->>API: GET /v1/send_command/{job_id}
+    Client->>API: GET /v2/send-command/{job_id}
     API->>Queue: fetch job result
     API-->>Client: 200 { status: finished, results: {...} }
 ```
@@ -83,11 +83,11 @@ NAAS connects to devices over SSH using Netmiko. The API credentials (HTTP Basic
 
 ## Request Lifecycle
 
-1. **Client** sends `POST /v1/send_command` with device IP, platform, and commands
-2. **API** validates the request (IP format, platform, auth), checks for duplicate job IDs and device lockout, then enqueues the job
+1. **Client** sends `POST /v2/send-command` with device host, platform, and commands
+2. **API** validates the request (host format, platform, auth), checks for duplicate job IDs and device lockout, then enqueues the job
 3. **API** returns `202 Accepted` with the `job_id` (= `X-Request-ID`)
 4. **Worker** picks up the job, checks the circuit breaker, connects to the device via SSH, runs the commands, and stores the result
-5. **Client** polls `GET /v1/send_command/{job_id}` until `status` is `finished` or `failed`
+5. **Client** polls `GET /v2/send-command/{job_id}` until `status` is `finished` or `failed`
 
 ## Why Async?
 
@@ -117,5 +117,17 @@ graph LR
 ```
 
 - **API** scales horizontally — stateless, any instance can handle any request
-- **Workers** scale horizontally — add containers with `docker compose up -d --scale worker=N`
+- **Workers** scale horizontally — add replicas to increase concurrent job capacity
 - **Redis** is the single coordination point — use Redis Sentinel or Cluster for HA
+
+=== "Docker Compose"
+
+    ```bash
+    docker compose up -d --scale worker=N
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas --set worker.replicas=N --set api.replicas=M
+    ```

--- a/docs/contexts.md
+++ b/docs/contexts.md
@@ -102,7 +102,7 @@ Omitting `context` defaults to `"default"`. Existing deployments require no chan
 List active contexts with worker counts and queue depths:
 
 ```bash
-curl -k https://naas.example.com/v1/contexts
+curl -k https://naas.example.com/v2/contexts
 ```
 
 ```json
@@ -121,7 +121,7 @@ curl -k https://naas.example.com/v1/contexts
 ### Unknown context (400)
 
 ```json
-{"error": "Unknown context. See GET /v1/contexts for valid contexts."}
+{"error": "Unknown context. See GET /v2/contexts for valid contexts."}
 ```
 
 ### No workers available (503)
@@ -134,26 +134,51 @@ This occurs when the context is valid but no workers are currently serving it. C
 
 ## Kubernetes Deployment
 
-Deploy separate worker Deployments per context:
+Deploy separate worker pools per context:
 
-```yaml
-# Corp workers
-- name: naas-worker-corp
-  env:
-    - name: WORKER_CONTEXTS
-      value: "corp"
+=== "Helm"
 
-# OOB workers (deployed in OOB network segment)
-- name: naas-worker-oob
-  env:
-    - name: WORKER_CONTEXTS
-      value: "oob-dc1,oob-dc2"
+    ```bash
+    # Main deployment (API + shared Redis)
+    helm install naas charts/naas \
+      --set config.NAAS_CONTEXTS=corp,oob-dc1,oob-dc2,hk-prod,hk-oob
 
-# Hong Kong workers
-- name: naas-worker-hk
-  env:
-    - name: WORKER_CONTEXTS
-      value: "hk-prod,hk-oob"
-```
+    # Corp workers
+    helm install naas-worker-corp charts/naas \
+      --set api.replicas=0 --set redis.enabled=false \
+      --set redis.external.host=naas-redis.naas.svc \
+      --set config.WORKER_CONTEXTS=corp
 
-See [Kubernetes deployment guide](kubernetes.md) for full examples.
+    # OOB workers
+    helm install naas-worker-oob charts/naas \
+      --set api.replicas=0 --set redis.enabled=false \
+      --set redis.external.host=naas-redis.naas.svc \
+      --set config.WORKER_CONTEXTS=oob-dc1,oob-dc2
+
+    # Hong Kong workers
+    helm install naas-worker-hk charts/naas \
+      --set api.replicas=0 --set redis.enabled=false \
+      --set redis.external.host=naas-redis.naas.svc \
+      --set config.WORKER_CONTEXTS=hk-prod,hk-oob
+    ```
+
+=== "Raw Manifests"
+
+    ```yaml
+    # k8s/worker-corp/deployment.yaml
+    env:
+      - name: WORKER_CONTEXTS
+        value: "corp"
+
+    # k8s/worker-oob/deployment.yaml
+    env:
+      - name: WORKER_CONTEXTS
+        value: "oob-dc1,oob-dc2"
+
+    # k8s/worker-hk/deployment.yaml
+    env:
+      - name: WORKER_CONTEXTS
+        value: "hk-prod,hk-oob"
+    ```
+
+See [Kubernetes deployment guide](kubernetes.md) for full details.

--- a/docs/deployment/environment-variables.md
+++ b/docs/deployment/environment-variables.md
@@ -1,6 +1,6 @@
 # Environment Variables Reference
 
-All NAAS configuration is driven by environment variables. Set these in `docker-compose.yml`, a `.env` file, or your deployment platform's secrets manager.
+All NAAS configuration is driven by environment variables. Set these in your Helm `values.yaml` (under `config:`), `docker-compose.yml`, a `.env` file, or your deployment platform's secrets manager.
 
 ## Redis
 
@@ -83,31 +83,54 @@ All NAAS configuration is driven by environment variables. Set these in `docker-
 
 Requires the `otel` extra: `pip install naas[otel]`. Set on both API and worker processes.
 
-## Example docker-compose.yml
+## Configuration Examples
 
-```yaml
-services:
-  api:
-    environment:
-      - REDIS_HOST=redis
-      - REDIS_PASSWORD=your-secure-password
-      - LOG_LEVEL=INFO
-      - JOB_TTL_SUCCESS=86400
-      - JOB_TTL_FAILED=604800
-      - CIRCUIT_BREAKER_THRESHOLD=5
-      - CIRCUIT_BREAKER_TIMEOUT=300
-      - RATE_LIMIT_PER_CALLER=1000
-      - RATE_LIMIT_PER_CALLER_DEVICE=20
-      - OTEL_ENABLED=true
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+=== "Kubernetes (Helm values.yaml)"
 
-  worker:
-    environment:
-      - REDIS_HOST=redis
-      - REDIS_PASSWORD=your-secure-password
-      - SHUTDOWN_TIMEOUT=60
-      - CIRCUIT_BREAKER_THRESHOLD=5
-      - CIRCUIT_BREAKER_TIMEOUT=300
-      - OTEL_ENABLED=true
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
-```
+    ```yaml
+    config:
+      LOG_LEVEL: "INFO"
+      CIRCUIT_BREAKER_THRESHOLD: "5"
+      CIRCUIT_BREAKER_TIMEOUT: "300"
+      RATE_LIMIT_PER_CALLER: "1000"
+      RATE_LIMIT_PER_CALLER_DEVICE: "20"
+      OTEL_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+
+    secrets:
+      redisPassword: "your-secure-password"
+
+    worker:
+      replicas: 4
+    ```
+
+    All `config.*` values are injected as a ConfigMap. Secrets are stored in a Kubernetes Secret.
+
+=== "Docker Compose"
+
+    ```yaml
+    services:
+      api:
+        environment:
+          - REDIS_HOST=redis
+          - REDIS_PASSWORD=your-secure-password
+          - LOG_LEVEL=INFO
+          - JOB_TTL_SUCCESS=86400
+          - JOB_TTL_FAILED=604800
+          - CIRCUIT_BREAKER_THRESHOLD=5
+          - CIRCUIT_BREAKER_TIMEOUT=300
+          - RATE_LIMIT_PER_CALLER=1000
+          - RATE_LIMIT_PER_CALLER_DEVICE=20
+          - OTEL_ENABLED=true
+          - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+
+      worker:
+        environment:
+          - REDIS_HOST=redis
+          - REDIS_PASSWORD=your-secure-password
+          - SHUTDOWN_TIMEOUT=60
+          - CIRCUIT_BREAKER_THRESHOLD=5
+          - CIRCUIT_BREAKER_TIMEOUT=300
+          - OTEL_ENABLED=true
+          - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+    ```

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -1,0 +1,58 @@
+# Deployment Overview
+
+NAAS supports multiple deployment methods. Choose based on your environment and requirements.
+
+## Deployment Methods
+
+| Method | Best For | Prerequisites |
+|--------|----------|---------------|
+| **[Kubernetes (Helm)](../kubernetes.md)** | Production, team environments, scalability | Kubernetes 1.27+, Helm 3 |
+| **[Docker Compose](docker-compose.md)** | Development, small/single-node deployments | Docker, Docker Compose |
+| **Manual** | Custom environments, development without Docker | Python 3.11+, Redis 6+, uv |
+
+## Quick Decision Guide
+
+- **Production deployment?** → Use the [Helm chart](../kubernetes.md)
+- **Local development or quick evaluation?** → Use [Docker Compose](docker-compose.md) or the [Quick Start](../quickstart.md)
+- **Need fine-grained control or no container runtime?** → Manual installation (see below)
+
+## Manual Installation
+
+### Prerequisites
+
+- Python 3.11+
+- Redis 6.0+
+- uv (Python package manager)
+
+### Steps
+
+```bash
+git clone https://github.com/lykinsbd/naas.git
+cd naas
+
+# Install dependencies
+uv sync
+
+# Set environment variables
+export REDIS_HOST=localhost
+export REDIS_PORT=6379
+
+# Start Redis
+redis-server
+
+# Start API server (in one terminal)
+uv run gunicorn -c gunicorn.py naas.app:app
+
+# Start worker (in another terminal)
+uv run python worker.py
+```
+
+## Configuration
+
+All deployment methods use the same environment variables. See [Environment Variables](environment-variables.md) for the full reference.
+
+## Next Steps
+
+- [Environment Variables](environment-variables.md) — Full configuration reference
+- [Security](../security.md) — Production hardening
+- [Observability](../observability.md) — Logging, metrics, and tracing

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,60 +1,22 @@
 # Installation
 
-## Docker Compose (Recommended)
+## Recommended: Quick Start
 
-The easiest way to run NAAS is with Docker Compose:
+The fastest way to get NAAS running is the [Quick Start guide](quickstart.md) — up and running in 5 minutes with Docker Compose.
 
-```bash
-# Clone the repository
-git clone https://github.com/lykinsbd/naas.git
-cd naas
+## Production Deployment
 
-# Start services
-docker compose up -d
+For production environments, see the [Deployment Overview](deployment/index.md) to choose the right method:
 
-# Verify it's running
-curl -k https://localhost:8443/healthcheck
-```
-
-## Manual Installation
-
-### Prerequisites
-
-- Python 3.11+
-- Redis 6.0+
-- uv (Python package manager)
-
-### Steps
-
-```bash
-# Clone repository
-git clone https://github.com/lykinsbd/naas.git
-cd naas
-
-# Install dependencies
-uv sync
-
-# Set environment variables
-export REDIS_HOST=localhost
-export REDIS_PORT=6379
-export NAAS_USERNAME=admin
-export NAAS_PASSWORD=password
-
-# Start Redis
-redis-server
-
-# Start API server
-uv run gunicorn -c gunicorn.py naas.app:app
-
-# Start worker (in another terminal)
-uv run python worker.py
-```
+- **[Kubernetes (Helm)](kubernetes.md)** — Recommended for production
+- **[Docker Compose](deployment/docker-compose.md)** — Development and small deployments
+- **[Manual](deployment/index.md#manual-installation)** — Custom environments
 
 ## Configuration
 
-See [Security](security.md) for production configuration options.
+All deployment methods share the same environment variables. See [Environment Variables](deployment/environment-variables.md) for the full reference.
 
-### OpenTelemetry tracing
+## OpenTelemetry Tracing
 
 NAAS supports optional distributed tracing via [OpenTelemetry](https://opentelemetry.io/).
 Traces follow the full request lifecycle: API request → RQ queue → worker → SSH device.
@@ -65,24 +27,9 @@ Install the optional dependencies:
 pip install naas[otel]
 ```
 
-Configure via environment variables:
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OTEL_ENABLED` | `false` | Enable OpenTelemetry instrumentation |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | (none) | OTLP collector endpoint (e.g. `http://otel-collector:4317`) |
 
-| Variable                      | Default | Description                                                 |
-| ----------------------------- | ------- | ----------------------------------------------------------- |
-| `OTEL_ENABLED`                | `false` | Enable OpenTelemetry instrumentation                        |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | (none)  | OTLP collector endpoint (e.g. `http://otel-collector:4317`) |
-
-When disabled (default), tracing adds zero overhead: no OTel packages are imported and all
-instrumentation functions are no-ops.
-
-When enabled, NAAS creates the following spans:
-
-- `naas.worker.execute`: Worker picks up and runs a job
-- `naas.netmiko.connect`: SSH connection establishment
-- `naas.netmiko.send_command`: Per-command execution
-- `naas.netmiko.send_config`: Configuration push
-
-Flask HTTP spans are auto-instrumented. Trace context propagates through the RQ queue
-via W3C `traceparent` in job metadata, linking API and worker spans into a single trace.
-
-See [ADR 0008](adr/0008-opentelemetry-instrumentation-strategy.md) for design decisions.
+When disabled (default), tracing adds zero overhead. See [Observability](observability.md) for full details and [ADR 0008](adr/0008-opentelemetry-instrumentation-strategy.md) for design decisions.

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,17 +1,204 @@
 # Kubernetes Deployment
 
-NAAS ships plain YAML manifests in `k8s/` for deploying to any Kubernetes cluster.
+NAAS provides a Helm chart for production Kubernetes deployments, with raw YAML manifests available as an alternative.
 
-## Prerequisites
+## Helm Chart (Recommended)
 
-- Kubernetes 1.27+ (or k3d for local dev — see below)
-- `kubectl` configured for your cluster
-- A container image of NAAS (built and pushed to a registry your cluster can pull from)
+The Helm chart in `charts/naas/` is the recommended way to deploy NAAS on Kubernetes. It handles namespaces, secrets, config, scaling, and ingress out of the box.
 
-> The manifests in `main` reference the image tag for that release. The manifests in `develop`
-> use `latest`. For production deployments, always deploy from a tagged release branch and
-> verify the image tag in `k8s/api/deployment.yaml` and `k8s/worker/deployment.yaml` matches
-> the version you intend to run.
+### Prerequisites
+
+- Kubernetes 1.27+
+- Helm 3.x
+- A container image of NAAS accessible to your cluster
+
+### Quick Start
+
+```bash
+helm install naas charts/naas \
+  --set secrets.redisPassword=changeme \
+  --set secrets.encryptionKey=$(openssl rand -base64 32)
+```
+
+Verify:
+
+```bash
+kubectl -n naas get pods
+```
+
+All pods should reach `Running`. The API readiness probe hits `/healthcheck` — pods will not become ready until Redis is up.
+
+### Common Configurations
+
+#### External Redis
+
+Disable the bundled Redis and point to a managed instance:
+
+```bash
+helm install naas charts/naas \
+  --set redis.enabled=false \
+  --set redis.external.host=redis.prod.internal \
+  --set redis.external.port=6379 \
+  --set secrets.redisPassword=changeme
+```
+
+#### Ingress
+
+```bash
+helm install naas charts/naas \
+  --set ingress.enabled=true \
+  --set ingress.className=nginx \
+  --set "ingress.hosts[0].host=naas.example.com" \
+  --set "ingress.hosts[0].paths[0].path=/" \
+  --set "ingress.hosts[0].paths[0].pathType=Prefix"
+```
+
+#### TLS with Custom Certificates
+
+```bash
+helm install naas charts/naas \
+  --set secrets.tlsCert="$(cat fullchain.pem)" \
+  --set secrets.tlsKey="$(cat privkey.pem)" \
+  --set secrets.tlsCaBundle="$(cat chain.pem)"
+```
+
+Without certificates, NAAS generates a self-signed cert at startup.
+
+**cert-manager:** Create a `Certificate` resource targeting the `naas-api` Service and reference the resulting secret via `secrets.existingSecret`.
+
+#### Context Routing
+
+Deploy workers for specific network contexts:
+
+```yaml
+# values-contexts.yaml
+worker:
+  replicas: 0  # Disable default workers
+
+# Use multiple helm releases or subcharts for context-specific workers.
+# Alternatively, deploy additional worker Deployments:
+```
+
+For context-based worker isolation, override `config` per worker pool:
+
+```bash
+# Corp workers
+helm install naas-worker-corp charts/naas \
+  --set api.replicas=0 \
+  --set redis.enabled=false \
+  --set redis.external.host=redis.naas.svc \
+  --set config.WORKER_CONTEXTS=corp \
+  --set config.NAAS_CONTEXTS=corp
+
+# OOB workers
+helm install naas-worker-oob charts/naas \
+  --set api.replicas=0 \
+  --set redis.enabled=false \
+  --set redis.external.host=redis.naas.svc \
+  --set config.WORKER_CONTEXTS=oob-dc1,oob-dc2 \
+  --set config.NAAS_CONTEXTS=oob-dc1,oob-dc2
+```
+
+See [Context Routing](contexts.md) for full details.
+
+#### Scaling
+
+```bash
+# Scale workers
+helm upgrade naas charts/naas --set worker.replicas=5
+
+# Scale API
+helm upgrade naas charts/naas --set api.replicas=4
+```
+
+Each worker pod runs `worker.processes` RQ processes (default: 10). Total job concurrency = `worker.replicas × worker.processes`.
+
+#### OpenTelemetry
+
+```bash
+helm install naas charts/naas \
+  --set config.OTEL_ENABLED=true \
+  --set config.OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.monitoring:4317
+```
+
+### Upgrade and Rollback
+
+```bash
+# Upgrade to new values or chart version
+helm upgrade naas charts/naas -f values-prod.yaml
+
+# Rollback to previous release
+helm rollback naas
+
+# Uninstall
+helm uninstall naas
+```
+
+### Values Reference
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.repository` | `ghcr.io/lykinsbd/naas` | Container image |
+| `image.tag` | Chart `appVersion` | Image tag |
+| `namespace` | `naas` | Target namespace |
+| `api.replicas` | `2` | API pod replicas |
+| `api.port` | `443` | API listen port |
+| `api.resources.limits.memory` | `768Mi` | API memory limit |
+| `api.resources.limits.cpu` | `500m` | API CPU limit |
+| `worker.replicas` | `2` | Worker pod replicas |
+| `worker.processes` | `10` | RQ processes per worker pod |
+| `worker.metricsPort` | `9090` | Worker metrics port |
+| `worker.resources.limits.memory` | `512Mi` | Worker memory limit |
+| `worker.resources.limits.cpu` | `500m` | Worker CPU limit |
+| `config.*` | *(see below)* | Application env vars (injected as ConfigMap) |
+| `secrets.existingSecret` | `""` | Use an existing K8s Secret |
+| `secrets.redisPassword` | `""` | Redis password |
+| `secrets.encryptionKey` | `""` | Credential encryption key |
+| `secrets.tlsCert` | `""` | TLS certificate (PEM) |
+| `secrets.tlsKey` | `""` | TLS private key (PEM) |
+| `secrets.tlsCaBundle` | `""` | TLS CA bundle (PEM) |
+| `redis.enabled` | `true` | Deploy bundled Redis |
+| `redis.external.host` | `""` | External Redis host |
+| `redis.external.port` | `6379` | External Redis port |
+| `ingress.enabled` | `false` | Create Ingress resource |
+| `ingress.className` | `""` | Ingress class |
+| `service.type` | `ClusterIP` | Service type |
+
+All `config.*` values map to environment variables. See [Environment Variables](deployment/environment-variables.md) for the full list.
+
+### Production Redis
+
+The bundled Redis is a single-replica deployment with no persistence — suitable for dev/test. **For production, use a managed Redis** (AWS ElastiCache, Redis Cloud, etc.) with `redis.enabled=false`.
+
+## Raw Manifests (Alternative)
+
+If you cannot use Helm, plain YAML manifests are available in `k8s/`.
+
+### Applying Manifests
+
+```bash
+# Create the secret from the example
+cp k8s/secret.yaml.example k8s/secret.yaml
+# Edit k8s/secret.yaml with base64-encoded values
+
+# Apply in order
+kubectl apply -f k8s/namespace.yaml
+kubectl apply -f k8s/secret.yaml
+kubectl apply -f k8s/configmap.yaml
+kubectl apply -f k8s/redis/
+kubectl apply -f k8s/api/
+kubectl apply -f k8s/worker/
+```
+
+> **Never commit `k8s/secret.yaml`** — it is in `.gitignore`.
+
+### Scaling Workers (Manifests)
+
+Edit `spec.replicas` in `k8s/worker/deployment.yaml`, or:
+
+```bash
+kubectl -n naas scale deploy/naas-worker --replicas=5
+```
 
 ## Local Development with k3d
 
@@ -24,193 +211,49 @@ curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 # Create a cluster
 k3d cluster create naas-dev --port "8443:443@loadbalancer"
 
+# Deploy with Helm
+helm install naas charts/naas \
+  --set secrets.redisPassword=devpassword \
+  --set secrets.encryptionKey=dev-encryption-key-32bytes!!
+
 # Verify
-kubectl get nodes
-```
-
-## Applying the Manifests
-
-### 1. Create the secret
-
-```bash
-cp k8s/secret.yaml.example k8s/secret.yaml
-```
-
-Edit `k8s/secret.yaml` and replace the placeholder values with base64-encoded secrets:
-
-```bash
-# Generate base64 values
-echo -n 'your-redis-password' | base64
-```
-
-> **Never commit `k8s/secret.yaml`** — it is in `.gitignore`.
-
-### 2. Apply in order
-
-```bash
-kubectl apply -f k8s/namespace.yaml
-kubectl apply -f k8s/secret.yaml
-kubectl apply -f k8s/configmap.yaml
-kubectl apply -f k8s/redis/
-kubectl apply -f k8s/api/
-kubectl apply -f k8s/worker/
-```
-
-### 3. Verify
-
-```bash
 kubectl -n naas get pods
-kubectl -n naas get svc
+curl -k https://localhost:8443/healthcheck
 ```
-
-All pods should reach `Running` status. The API readiness probe hits `/healthcheck` — pods
-will not become ready until Redis is up and responding.
 
 ## Security Context
 
-Both the API and worker deployments run as UID 1000 (`naas` user, non-root) with all
-Linux capabilities dropped. The API retains `NET_BIND_SERVICE` to bind port 443 without
-root. TLS certificates are written to `/tmp/` at startup (world-writable, no special
-permissions required).
-
-## TLS / Ingress
-
-The NAAS API listens on HTTPS (port 443). The `api` Service is `ClusterIP` — expose it
-via your cluster's ingress controller or a `LoadBalancer` service as appropriate for your
-environment.
-
-**With a custom certificate:** populate `NAAS_CERT`, `NAAS_KEY`, and optionally
-`NAAS_CA_BUNDLE` in `k8s/secret.yaml`. These values must be the **raw PEM content**
-(not a file path), base64-encoded for the Kubernetes Secret.
-
-```bash
-# Encode a certificate file for use in secret.yaml
-cat cert.pem | base64 -w 0
-```
-
-The double-encoding works as follows: Kubernetes decodes the base64 value from the Secret
-and injects the raw PEM string as an environment variable. NAAS writes that string to disk
-at startup for Gunicorn to use.
-
-**Without a certificate:** NAAS generates a self-signed certificate at startup. Suitable
-for dev/internal use where clients can skip TLS verification or trust the self-signed cert.
-
-**cert-manager:** If your cluster runs cert-manager, create a `Certificate` resource
-targeting the `naas-api` Service and mount the resulting secret into the API pods via
-`NAAS_CERT` / `NAAS_KEY` / `NAAS_CA_BUNDLE` environment variables.
-
-## Resource Sizing
-
-The manifests include conservative defaults suitable for a small deployment:
-
-| Component | Memory request | Memory limit | CPU request | CPU limit |
-| ----------- | --------------- | -------------- | ------------- | ----------- |
-| API | 256Mi | 768Mi | 100m | 500m |
-| Worker | 128Mi | 512Mi | 100m | 500m |
-| Redis | 64Mi | 256Mi | 50m | 200m |
-
-Workers are CPU-bound during Netmiko SSH operations. Increase `limits.cpu` and replica
-count if you observe throttling under load.
-
-## Production Redis
-
-The bundled Redis manifest is a single-replica Deployment with no persistence — suitable
-for dev and testing. **For production, use a managed Redis service** (AWS ElastiCache,
-Redis Cloud, DigitalOcean Managed Redis, etc.) or a Redis Operator with replication and
-persistence configured.
-
-To use an external Redis, update `REDIS_HOST` and `REDIS_PORT` in `k8s/configmap.yaml`
-and remove the `k8s/redis/` manifests.
-
-## Connection Pooling
-
-NAAS reuses SSH connections across sequential jobs to the same device, reducing VTY session
-overhead on network equipment. Pooling is enabled by default.
-
-| Variable | Default | Description |
-| ---------- | --------- | ------------- |
-| `CONNECTION_POOL_ENABLED` | `true` | Set to `false` to disable pooling for all devices |
-| `CONNECTION_POOL_MAX_SIZE` | `10` | Max pooled connections per worker process |
-| `CONNECTION_POOL_IDLE_TIMEOUT` | `300` | Evict connections idle for this many seconds |
-| `CONNECTION_POOL_MAX_AGE` | `3600` | Evict connections older than this many seconds |
-| `CONNECTION_POOL_KEEPALIVE` | `60` | Paramiko SSH keepalive interval (seconds) |
-
-Disable pooling for specific environments where devices do not handle persistent SSH sessions
-well (e.g. older IOS, out-of-band management platforms). Per-device exclusions are tracked
-in [#187](https://github.com/lykinsbd/naas/issues/187).
-
-## Scaling Workers
-
-Worker replicas are set to `2` by default. Increase `spec.replicas` in
-`k8s/worker/deployment.yaml` based on your job throughput requirements. Each worker
-handles one job at a time per process; the number of concurrent jobs equals the number
-of worker replicas.
-
-**Note:** Connection pooling (v1.2+) reuses SSH sessions across sequential jobs on the
-same worker, reducing latency. However, it does not change job concurrency—each worker
-still processes one job at a time. Scale replicas to increase concurrent job capacity.
-
-The worker process writes a heartbeat file to `/tmp/worker_heartbeat` every 30 seconds.
-The liveness probe checks this file was modified within the last 2 minutes — if the
-parent process hangs, Kubernetes will restart the pod. Override the path via the
-`WORKER_HEARTBEAT_FILE` environment variable if needed.
+Both API and worker pods run as UID 1000 (`naas` user, non-root) with all Linux capabilities dropped. The API retains `NET_BIND_SERVICE` to bind port 443 without root.
 
 ## Monitoring
 
-The `/metrics` endpoint on the API pods exposes Prometheus metrics. Configure your
-Prometheus instance to scrape port `443` (HTTPS) with the appropriate TLS config, or
-use a `ServiceMonitor` if running the Prometheus Operator.
+The `/metrics` endpoint on API pods exposes Prometheus metrics. Configure scraping via a `ServiceMonitor` (Prometheus Operator) or static config:
+
+```yaml
+scrape_configs:
+  - job_name: naas
+    static_configs:
+      - targets: ['naas-api.naas.svc:443']
+    scheme: https
+    tls_config:
+      insecure_skip_verify: true
+```
 
 | Metric | Type | Description |
-| -------- | ------ | ------------- |
-| `naas_http_requests_total` | Counter | Total HTTP requests by endpoint, method, and status code |
+|--------|------|-------------|
+| `naas_http_requests_total` | Counter | HTTP requests by endpoint, method, status |
 | `naas_http_request_duration_seconds` | Histogram | Request latency by endpoint |
-| `naas_queue_depth` | Gauge | Number of jobs waiting in the RQ queue |
-| `naas_workers_active` | Gauge | Number of active RQ worker processes (cached, 10s TTL) |
+| `naas_queue_depth` | Gauge | Jobs waiting in queue |
+| `naas_workers_active` | Gauge | Active RQ worker processes |
 
-## Helm Chart
+## Connection Pooling
 
-A Helm chart is available in `charts/naas/` for parameterized deployments.
-
-### Quickstart
-
-```bash
-helm install naas charts/naas \
-  --set secrets.redisPassword=changeme \
-  --set secrets.encryptionKey=my-32-byte-key
-```
-
-### Key values
+Workers reuse SSH connections across sequential jobs to the same device. Configure via `config.*` values:
 
 | Value | Default | Description |
-| ----- | ------- | ----------- |
-| `api.replicas` | `2` | API pod replicas |
-| `worker.replicas` | `2` | Worker pod replicas |
-| `worker.processes` | `10` | RQ worker processes per pod |
-| `redis.enabled` | `true` | Deploy bundled Redis |
-| `redis.external.host` | `""` | External Redis host (when `redis.enabled=false`) |
-| `ingress.enabled` | `false` | Create Ingress resource |
-| `secrets.existingSecret` | `""` | Use an existing Secret instead of creating one |
-| `image.tag` | `appVersion` | Container image tag |
-
-### External Redis
-
-```bash
-helm install naas charts/naas \
-  --set redis.enabled=false \
-  --set redis.external.host=redis.prod.internal \
-  --set secrets.redisPassword=changeme
-```
-
-### Ingress
-
-```bash
-helm install naas charts/naas \
-  --set ingress.enabled=true \
-  --set ingress.className=nginx \
-  --set ingress.hosts[0].host=naas.example.com \
-  --set ingress.hosts[0].paths[0].path=/ \
-  --set ingress.hosts[0].paths[0].pathType=Prefix
-```
-
-See `charts/naas/values.yaml` for the full list of configurable values.
+|-------|---------|-------------|
+| `config.CONNECTION_POOL_ENABLED` | `true` | Enable pooling |
+| `config.CONNECTION_POOL_MAX_SIZE` | `10` | Max connections per worker process |
+| `config.CONNECTION_POOL_IDLE_TIMEOUT` | `300` | Evict idle connections (seconds) |
+| `config.CONNECTION_POOL_MAX_AGE` | `3600` | Evict old connections (seconds) |
+| `config.CONNECTION_POOL_KEEPALIVE` | `60` | SSH keepalive interval (seconds) |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -32,9 +32,17 @@ This format is directly ingestible by ELK, Splunk, CloudWatch Logs, Datadog, and
 
 Set via `LOG_LEVEL` environment variable (default: `INFO`). Use `DEBUG` for verbose output including per-command device interaction.
 
-```bash
-LOG_LEVEL=DEBUG docker compose up -d
-```
+=== "Docker Compose"
+
+    ```bash
+    LOG_LEVEL=DEBUG docker compose up -d
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas --set config.LOG_LEVEL=DEBUG
+    ```
 
 ## Correlation ID Tracing
 
@@ -51,7 +59,7 @@ This enables end-to-end tracing of a single request across API and worker logs.
 Pass `X-Request-ID` in the request to use your own correlation ID (must be a valid UUID v4):
 
 ```bash
-curl -k -X POST https://localhost:8443/v1/send_command \
+curl -k -X POST https://localhost:8443/v2/send-command \
   -u "admin:password" \
   -H "Content-Type: application/json" \
   -H "X-Request-ID: 550e8400-e29b-41d4-a716-446655440000" \
@@ -62,10 +70,17 @@ If omitted, NAAS generates one automatically.
 
 ### Tracing a request through logs
 
-```bash
-# Find all log lines for a specific job
-docker compose logs worker | grep "550e8400-e29b-41d4-a716-446655440000"
-```
+=== "Docker Compose"
+
+    ```bash
+    docker compose logs worker | grep "550e8400-e29b-41d4-a716-446655440000"
+    ```
+
+=== "Kubernetes"
+
+    ```bash
+    kubectl -n naas logs deploy/naas-worker | grep "550e8400-e29b-41d4-a716-446655440000"
+    ```
 
 ## Health Check
 
@@ -303,26 +318,38 @@ pip install naas[otel]
 
 This means a single trace ID connects the HTTP request, queue wait time, and device operation — visible in Jaeger, Grafana Tempo, or any OTLP-compatible backend.
 
-### Docker Compose Example
+### Deployment Example
 
-```yaml
-services:
-  api:
-    environment:
-      - OTEL_ENABLED=true
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+=== "Docker Compose"
 
-  worker:
-    environment:
-      - OTEL_ENABLED=true
-      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+    ```yaml
+    services:
+      api:
+        environment:
+          - OTEL_ENABLED=true
+          - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
 
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.127.0
-    ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP
-```
+      worker:
+        environment:
+          - OTEL_ENABLED=true
+          - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+
+      otel-collector:
+        image: otel/opentelemetry-collector-contrib:0.127.0
+        ports:
+          - "4317:4317"   # OTLP gRPC
+          - "4318:4318"   # OTLP HTTP
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas \
+      --set config.OTEL_ENABLED=true \
+      --set config.OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector.monitoring:4317
+    ```
+
+    Deploy an OpenTelemetry Collector separately (e.g. via the [OpenTelemetry Helm chart](https://opentelemetry.io/docs/kubernetes/helm/)).
 
 ### Graceful Degradation
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,15 +20,25 @@ NAAS transmits credentials to network devices. **Never** use HTTP in production.
 
 **Default**: NAAS generates a self-signed certificate at startup if no certificate is provided.
 
-**Production**: Supply a valid TLS certificate via environment variables:
+**Production**: Supply a valid TLS certificate:
 
-```bash
-export NAAS_CERT=$(cat /path/to/fullchain.pem)
-export NAAS_KEY=$(cat /path/to/privkey.pem)
-export NAAS_CA_BUNDLE=$(cat /path/to/chain.pem)
+=== "Docker Compose"
 
-docker compose up -d
-```
+    ```bash
+    export NAAS_CERT=$(cat /path/to/fullchain.pem)
+    export NAAS_KEY=$(cat /path/to/privkey.pem)
+    export NAAS_CA_BUNDLE=$(cat /path/to/chain.pem)
+    docker compose up -d
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas \
+      --set secrets.tlsCert="$(cat fullchain.pem)" \
+      --set secrets.tlsKey="$(cat privkey.pem)" \
+      --set secrets.tlsCaBundle="$(cat chain.pem)"
+    ```
 
 ### TLS Configuration
 
@@ -46,13 +56,27 @@ Rotate certificates before expiration:
 ```bash
 # Check certificate expiration
 openssl x509 -in cert.pem -noout -enddate
-
-# Update certificates and restart
-export NAAS_CERT=$(cat new-cert.pem)
-export NAAS_KEY=$(cat new-key.pem)
-export NAAS_CA_BUNDLE=$(cat new-bundle.pem)
-docker compose up -d
 ```
+
+=== "Docker Compose"
+
+    ```bash
+    export NAAS_CERT=$(cat new-cert.pem)
+    export NAAS_KEY=$(cat new-key.pem)
+    export NAAS_CA_BUNDLE=$(cat new-bundle.pem)
+    docker compose up -d
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas \
+      --set secrets.tlsCert="$(cat new-cert.pem)" \
+      --set secrets.tlsKey="$(cat new-key.pem)" \
+      --set secrets.tlsCaBundle="$(cat new-bundle.pem)"
+    ```
+
+    Or with cert-manager, rotation is automatic.
 
 ## Authentication
 
@@ -167,7 +191,7 @@ server {
 ```python
 # Don't do this!
 response = requests.post(
-    "https://naas.example.com/send_command",
+    "https://naas.example.com/v2/send-command",
     auth=("admin", "password123"),  # Hardcoded!
     json=payload
 )
@@ -184,7 +208,7 @@ username = os.environ["DEVICE_USERNAME"]
 password = os.environ["DEVICE_PASSWORD"]
 
 response = requests.post(
-    "https://naas.example.com/send_command",
+    "https://naas.example.com/v2/send-command",
     auth=HTTPBasicAuth(username, password),
     json=payload
 )
@@ -221,30 +245,43 @@ Implement automated credential rotation:
 
 Secure Redis with authentication:
 
-```bash
-# Use strong password
-export REDIS_PASSWORD=$(openssl rand -base64 32)
+=== "Docker Compose"
 
-# Disable dangerous commands
-docker compose exec redis redis-cli -a $REDIS_PASSWORD \
-  CONFIG SET rename-command FLUSHDB ""
-```
+    ```bash
+    export REDIS_PASSWORD=$(openssl rand -base64 32)
+    docker compose up -d
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas \
+      --set secrets.redisPassword=$(openssl rand -base64 32)
+    ```
+
+    Or reference an existing secret: `--set secrets.existingSecret=my-naas-secrets`
 
 ### Container Isolation
 
-Run containers with minimal privileges:
+Run with minimal privileges:
 
-```yaml
-# docker-compose.override.yml
-services:
-  api:
-    security_opt:
-      - no-new-privileges:true
-    read_only: true
-    tmpfs:
-      - /tmp
-    user: "1000:1000"
-```
+=== "Docker Compose"
+
+    ```yaml
+    # docker-compose.override.yml
+    services:
+      api:
+        security_opt:
+          - no-new-privileges:true
+        read_only: true
+        tmpfs:
+          - /tmp
+        user: "1000:1000"
+    ```
+
+=== "Kubernetes"
+
+    The Helm chart applies these by default: non-root UID 1000, all capabilities dropped, read-only root filesystem. No additional configuration needed.
 
 ### Rate Limiting
 
@@ -339,16 +376,21 @@ tokens. Only usernames, key IDs, and operational metadata are logged.
 Audit events are mixed with operational logs in the JSON output stream. Filter on
 the `event_type` field:
 
-```bash
-# All audit events
-docker compose logs api | jq 'select(.event_type)'
+=== "Docker Compose"
 
-# Auth failures only
-docker compose logs api | jq 'select(.event_type == "auth.failure")'
+    ```bash
+    docker compose logs api | jq 'select(.event_type)'
+    docker compose logs api | jq 'select(.event_type == "auth.failure")'
+    docker compose logs api | jq 'select(.event_type | startswith("auth."))'
+    ```
 
-# All security events
-docker compose logs api | jq 'select(.event_type | startswith("auth."))'
-```
+=== "Kubernetes"
+
+    ```bash
+    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type)'
+    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type == "auth.failure")'
+    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type | startswith("auth."))'
+    ```
 
 ### SIEM Integration
 
@@ -376,22 +418,28 @@ For compliance, ship logs to an append-only store:
 
 Send logs to centralized logging:
 
-```yaml
-# docker-compose.override.yml
-services:
-  api:
-    logging:
-      driver: "syslog"
-      options:
-        syslog-address: "tcp://logserver.example.com:514"
-        tag: "naas-api"
-  worker:
-    logging:
-      driver: "syslog"
-      options:
-        syslog-address: "tcp://logserver.example.com:514"
-        tag: "naas-worker"
-```
+=== "Docker Compose"
+
+    ```yaml
+    # docker-compose.override.yml
+    services:
+      api:
+        logging:
+          driver: "syslog"
+          options:
+            syslog-address: "tcp://logserver.example.com:514"
+            tag: "naas-api"
+      worker:
+        logging:
+          driver: "syslog"
+          options:
+            syslog-address: "tcp://logserver.example.com:514"
+            tag: "naas-worker"
+    ```
+
+=== "Kubernetes"
+
+    Use a log shipper DaemonSet (Fluentd, Vector, Filebeat) to collect pod logs from `/var/log/containers/`. NAAS emits structured JSON, so no parsing is needed — route directly to your SIEM or log backend.
 
 ### Monitor Authentication Failures
 
@@ -403,13 +451,18 @@ Set up alerts for `auth.failure` events (see [Recommended Alerts](#recommended-a
 
 Regularly update NAAS and dependencies:
 
-```bash
-# Pull latest images
-docker compose pull
+=== "Docker Compose"
 
-# Restart with new images
-docker compose up -d
-```
+    ```bash
+    docker compose pull
+    docker compose up -d
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas --set image.tag=2.1.0
+    ```
 
 ### Scan for Vulnerabilities
 
@@ -427,28 +480,40 @@ docker scout cves ghcr.io/lykinsbd/naas:latest
 
 Prevent resource exhaustion:
 
-```yaml
-# docker-compose.override.yml
-services:
-  api:
-    deploy:
-      resources:
-        limits:
-          cpus: '1'
-          memory: 512M
-        reservations:
-          cpus: '0.5'
-          memory: 256M
-  worker:
-    deploy:
-      resources:
-        limits:
-          cpus: '2'
-          memory: 1G
-        reservations:
-          cpus: '1'
-          memory: 512M
-```
+=== "Docker Compose"
+
+    ```yaml
+    # docker-compose.override.yml
+    services:
+      api:
+        deploy:
+          resources:
+            limits:
+              cpus: '1'
+              memory: 512M
+            reservations:
+              cpus: '0.5'
+              memory: 256M
+      worker:
+        deploy:
+          resources:
+            limits:
+              cpus: '2'
+              memory: 1G
+            reservations:
+              cpus: '1'
+              memory: 512M
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas \
+      --set api.resources.limits.cpu=1000m \
+      --set api.resources.limits.memory=512Mi \
+      --set worker.resources.limits.cpu=2000m \
+      --set worker.resources.limits.memory=1Gi
+    ```
 
 ### Read-Only Filesystem
 
@@ -524,13 +589,25 @@ For healthcare environments:
 
 ### Emergency Shutdown
 
-```bash
-# Stop all NAAS services immediately
-docker compose down
+=== "Docker Compose"
 
-# Clear Redis data if compromised
-docker compose down -v
-```
+    ```bash
+    # Stop all NAAS services immediately
+    docker compose down
+
+    # Clear Redis data if compromised
+    docker compose down -v
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    # Stop all NAAS services
+    helm uninstall naas
+
+    # Or delete the namespace entirely (including PVCs)
+    kubectl delete namespace naas
+    ```
 
 ## Next steps
 

--- a/docs/structured-output.md
+++ b/docs/structured-output.md
@@ -5,10 +5,10 @@ typed data structures (list of dicts). This eliminates custom parsing logic in c
 
 ## Quick Start
 
-Use the `/v1/send_command_structured` endpoint:
+Use the `/v2/send-command-structured` endpoint:
 
 ```bash
-curl -k -u "username:password" https://localhost:8443/v1/send_command_structured \
+curl -k -u "username:password" https://localhost:8443/v2/send-command-structured \
   -H "Content-Type: application/json" \
   -d '{
     "host": "192.168.1.1",
@@ -23,7 +23,7 @@ curl -k -u "username:password" https://localhost:8443/v1/send_command_structured
    a community library with 1000+ TextFSM templates for common vendor commands
 2. **Template matching** — Netmiko matches `(platform, command)` to a template automatically
 3. **Structured output** — Returns `list[dict]` per command instead of raw strings
-4. **Fallback** — If no template exists, returns raw string (same as `/v1/send_command`)
+4. **Fallback** — If no template exists, returns raw string (same as `/v2/send-command`)
 
 ## Return Type
 
@@ -124,13 +124,13 @@ connection pooling. Best for discovery workflows, not production automation.
 
 ## When to Use Structured Output
 
-**Use `/v1/send_command_structured` when:**
+**Use `/v2/send-command-structured` when:**
 
 - You need typed data for programmatic processing
 - The command is covered by ntc-templates (check [the template index](https://github.com/networktocode/ntc-templates/tree/master/ntc_templates/templates))
 - You're willing to handle mixed return types (list vs string)
 
-**Use `/v1/send_command` when:**
+**Use `/v2/send-command` when:**
 
 - You need raw output for logging/display
 - The command has no ntc-template and you don't want to write one
@@ -151,7 +151,7 @@ connection pooling. Best for discovery workflows, not production automation.
 import requests
 
 response = requests.post(
-    "https://naas.local/v1/send_command_structured",
+    "https://naas.local/v2/send-command-structured",
     auth=("user", "pass"),
     json={
         "host": "192.168.1.1",
@@ -165,7 +165,7 @@ job_id = response.json()["job_id"]
 
 # Poll for results
 result = requests.get(
-    f"https://naas.local/v1/send_command_structured/{job_id}",
+    f"https://naas.local/v2/send-command-structured/{job_id}",
     auth=("user", "pass"),
     verify=False
 ).json()
@@ -178,7 +178,7 @@ for device in result["results"]["show version"]:
 
 ```python
 response = requests.post(
-    "https://naas.local/v1/send_command_structured",
+    "https://naas.local/v2/send-command-structured",
     auth=("user", "pass"),
     json={
         "host": "192.168.1.1",
@@ -207,7 +207,7 @@ Start
 """
 
 response = requests.post(
-    "https://naas.local/v1/send_command_structured",
+    "https://naas.local/v2/send-command-structured",
     auth=("user", "pass"),
     json={
         "host": "192.168.1.1",

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,26 +20,40 @@ Common issues and solutions for NAAS deployment and operation.
 
 **Solutions**:
 
-1. Check if containers are running:
+1. Check if services are running:
 
-   ```bash
-   docker compose ps
-   ```
+    === "Docker Compose"
 
-2. Check container logs:
+        ```bash
+        docker compose ps
+        docker compose logs api
+        ```
 
-   ```bash
-   docker compose logs api
-   ```
+    === "Kubernetes"
 
-3. Verify port mapping:
+        ```bash
+        kubectl -n naas get pods
+        kubectl -n naas logs deploy/naas-api
+        ```
 
-   ```bash
-   docker compose ps | grep api
-   # Should show 0.0.0.0:8443->8443/tcp
-   ```
+2. Verify port/service exposure:
 
-4. Check firewall rules:
+    === "Docker Compose"
+
+        ```bash
+        docker compose ps | grep api
+        # Should show 0.0.0.0:8443->8443/tcp
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas get svc
+        # For port-forward testing:
+        kubectl -n naas port-forward svc/naas-api 8443:443
+        ```
+
+3. Check firewall rules:
 
    ```bash
    sudo ufw status
@@ -55,27 +69,38 @@ Common issues and solutions for NAAS deployment and operation.
 1. Verify network connectivity from NAAS host:
 
    ```bash
-   # From the host
    ping 192.168.1.1
    telnet 192.168.1.1 22
    ```
 
-2. Check Docker network configuration:
+2. Check connectivity from inside the container/pod:
 
-   ```bash
-   docker compose exec api ping 192.168.1.1
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose exec worker ping 192.168.1.1
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas exec deploy/naas-worker -- ping 192.168.1.1
+        ```
 
 3. If using custom networks, ensure proper routing:
 
-   ```yaml
-   # docker-compose.override.yml
-   services:
-     api:
-       network_mode: host
-     worker:
-       network_mode: host
-   ```
+    === "Docker Compose"
+
+        ```yaml
+        # docker-compose.override.yml
+        services:
+          worker:
+            network_mode: host
+        ```
+
+    === "Kubernetes"
+
+        Ensure worker pods have network policies allowing egress to device subnets, or use `hostNetwork: true` in the worker Deployment spec if required.
 
 ## Authentication Problems
 
@@ -89,17 +114,17 @@ Common issues and solutions for NAAS deployment and operation.
 
    ```bash
    # Correct
-   curl -k -u "username:password" https://localhost:8443/v1/send_command
+   curl -k -u "username:password" https://localhost:8443/v2/send-command
 
    # Wrong - missing credentials
-   curl -k https://localhost:8443/v1/send_command
+   curl -k https://localhost:8443/v2/send-command
    ```
 
 2. Check for special characters in password:
 
    ```bash
    # URL encode special characters
-   curl -k -u "username:p@ssw0rd!" https://localhost:8443/v1/send_command
+   curl -k -u "username:p@ssw0rd!" https://localhost:8443/v2/send-command
    ```
 
 3. Verify credentials work directly on device:
@@ -137,28 +162,50 @@ Common issues and solutions for NAAS deployment and operation.
 
 **Solutions**:
 
-1. Check Redis container:
+1. Check Redis is running:
 
-   ```bash
-   docker compose ps redis
-   docker compose logs redis
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose ps redis
+        docker compose logs redis
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas get pods -l app=redis
+        kubectl -n naas logs deploy/redis
+        ```
 
 2. Verify Redis password:
 
-   ```bash
-   # Check environment variable
-   docker compose exec api env | grep REDIS_PASSWORD
+    === "Docker Compose"
 
-   # Test Redis connection
-   docker compose exec redis redis-cli -a your_password ping
-   ```
+        ```bash
+        docker compose exec api env | grep REDIS_PASSWORD
+        docker compose exec redis redis-cli -a your_password ping
+        ```
 
-3. Check Redis connectivity from API:
+    === "Kubernetes"
 
-   ```bash
-   docker compose exec api nc -zv redis 6379
-   ```
+        ```bash
+        kubectl -n naas exec deploy/redis -- redis-cli -a "$REDIS_PASSWORD" ping
+        ```
+
+3. Check connectivity from API to Redis:
+
+    === "Docker Compose"
+
+        ```bash
+        docker compose exec api nc -zv redis 6379
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas exec deploy/naas-api -- nc -zv naas-redis 6379
+        ```
 
 ### Redis Out of Memory
 
@@ -168,24 +215,48 @@ Common issues and solutions for NAAS deployment and operation.
 
 1. Check Redis memory usage:
 
-   ```bash
-   docker compose exec redis redis-cli -a your_password INFO memory
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose exec redis redis-cli -a your_password INFO memory
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas exec deploy/redis -- redis-cli -a "$REDIS_PASSWORD" INFO memory
+        ```
 
 2. Increase Redis memory limit:
 
-   ```yaml
-   # docker-compose.override.yml
-   services:
-     redis:
-       command: redis-server --maxmemory 2gb --maxmemory-policy allkeys-lru
-   ```
+    === "Docker Compose"
+
+        ```yaml
+        # docker-compose.override.yml
+        services:
+          redis:
+            command: redis-server --maxmemory 2gb --maxmemory-policy allkeys-lru
+        ```
+
+    === "Kubernetes (Helm)"
+
+        ```bash
+        helm upgrade naas charts/naas --set redis.resources.limits.memory=2Gi
+        ```
 
 3. Clear old job data:
 
-   ```bash
-   docker compose exec redis redis-cli -a your_password FLUSHDB
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose exec redis redis-cli -a your_password FLUSHDB
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas exec deploy/redis -- redis-cli -a "$REDIS_PASSWORD" FLUSHDB
+        ```
 
 ## Worker Problems
 
@@ -195,53 +266,78 @@ Common issues and solutions for NAAS deployment and operation.
 
 **Solutions**:
 
-1. Check worker containers:
+1. Check workers are running:
 
-   ```bash
-   docker compose ps worker
-   docker compose logs worker
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose ps worker
+        docker compose logs worker
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas get pods -l app=naas-worker
+        kubectl -n naas logs deploy/naas-worker
+        ```
 
 2. Scale up workers:
 
-   ```bash
-   docker compose up -d --scale worker=5
-   ```
+    === "Docker Compose"
 
-3. Check worker processes:
+        ```bash
+        docker compose up -d --scale worker=5
+        ```
 
-   ```bash
-   docker compose exec worker ps aux | grep rq
-   ```
+    === "Kubernetes (Helm)"
+
+        ```bash
+        helm upgrade naas charts/naas --set worker.replicas=5
+        ```
 
 ### Workers Crashing
 
-**Symptom**: Worker containers restart frequently
+**Symptom**: Worker containers/pods restart frequently
 
 **Solutions**:
 
-1. Check worker logs for errors:
+1. Check worker logs:
 
-   ```bash
-   docker compose logs worker --tail=100
-   ```
+    === "Docker Compose"
 
-2. Common issues:
-   - Memory limits too low
-   - Network connectivity problems
-   - Python dependency issues
+        ```bash
+        docker compose logs worker --tail=100
+        ```
 
-3. Increase worker resources:
+    === "Kubernetes"
 
-   ```yaml
-   # docker-compose.override.yml
-   services:
-     worker:
-       deploy:
-         resources:
-           limits:
-             memory: 1G
-   ```
+        ```bash
+        kubectl -n naas logs deploy/naas-worker --tail=100
+        kubectl -n naas describe pod -l app=naas-worker  # Check events/OOMKilled
+        ```
+
+2. Increase worker resources:
+
+    === "Docker Compose"
+
+        ```yaml
+        # docker-compose.override.yml
+        services:
+          worker:
+            deploy:
+              resources:
+                limits:
+                  memory: 1G
+        ```
+
+    === "Kubernetes (Helm)"
+
+        ```bash
+        helm upgrade naas charts/naas \
+          --set worker.resources.limits.memory=1Gi \
+          --set worker.resources.limits.cpu=1000m
+        ```
 
 ## SSL/TLS Issues
 
@@ -259,11 +355,21 @@ Common issues and solutions for NAAS deployment and operation.
 
 2. For production, use valid certificates:
 
-   ```bash
-   export NAAS_CERT=$(cat /path/to/cert.crt)
-   export NAAS_KEY=$(cat /path/to/key.pem)
-   docker compose up -d
-   ```
+    === "Docker Compose"
+
+        ```bash
+        export NAAS_CERT=$(cat /path/to/cert.crt)
+        export NAAS_KEY=$(cat /path/to/key.pem)
+        docker compose up -d
+        ```
+
+    === "Kubernetes (Helm)"
+
+        ```bash
+        helm upgrade naas charts/naas \
+          --set secrets.tlsCert="$(cat cert.crt)" \
+          --set secrets.tlsKey="$(cat key.pem)"
+        ```
 
 3. Add CA certificate to trust store:
 
@@ -282,24 +388,45 @@ Common issues and solutions for NAAS deployment and operation.
 
 **Solutions**:
 
-1. Generate new self-signed certificate:
+1. Regenerate self-signed certificate (restart the service):
 
-   ```bash
-   docker compose down
-   docker compose up -d
-   # NAAS generates new cert on startup
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose down
+        docker compose up -d
+        # NAAS generates new cert on startup
+        ```
+
+    === "Kubernetes"
+
+        ```bash
+        kubectl -n naas rollout restart deploy/naas-api
+        ```
 
 2. Or provide your own:
 
-   ```bash
-   openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-     -keyout naas.key -out naas.crt
+    === "Docker Compose"
 
-   export NAAS_CERT=$(cat naas.crt)
-   export NAAS_KEY=$(cat naas.key)
-   docker compose up -d
-   ```
+        ```bash
+        openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+          -keyout naas.key -out naas.crt
+
+        export NAAS_CERT=$(cat naas.crt)
+        export NAAS_KEY=$(cat naas.key)
+        docker compose up -d
+        ```
+
+    === "Kubernetes (Helm)"
+
+        ```bash
+        openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+          -keyout naas.key -out naas.crt
+
+        helm upgrade naas charts/naas \
+          --set secrets.tlsCert="$(cat naas.crt)" \
+          --set secrets.tlsKey="$(cat naas.key)"
+        ```
 
 ## Performance Issues
 
@@ -369,66 +496,102 @@ Common issues and solutions for NAAS deployment and operation.
 
 3. Scale workers for parallel execution:
 
-   ```bash
-   docker compose up -d --scale worker=10
-   ```
+    === "Docker Compose"
+
+        ```bash
+        docker compose up -d --scale worker=10
+        ```
+
+    === "Kubernetes (Helm)"
+
+        ```bash
+        helm upgrade naas charts/naas --set worker.replicas=10
+        ```
 
 ### High Memory Usage
 
-**Symptom**: Containers using excessive memory
+**Symptom**: Containers/pods using excessive memory
 
 **Solutions**:
 
 1. Check memory usage:
 
-   ```bash
-   docker stats
-   ```
+    === "Docker Compose"
 
-2. Reduce worker processes per container:
+        ```bash
+        docker stats
+        ```
 
-   ```bash
-   export NAAS_WORKER_PROCESSES=50
-   docker compose up -d
-   ```
+    === "Kubernetes"
 
-3. Set memory limits:
+        ```bash
+        kubectl -n naas top pods
+        ```
 
-   ```yaml
-   # docker-compose.override.yml
-   services:
-     api:
-       deploy:
-         resources:
-           limits:
-             memory: 512M
-     worker:
-       deploy:
-         resources:
-           limits:
-             memory: 1G
-   ```
+2. Set memory limits:
+
+    === "Docker Compose"
+
+        ```yaml
+        # docker-compose.override.yml
+        services:
+          api:
+            deploy:
+              resources:
+                limits:
+                  memory: 512M
+          worker:
+            deploy:
+              resources:
+                limits:
+                  memory: 1G
+        ```
+
+    === "Kubernetes (Helm)"
+
+        ```bash
+        helm upgrade naas charts/naas \
+          --set api.resources.limits.memory=512Mi \
+          --set worker.resources.limits.memory=1Gi
+        ```
 
 ## Debugging
 
 ### Enable Debug Logging
 
-```bash
-# Set environment to dev for debug logs
-export APP_ENVIRONMENT=dev
-docker compose up -d
+=== "Docker Compose"
 
-# View logs
-docker compose logs -f api
-docker compose logs -f worker
-```
+    ```bash
+    LOG_LEVEL=DEBUG docker compose up -d
+    docker compose logs -f api
+    docker compose logs -f worker
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas --set config.LOG_LEVEL=DEBUG
+    kubectl -n naas logs -f deploy/naas-api
+    kubectl -n naas logs -f deploy/naas-worker
+    ```
 
 ### Check Job Details in Redis
 
-```bash
-# Connect to Redis
-docker compose exec redis redis-cli -a your_password
+=== "Docker Compose"
 
+    ```bash
+    docker compose exec redis redis-cli -a your_password
+    ```
+
+=== "Kubernetes"
+
+    ```bash
+    kubectl -n naas exec deploy/redis -- redis-cli -a "$REDIS_PASSWORD"
+    ```
+
+Common Redis commands:
+
+```bash
 # List all jobs
 KEYS rq:job:*
 
@@ -439,41 +602,23 @@ HGETALL rq:job:550e8400-e29b-41d4-a716-446655440000
 LLEN rq:queue:default
 ```
 
-### Test API Endpoints
+### Container/Pod Shell Access
 
-```bash
-# Health check
-curl -k https://localhost:8443/healthcheck
+=== "Docker Compose"
 
-# Test with verbose output
-curl -k -v -X POST https://localhost:8443/v1/send_command \
-  -u "admin:password" \
-  -H "Content-Type: application/json" \
-  -d '{"host": "192.168.1.1", "platform": "cisco_ios", "commands": ["show version"]}'
-```
+    ```bash
+    docker compose exec api bash
+    docker compose exec worker bash
+    docker compose exec redis sh
+    ```
 
-### Container Shell Access
+=== "Kubernetes"
 
-```bash
-# Access API container
-docker compose exec api bash
-
-# Access worker container
-docker compose exec worker bash
-
-# Access Redis container
-docker compose exec redis sh
-```
-
-### Check Python Dependencies
-
-```bash
-# List installed packages
-docker compose exec api pip list
-
-# Check specific package
-docker compose exec api pip show netmiko
-```
+    ```bash
+    kubectl -n naas exec -it deploy/naas-api -- bash
+    kubectl -n naas exec -it deploy/naas-worker -- bash
+    kubectl -n naas exec -it deploy/redis -- sh
+    ```
 
 ## Getting help
 
@@ -483,7 +628,7 @@ If you're still experiencing issues:
 2. Review [API documentation](https://naas.readthedocs.io/en/latest/api-reference/)
 3. Open a new issue with:
    - NAAS version
-   - Docker/Docker Compose version
+   - Deployment method and version (Docker Compose, Helm chart, Kubernetes version)
    - Error messages and logs
    - Steps to reproduce
 
@@ -523,7 +668,7 @@ CONNECTION_POOL_MAX_SIZE: "5"  # Default is 10
 
 ### No Template Found
 
-**Symptom:** `/v1/send_command_structured` returns raw string instead of list[dict].
+**Symptom:** `/v2/send-command-structured` returns raw string instead of list[dict].
 
 **Cause:** No TextFSM template exists for the (platform, command) combination.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,8 +76,9 @@ nav:
       - Troubleshooting: troubleshooting.md
       - Upgrading to v2.0: upgrading.md
   - Deployment:
-      - Docker Compose: deployment/docker-compose.md
+      - Overview: deployment/index.md
       - Kubernetes: kubernetes.md
+      - Docker Compose: deployment/docker-compose.md
       - Environment Variables: deployment/environment-variables.md
   - Development:
       - Contributing: contributing.md
@@ -97,6 +98,7 @@ nav:
           - "0007: API Versioning Strategy": adr/0007-api-versioning-strategy.md
           - "0008: OpenTelemetry Instrumentation": adr/0008-opentelemetry-instrumentation-strategy.md
           - "0009: Command Authorization Deferred to AAA": adr/0009-command-authorization-deferred-to-aaa.md
+          - "0010: MCP Server Thin Client over REST API": adr/0010-mcp-server-thin-client-over-rest-api.md
       - Changelog: changelog.md
       - Release Notes:
           - v2.0: release-notes/v2.0.md

--- a/packages/naas/changes/448.doc.md
+++ b/packages/naas/changes/448.doc.md
@@ -1,0 +1,1 @@
+Restructure documentation for v2.1: Helm-first Kubernetes page, add K8s/Helm equivalents across all operational docs, create deployment overview page, update v1 API references to v2


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul for the v2.1 release. Removes Docker Compose bias across all operational docs and establishes Helm/Kubernetes as the primary production deployment method.

## Changes

### #448 — Kubernetes page restructured as Helm-first
- Helm chart is now the primary section with full values reference table
- Common configurations: external Redis, ingress, TLS, context routing, scaling, OTel
- Upgrade/rollback/uninstall commands documented
- Raw manifests moved to a short secondary section
- `contexts.md` K8s section updated with Helm tabbed examples

### #449 — K8s/Helm equivalents added to cross-cutting docs
- `troubleshooting.md`: All operational commands now have Docker Compose + Kubernetes tabs
- `security.md`: TLS, cert rotation, Redis, container isolation, resource limits, emergency shutdown
- `observability.md`: Log level, request tracing, OTel deployment
- `architecture.md`: Scaling section
- `environment-variables.md`: Helm values.yaml example tab added

### #450 — Deployment navigation and overview
- New `deployment/index.md` with deployment method decision guide
- Nav reordered: Overview → Kubernetes → Docker Compose → Env Vars
- `installation.md` consolidated to redirect to deployment pages
- ADR 0010 added to nav

### #451 — v1 API references updated to v2
- All `/v1/` route references replaced with `/v2/` equivalents
- Unversioned URLs updated
- Troubleshooting "Getting help" now mentions K8s/Helm version
- Release notes, changelog, and ADRs left untouched (historical records)

## Testing

- `mkdocs build` passes for all modified/new pages
- No orphaned pages introduced
- Pre-existing `api-usage.md` error (pygments incompatibility) is unrelated

Closes #448, closes #449, closes #450, closes #451