### PR TITLE
docs: editorial improvements to home page and getting started

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -10,12 +10,6 @@ NAAS supports multiple deployment methods. Choose based on your environment and 
 | **[Docker Compose](docker-compose.md)** | Development, small/single-node deployments | Docker, Docker Compose |
 | **Manual** | Custom environments, development without Docker | Python 3.11+, Redis 6+, uv |
 
-## Quick Decision Guide
-
-- **Production deployment?** → Use the [Helm chart](../kubernetes.md)
-- **Local development or quick evaluation?** → Use [Docker Compose](docker-compose.md) or the [Quick Start](../quickstart.md)
-- **Need fine-grained control or no container runtime?** → Manual installation (see below)
-
 ## Manual Installation
 
 ### Prerequisites
@@ -36,9 +30,10 @@ uv sync
 # Set environment variables
 export REDIS_HOST=localhost
 export REDIS_PORT=6379
+export REDIS_PASSWORD=your-redis-password
 
-# Start Redis
-redis-server
+# Start Redis (with password)
+redis-server --requirepass "$REDIS_PASSWORD"
 
 # Start API server (in one terminal)
 uv run gunicorn -c gunicorn.py naas.app:app
@@ -46,6 +41,8 @@ uv run gunicorn -c gunicorn.py naas.app:app
 # Start worker (in another terminal)
 uv run python worker.py
 ```
+
+NAAS uses HTTP Basic Auth — credentials in requests are passed through to network devices as SSH credentials. No separate user database is required.
 
 ## Configuration
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,17 @@
 # NAAS - Netmiko As A Service
 
-Welcome to the NAAS documentation! NAAS is a REST API wrapper for [Netmiko](https://github.com/ktbyers/netmiko), enabling network device automation through a simple HTTP interface.
+NAAS is a REST API wrapper for [Netmiko](https://github.com/ktbyers/netmiko) that runs commands and pushes configurations to network devices over SSH. You submit jobs via HTTP; workers execute them asynchronously and store results in Redis.
 
-## What is NAAS?
+## What does it do?
 
-NAAS provides a production-ready API for executing commands and configurations on network devices. It handles:
-
-- **Asynchronous job processing**: Commands run in background workers
-- **Multiple device platforms**: Supports all Netmiko-compatible devices (Cisco, Arista, Juniper, etc.)
-- **Python client & CLI**: `pip install naas-client[cli]` for typed API access and terminal usage
-- **Secure authentication**: HTTPS, Basic Auth, JWT API keys with RBAC
-- **Context routing**: Isolate workloads across dedicated worker pools
-- **Job tracking**: Query status, wait for completion, cancel, replay
-- **Production features**: Prometheus metrics, audit logging, circuit breakers, connection pooling
+- **Asynchronous job processing** — Commands run in background workers; the API returns immediately with a job ID
+- **Broad device support** — Works with any device Netmiko supports (Cisco IOS/NX-OS, Arista EOS, Juniper Junos, Palo Alto, and many others)
+- **Python client & CLI** — `pip install naas-client[cli]` for typed API access and terminal usage
+- **Authentication & RBAC** — HTTPS, HTTP Basic Auth, JWT API keys with role-based access control (admin/operator/viewer)
+- **Context routing** — Route jobs to workers in specific network segments, VRFs, or geographies
+- **Job lifecycle** — Query status, wait for completion, cancel in-flight jobs, replay failed jobs
+- **Observability** — Prometheus metrics, structured audit logging, OpenTelemetry distributed tracing
+- **Reliability** — Circuit breakers, SSH connection pooling, graceful shutdown, queue backpressure
 
 ## Quick Example
 
@@ -52,27 +51,15 @@ NAAS provides a production-ready API for executing commands and configurations o
       -H "Authorization: Bearer eyJ..."
     ```
 
-## Features
-
-- ✅ REST API for network device automation (v2 with hyphenated routes)
-- ✅ Python client library with sync and async support
-- ✅ CLI tool with human and JSON output modes
-- ✅ Asynchronous job processing with Redis Queue (RQ)
-- ✅ Support for 100+ device platforms via Netmiko
-- ✅ JWT API key authentication with RBAC (admin/operator/viewer)
-- ✅ Context-based routing and worker isolation
-- ✅ Prometheus metrics (API and worker)
-- ✅ Helm chart for Kubernetes deployment
-- ✅ Structured audit logging
-- ✅ Circuit breakers and SSH connection pooling
-- ✅ Credential encryption at rest
+Basic Auth also works for quick testing — see the [Quick Start](quickstart.md) for a minimal example.
 
 ## Getting Started
 
-- [Quick Start](quickstart.md): Get NAAS running in 5 minutes
-- [Python Client](client.md): Library and CLI usage
-- [API Usage](api-usage.md): REST API examples
-- [Upgrading to v2.0](upgrading.md): Migration guide from v1.x
+- [Quick Start](quickstart.md) — Get NAAS running in 5 minutes with Docker Compose
+- [Deployment Overview](deployment/index.md) — Choose a deployment method (Helm, Docker Compose, or manual)
+- [Python Client & CLI](client.md) — Library and CLI usage
+- [API Usage](api-usage.md) — REST API examples
+- [Upgrading to v2.0](upgrading.md) — Migration guide from v1.x
 
 ## Project Links
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,21 +15,3 @@ For production environments, see the [Deployment Overview](deployment/index.md) 
 ## Configuration
 
 All deployment methods share the same environment variables. See [Environment Variables](deployment/environment-variables.md) for the full reference.
-
-## OpenTelemetry Tracing
-
-NAAS supports optional distributed tracing via [OpenTelemetry](https://opentelemetry.io/).
-Traces follow the full request lifecycle: API request → RQ queue → worker → SSH device.
-
-Install the optional dependencies:
-
-```bash
-pip install naas[otel]
-```
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `OTEL_ENABLED` | `false` | Enable OpenTelemetry instrumentation |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | (none) | OTLP collector endpoint (e.g. `http://otel-collector:4317`) |
-
-When disabled (default), tracing adds zero overhead. See [Observability](observability.md) for full details and [ADR 0008](adr/0008-opentelemetry-instrumentation-strategy.md) for design decisions.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,9 @@
 # Quick Start Guide
 
-Get NAAS up and running in 5 minutes.
+Get NAAS up and running in 5 minutes using Docker Compose.
+
+!!! tip "Prefer Kubernetes?"
+    If you already have a cluster, skip this and go to the [Helm chart deployment](kubernetes.md).
 
 ## Prerequisites
 
@@ -16,12 +19,12 @@ docker compose up -d
 curl -k https://localhost:8443/healthcheck
 ```
 
-Expected response:
+Expected response (version will match your release):
 
 ```json
 {
   "status": "healthy",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "uptime_seconds": 42,
   "components": {
     "redis": { "status": "healthy" },
@@ -31,6 +34,8 @@ Expected response:
 ```
 
 ## 2. Send a command
+
+The default `docker-compose.yml` ships with Basic Auth credentials `admin:admin`. These are passed through to your network devices as SSH credentials — replace them with valid device credentials for your environment.
 
 === "Python Client"
 

--- a/docs/release-notes/v2.1.md
+++ b/docs/release-notes/v2.1.md
@@ -1,0 +1,103 @@
+# NAAS v2.1 Release Notes
+
+NAAS v2.1 adds OpenTelemetry tracing, an MCP server for AI-assisted operations, SSE streaming for real-time job updates, structured error codes, and rate limiting.
+
+## Highlights
+
+- **OpenTelemetry distributed tracing** — End-to-end traces from API request through RQ queue to SSH device operation
+- **MCP server** — AI assistants can manage network devices through the Model Context Protocol (`mcp-server-naas` on PyPI)
+- **SSE streaming** — Real-time job status updates via Server-Sent Events
+- **Structured error codes** — Machine-parseable error classification (`CONNECTION_TIMEOUT`, `AUTH_FAILURE`, `CONFIG_REJECTED`, etc.)
+- **Rate limiting** — Per-caller and per-caller-per-device sliding window limits on submission endpoints
+
+## New Features
+
+### OpenTelemetry Distributed Tracing
+
+Traces follow the full request lifecycle: API → RQ queue → worker → SSH device. Trace context propagates through the job queue via W3C `traceparent`, linking API and worker spans into a single trace.
+
+```bash
+# Enable on both API and worker
+OTEL_ENABLED=true
+OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4317
+```
+
+Install the optional dependency: `pip install naas[otel]`. When disabled (default), tracing adds zero overhead.
+
+See [Observability](../observability.md#opentelemetry-distributed-tracing) and [ADR 0008](../adr/0008-opentelemetry-instrumentation-strategy.md).
+
+### MCP Server
+
+The `mcp-server-naas` package exposes NAAS operations to AI assistants (Claude, Copilot, etc.) via the [Model Context Protocol](https://modelcontextprotocol.io/). Tools include `send_command`, `send_config`, `send_command_structured`, `create_api_key`, `revoke_api_key`, and job management. Includes prompt templates for common workflows.
+
+```bash
+pip install mcp-server-naas
+```
+
+See [MCP Server](../mcp-server.md) and [ADR 0010](../adr/0010-mcp-server-thin-client-over-rest-api.md).
+
+### SSE Streaming
+
+Subscribe to real-time job status updates instead of polling:
+
+```bash
+curl -N https://naas.example.com/v2/send-command/<job_id>/stream \
+  -H "Authorization: Bearer eyJ..."
+```
+
+Events are delivered as the job transitions through `queued → started → finished/failed`.
+
+### Structured Error Codes
+
+Job results now include `error_code` and `error_retryable` fields when a job fails:
+
+```json
+{
+  "status": "failed",
+  "error": "Connection to 10.0.0.1 timed out after 30 seconds",
+  "error_code": "CONNECTION_TIMEOUT",
+  "error_retryable": true
+}
+```
+
+Error codes map each netmiko/paramiko exception to a structured identifier. The Python client library gains exception subclasses routed by error code.
+
+See [Error Codes](../error-codes.md).
+
+### Rate Limiting
+
+Per-caller and per-caller-per-device sliding window rate limits protect against abuse and accidental flooding:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting |
+| `RATE_LIMIT_PER_CALLER` | `1000` | Max requests per caller per window |
+| `RATE_LIMIT_PER_CALLER_DEVICE` | `20` | Max requests per caller per device per window |
+| `RATE_LIMIT_WINDOW` | `60` | Sliding window size in seconds |
+
+Returns `429 Too Many Requests` with `Retry-After` header when exceeded. Admin role is exempt by default.
+
+See [Security — Rate Limiting](../security.md#rate-limiting).
+
+## Documentation
+
+- Kubernetes deployment page restructured as Helm-first
+- K8s/Helm equivalents added across troubleshooting, security, observability, and architecture docs
+- Deployment overview page with method decision guide
+- All v1 API references updated to v2
+- ADR 0009: Command authorization deferred to AAA
+- ADR 0010: MCP server as thin client over REST API
+
+## Testing
+
+- Locust-based load testing with smoke (PR) and full (RC) CI profiles
+- OTel integration tests with OTLP collector
+- SSE streaming integration tests
+- RBAC, API key, and v2 field rejection integration tests
+
+## Compatibility
+
+- Python 3.11+
+- Netmiko 4.x
+- Redis 7+
+- Kubernetes 1.27+ (Helm chart)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
           - "0010: MCP Server Thin Client over REST API": adr/0010-mcp-server-thin-client-over-rest-api.md
       - Changelog: changelog.md
       - Release Notes:
+          - v2.1: release-notes/v2.1.md
           - v2.0: release-notes/v2.0.md
           - v1.4: release-notes/v1.4.md
           - v1.3: release-notes/v1.3.md

--- a/packages/naas/changes/+getting-started-editorial.doc.md
+++ b/packages/naas/changes/+getting-started-editorial.doc.md
@@ -1,0 +1,1 @@
+Editorial improvements to home page, quick start, installation, and deployment overview


### PR DESCRIPTION
Editorial pass on the home page and getting started docs.

## Changes

- **index.md**: Removed filler intro, deduplicated features (was listed twice in different formats), clarified device support scope, added deployment overview link to Getting Started section, noted Basic Auth works for quick testing
- **quickstart.md**: Fixed hardcoded version in healthcheck response, added explanation of default credentials, added tip callout pointing Kubernetes users to the Helm chart
- **installation.md**: Removed misplaced OpenTelemetry section (already in observability.md), kept page as a concise pointer to quickstart and deployment docs
- **deployment/index.md**: Removed redundant decision guide bullets that restated the table, added Redis password and credential explanation to manual install steps