### PR TITLE
docs: rewrite security page — cut generic advice, keep actionable content

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,26 +1,14 @@
-# Security best practices
+# Security
 
-Guidelines for securing your NAAS deployment.
+NAAS transmits SSH credentials to network devices. This page covers how to secure the deployment itself.
 
-## Contents
+## TLS
 
-- [Transport Security](#transport-security)
-- [Authentication](#authentication)
-- [Network Security](#network-security)
-- [Credential Management](#credential-management)
-- [Access Control](#access-control)
-- [Monitoring and Auditing](#monitoring-and-auditing)
-- [Container Security](#container-security)
+NAAS listens on HTTPS only. Gunicorn handles TLS directly — no reverse proxy required.
 
-## Transport security
+**Default behavior:** Generates a self-signed certificate at startup if none is provided.
 
-### Always use HTTPS
-
-NAAS transmits credentials to network devices. **Never** use HTTP in production.
-
-**Default**: NAAS generates a self-signed certificate at startup if no certificate is provided.
-
-**Production**: Supply a valid TLS certificate:
+**Production:** Supply a valid certificate:
 
 === "Docker Compose"
 
@@ -40,21 +28,18 @@ NAAS transmits credentials to network devices. **Never** use HTTP in production.
       --set secrets.tlsCaBundle="$(cat chain.pem)"
     ```
 
-### TLS Configuration
+    With cert-manager, create a `Certificate` resource and reference the resulting secret via `secrets.existingSecret`.
 
-TLS is handled by Gunicorn directly — no reverse proxy required. The cipher suite and minimum TLS version are hardcoded to secure defaults:
+**TLS settings** (hardcoded, not configurable):
 
-- **Minimum version**: TLS 1.2
-- **Ciphers**: `HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK`
+- Minimum version: TLS 1.2
+- Ciphers: `HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK`
 
-For custom cipher configuration, use a reverse proxy (see [Reverse Proxy](#reverse-proxy) below).
+To customize ciphers, terminate TLS at a reverse proxy instead.
 
 ### Certificate Rotation
 
-Rotate certificates before expiration:
-
 ```bash
-# Check certificate expiration
 openssl x509 -in cert.pem -noout -enddate
 ```
 
@@ -63,7 +48,6 @@ openssl x509 -in cert.pem -noout -enddate
     ```bash
     export NAAS_CERT=$(cat new-cert.pem)
     export NAAS_KEY=$(cat new-key.pem)
-    export NAAS_CA_BUNDLE=$(cat new-bundle.pem)
     docker compose up -d
     ```
 
@@ -72,34 +56,29 @@ openssl x509 -in cert.pem -noout -enddate
     ```bash
     helm upgrade naas charts/naas \
       --set secrets.tlsCert="$(cat new-cert.pem)" \
-      --set secrets.tlsKey="$(cat new-key.pem)" \
-      --set secrets.tlsCaBundle="$(cat new-bundle.pem)"
+      --set secrets.tlsKey="$(cat new-key.pem)"
     ```
-
-    Or with cert-manager, rotation is automatic.
 
 ## Authentication
 
-### Basic Authentication
+NAAS supports two authentication methods:
 
-NAAS uses HTTP Basic Authentication. Credentials are passed through to network devices.
+- **HTTP Basic Auth** — Credentials are passed through to the target device as SSH credentials. NAAS does not store them.
+- **JWT API keys** — Created via `/v2/api-keys`. Scoped by role and context. Used for automation and service-to-service access.
 
-**Important**:
+### RBAC
 
-- Credentials are **not** stored by NAAS
-- Credentials are transmitted to the target device
-- Always use HTTPS to protect credentials in transit
+| Role | Can do |
+|------|--------|
+| `admin` | Everything, including API key management |
+| `operator` | Submit jobs, view results |
+| `viewer` | View job status and results only |
+
+API keys carry a `role` and optional `contexts` claim. Requests to endpoints above the key's role return `403`.
 
 ### Device Credentials
 
-**Best Practices**:
-
-1. **Use dedicated service accounts** for automation
-2. **Rotate credentials regularly**
-3. **Use least privilege** - only grant necessary permissions
-4. **Monitor authentication failures** - detect brute force attempts
-
-### Enable Password
+NAAS is a pass-through — it connects to devices using whatever credentials the caller provides. Use dedicated service accounts with least privilege on your devices. Rotate them on your own schedule.
 
 For devices requiring enable mode:
 
@@ -112,138 +91,9 @@ For devices requiring enable mode:
 }
 ```
 
-**Note**: Enable passwords are also transmitted securely over HTTPS.
+## Redis
 
-## Network Security
-
-### Firewall Rules
-
-Restrict access to NAAS:
-
-```bash
-# Allow only from specific networks
-sudo ufw allow from 10.0.0.0/8 to any port 8443
-sudo ufw deny 8443
-
-# Or using iptables
-sudo iptables -A INPUT -p tcp -s 10.0.0.0/8 --dport 8443 -j ACCEPT
-sudo iptables -A INPUT -p tcp --dport 8443 -j DROP
-```
-
-### Network Segmentation
-
-Deploy NAAS in a management network:
-
-```text
-[Automation Tools] --> [NAAS] --> [Network Devices]
-     10.0.1.0/24      10.0.2.0/24    10.0.3.0/24
-```
-
-**Benefits**:
-
-- Limit blast radius
-- Easier to audit and monitor
-- Centralized access control
-
-### Reverse Proxy
-
-Use a reverse proxy for additional security:
-
-```nginx
-# nginx.conf
-upstream naas {
-    server localhost:8443;
-}
-
-server {
-    listen 443 ssl http2;
-    server_name naas.example.com;
-
-    ssl_certificate /path/to/cert.pem;
-    ssl_certificate_key /path/to/key.pem;
-
-    # Security headers
-    add_header Strict-Transport-Security "max-age=31536000" always;
-    add_header X-Frame-Options "DENY" always;
-    add_header X-Content-Type-Options "nosniff" always;
-
-    # Rate limiting
-    limit_req_zone $binary_remote_addr zone=naas:10m rate=10r/s;
-    limit_req zone=naas burst=20;
-
-    location / {
-        proxy_pass https://naas;
-        proxy_ssl_verify off;
-
-        # Pass through auth headers
-        proxy_set_header Authorization $http_authorization;
-        proxy_pass_header Authorization;
-    }
-}
-```
-
-## Credential Management
-
-### Avoid Hardcoding Credentials
-
-**Bad**:
-
-```python
-# Don't do this!
-response = requests.post(
-    "https://naas.example.com/v2/send-command",
-    auth=("admin", "password123"),  # Hardcoded!
-    json=payload
-)
-```
-
-**Good**:
-
-```python
-import os
-from requests.auth import HTTPBasicAuth
-
-# Use environment variables
-username = os.environ["DEVICE_USERNAME"]
-password = os.environ["DEVICE_PASSWORD"]
-
-response = requests.post(
-    "https://naas.example.com/v2/send-command",
-    auth=HTTPBasicAuth(username, password),
-    json=payload
-)
-```
-
-### Use Secrets Management
-
-Integrate with secrets management systems:
-
-```python
-# Using HashiCorp Vault
-import hvac
-
-client = hvac.Client(url='https://vault.example.com')
-secret = client.secrets.kv.v2.read_secret_version(path='network/devices')
-
-username = secret['data']['data']['username']
-password = secret['data']['data']['password']
-```
-
-### Credential Rotation
-
-Implement automated credential rotation:
-
-1. Generate new credentials
-2. Update on all devices
-3. Update in secrets management
-4. Verify NAAS can authenticate
-5. Revoke old credentials
-
-## Access Control
-
-### Redis Security
-
-Secure Redis with authentication:
+Redis holds the job queue, results, circuit breaker state, and rate limit counters. Secure it:
 
 === "Docker Compose"
 
@@ -261,195 +111,68 @@ Secure Redis with authentication:
 
     Or reference an existing secret: `--set secrets.existingSecret=my-naas-secrets`
 
-### Container Isolation
+For production, use a managed Redis (ElastiCache, Redis Cloud, etc.) with encryption in transit and at rest. The bundled Redis is single-replica with no persistence.
 
-Run with minimal privileges:
+## Rate Limiting
 
-=== "Docker Compose"
-
-    ```yaml
-    # docker-compose.override.yml
-    services:
-      api:
-        security_opt:
-          - no-new-privileges:true
-        read_only: true
-        tmpfs:
-          - /tmp
-        user: "1000:1000"
-    ```
-
-=== "Kubernetes"
-
-    The Helm chart applies these by default: non-root UID 1000, all capabilities dropped, read-only root filesystem. No additional configuration needed.
-
-### Rate Limiting
-
-NAAS includes a built-in per-caller sliding window rate limiter backed by Redis sorted sets. It applies to all submission endpoints (`/v2/send-command`, `/v2/send-config`, `/v2/send-command-structured`).
-
-**Two tiers:**
-
-- **Per-caller:** Limits total submissions across all devices for a given identity
-- **Per-caller-per-device:** Limits submissions to a single device from a given identity
-
-When a limit is exceeded, the API returns `429 Too Many Requests` with a `Retry-After` header.
-
-**Configuration (environment variables):**
+Built-in per-caller sliding window rate limiter on all submission endpoints.
 
 | Variable | Default | Description |
-| -------- | ------- | ----------- |
-| `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting |
+|----------|---------|-------------|
+| `RATE_LIMIT_ENABLED` | `true` | Enable/disable |
 | `RATE_LIMIT_PER_CALLER` | `1000` | Max requests per caller per window |
 | `RATE_LIMIT_PER_CALLER_DEVICE` | `20` | Max requests per caller per device per window |
-| `RATE_LIMIT_WINDOW` | `60` | Sliding window size in seconds |
-| `RATE_LIMIT_EXEMPT_ROLES` | `admin` | Comma-separated roles exempt from limits |
+| `RATE_LIMIT_WINDOW` | `60` | Window size in seconds |
+| `RATE_LIMIT_EXEMPT_ROLES` | `admin` | Roles exempt from limits |
 
-**Response headers** (included on every submission response):
+When exceeded, returns `429 Too Many Requests` with `Retry-After` header. Basic auth users are exempt (treated as admin role).
 
-- `X-RateLimit-Limit` — the applicable limit
-- `X-RateLimit-Remaining` — requests remaining in the window
-- `X-RateLimit-Reset` — Unix timestamp when the window resets
+Response headers on every submission:
 
-**429 response body:**
-
-```json
-{
-  "error": "Rate limit exceeded",
-  "retry_after": 60
-}
-```
-
-Basic auth users are implicitly exempt (treated as admin). API key users are subject to limits based on their role.
-
-You can also add external rate limiting via a reverse proxy (see the nginx example above).
-
-## Monitoring and Auditing
-
-### Structured Audit Events
-
-NAAS emits structured JSON audit events at INFO level via the `NAAS` logger. Each
-event includes an `event_type` field for filtering.
-
-#### Authentication Events
-
-| Event | Fields | Description |
-| --- | --- | --- |
-| `auth.success` | `method`, `identity` | Successful authentication (Basic or Bearer) |
-| `auth.failure` | `method`, `reason` | Failed authentication attempt |
-
-#### Authorization Events
-
-| Event | Fields | Description |
-| --- | --- | --- |
-| `auth.context_denied` | `identity`, `context`, `allowed_contexts` | Context authorization failure |
-| `auth.rbac_denied` | `identity`, `role`, `required_role`, `endpoint` | Insufficient role |
-
-#### API Key Management Events
-
-| Event | Fields | Description |
-| --- | --- | --- |
-| `apikey.created` | `key_id`, `role`, `contexts`, `created_by` | New API key created |
-| `apikey.revoked` | `key_id`, `revoked_by` | API key revoked |
-
-#### Job Lifecycle Events
-
-| Event | Fields | Description |
-| --- | --- | --- |
-| `job.submitted` | `host`, `platform`, `port`, `command_count`, `user_hash`, `request_id` | Job enqueued |
-| `job.completed` | `request_id`, `status`, `duration_ms` | Job finished |
-| `job.cancelled` | `request_id`, `cancelled_by_hash` | Job cancelled |
-| `job.orphaned` | `request_id`, `worker_name` | Orphaned job reaped |
-
-#### Device Events
-
-| Event | Fields | Description |
-| --- | --- | --- |
-| `device.locked_out` | `host`, `failure_count` | Device locked after repeated failures |
-| `circuit.opened` | `host` | Circuit breaker opened |
-| `circuit.closed` | `host` | Circuit breaker closed |
-
-**Data privacy**: Audit events never contain passwords, command output, or API key
-tokens. Only usernames, key IDs, and operational metadata are logged.
-
-### Filtering Audit Events
-
-Audit events are mixed with operational logs in the JSON output stream. Filter on
-the `event_type` field:
-
-=== "Docker Compose"
-
-    ```bash
-    docker compose logs api | jq 'select(.event_type)'
-    docker compose logs api | jq 'select(.event_type == "auth.failure")'
-    docker compose logs api | jq 'select(.event_type | startswith("auth."))'
-    ```
-
-=== "Kubernetes"
-
-    ```bash
-    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type)'
-    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type == "auth.failure")'
-    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type | startswith("auth."))'
-    ```
-
-### SIEM Integration
-
-Ship structured JSON logs to your SIEM using any log shipper (Fluentd, Vector,
-Filebeat). Filter on `event_type` to route audit events to a dedicated index.
-
-### Tamper-Evident Logging
-
-For compliance, ship logs to an append-only store:
-
-- **AWS**: CloudWatch Logs with retention policy
-- **S3**: With Object Lock enabled
-- **Syslog**: Forward to a hardened syslog server
-
-### Recommended Alerts
-
-| Event | Alert condition | Indicates |
-| --- | --- | --- |
-| `auth.failure` | >10 in 5 minutes | Brute force attempt |
-| `auth.rbac_denied` | Any occurrence | Privilege escalation attempt |
-| `apikey.created` | Any occurrence | New API key (verify expected) |
-| `device.locked_out` | Any occurrence | Device under attack or misconfigured |
-
-### Log Aggregation
-
-Send logs to centralized logging:
-
-=== "Docker Compose"
-
-    ```yaml
-    # docker-compose.override.yml
-    services:
-      api:
-        logging:
-          driver: "syslog"
-          options:
-            syslog-address: "tcp://logserver.example.com:514"
-            tag: "naas-api"
-      worker:
-        logging:
-          driver: "syslog"
-          options:
-            syslog-address: "tcp://logserver.example.com:514"
-            tag: "naas-worker"
-    ```
-
-=== "Kubernetes"
-
-    Use a log shipper DaemonSet (Fluentd, Vector, Filebeat) to collect pod logs from `/var/log/containers/`. NAAS emits structured JSON, so no parsing is needed — route directly to your SIEM or log backend.
-
-### Monitor Authentication Failures
-
-Set up alerts for `auth.failure` events (see [Recommended Alerts](#recommended-alerts) above).
+- `X-RateLimit-Limit` — applicable limit
+- `X-RateLimit-Remaining` — requests left in window
+- `X-RateLimit-Reset` — Unix timestamp when window resets
 
 ## Container Security
 
-### Keep Images Updated
+The Helm chart and default `docker-compose.yml` apply these by default:
 
-Regularly update NAAS and dependencies:
+- Non-root user (UID 1000)
+- All Linux capabilities dropped (API retains `NET_BIND_SERVICE` for port 443)
+- Read-only root filesystem (`/tmp` writable via tmpfs)
+
+### Resource Limits
+
+=== "Docker Compose"
+
+    ```yaml
+    # docker-compose.override.yml
+    services:
+      api:
+        deploy:
+          resources:
+            limits:
+              cpus: '1'
+              memory: 512M
+      worker:
+        deploy:
+          resources:
+            limits:
+              cpus: '2'
+              memory: 1G
+    ```
+
+=== "Kubernetes (Helm)"
+
+    ```bash
+    helm upgrade naas charts/naas \
+      --set api.resources.limits.cpu=1000m \
+      --set api.resources.limits.memory=512Mi \
+      --set worker.resources.limits.cpu=2000m \
+      --set worker.resources.limits.memory=1Gi
+    ```
+
+### Image Updates
 
 === "Docker Compose"
 
@@ -464,153 +187,104 @@ Regularly update NAAS and dependencies:
     helm upgrade naas charts/naas --set image.tag=2.1.0
     ```
 
-### Scan for Vulnerabilities
+Scan images with `trivy image ghcr.io/lykinsbd/naas:latest` or Docker Scout.
 
-Use container scanning tools:
+## Audit Events
 
-```bash
-# Using Trivy
-trivy image ghcr.io/lykinsbd/naas:latest
+NAAS emits structured JSON audit events via the `NAAS` logger. Each event has an `event_type` field.
 
-# Using Docker Scout
-docker scout cves ghcr.io/lykinsbd/naas:latest
-```
+### Event Reference
 
-### Resource Limits
+| Event | Key Fields | Meaning |
+|-------|-----------|---------|
+| `auth.success` | `method`, `identity` | Successful authentication |
+| `auth.failure` | `method`, `reason` | Failed authentication attempt |
+| `auth.context_denied` | `identity`, `context`, `allowed_contexts` | Context authorization failure |
+| `auth.rbac_denied` | `identity`, `role`, `required_role`, `endpoint` | Insufficient role |
+| `apikey.created` | `key_id`, `role`, `contexts`, `created_by` | New API key created |
+| `apikey.revoked` | `key_id`, `revoked_by` | API key revoked |
+| `job.submitted` | `host`, `platform`, `command_count`, `request_id` | Job enqueued |
+| `job.completed` | `request_id`, `status`, `duration_ms` | Job finished |
+| `job.cancelled` | `request_id`, `cancelled_by_hash` | Job cancelled |
+| `job.orphaned` | `request_id`, `worker_name` | Orphaned job reaped |
+| `device.locked_out` | `host`, `failure_count` | Device locked after repeated failures |
+| `circuit.opened` | `host` | Circuit breaker tripped |
+| `circuit.closed` | `host` | Circuit breaker recovered |
 
-Prevent resource exhaustion:
+Audit events never contain passwords, command output, or API key tokens.
+
+### Filtering
 
 === "Docker Compose"
 
-    ```yaml
-    # docker-compose.override.yml
-    services:
-      api:
-        deploy:
-          resources:
-            limits:
-              cpus: '1'
-              memory: 512M
-            reservations:
-              cpus: '0.5'
-              memory: 256M
-      worker:
-        deploy:
-          resources:
-            limits:
-              cpus: '2'
-              memory: 1G
-            reservations:
-              cpus: '1'
-              memory: 512M
+    ```bash
+    docker compose logs api | jq 'select(.event_type)'
+    docker compose logs api | jq 'select(.event_type | startswith("auth."))'
+    ```
+
+=== "Kubernetes"
+
+    ```bash
+    kubectl -n naas logs deploy/naas-api | jq 'select(.event_type)'
+    ```
+
+Ship to your SIEM via any log shipper (Fluentd, Vector, Filebeat). Filter on `event_type` to route audit events to a dedicated index.
+
+### Recommended Alerts
+
+| Event | Condition | Indicates |
+|-------|-----------|-----------|
+| `auth.failure` | >10 in 5 minutes | Brute force attempt |
+| `auth.rbac_denied` | Any occurrence | Privilege escalation attempt |
+| `apikey.created` | Any occurrence | New API key — verify expected |
+| `device.locked_out` | Any occurrence | Device under attack or misconfigured credentials |
+
+## Reverse Proxy (Optional)
+
+If you need custom TLS ciphers, additional rate limiting, or security headers beyond what NAAS provides:
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name naas.example.com;
+
+    ssl_certificate /path/to/cert.pem;
+    ssl_certificate_key /path/to/key.pem;
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options "nosniff" always;
+
+    location / {
+        proxy_pass https://naas;
+        proxy_ssl_verify off;
+        proxy_set_header Authorization $http_authorization;
+    }
+}
+```
+
+## Emergency Shutdown
+
+=== "Docker Compose"
+
+    ```bash
+    docker compose down        # Stop services
+    docker compose down -v     # Stop and wipe Redis data
     ```
 
 === "Kubernetes (Helm)"
 
     ```bash
-    helm upgrade naas charts/naas \
-      --set api.resources.limits.cpu=1000m \
-      --set api.resources.limits.memory=512Mi \
-      --set worker.resources.limits.cpu=2000m \
-      --set worker.resources.limits.memory=1Gi
+    helm uninstall naas              # Remove release
+    kubectl delete namespace naas    # Remove everything including PVCs
     ```
 
-### Read-Only Filesystem
+## Pre-Production Checklist
 
-Run containers with read-only root filesystem:
-
-```yaml
-# docker-compose.override.yml
-services:
-  api:
-    read_only: true
-    tmpfs:
-      - /tmp
-      - /var/run
-```
-
-## Security Checklist
-
-Before deploying to production:
-
-- [ ] Use valid TLS certificates (not self-signed)
-- [ ] Configure firewall rules
-- [ ] Use strong Redis password
-- [ ] Enable production logging
-- [ ] Set up log aggregation
-- [ ] Configure rate limiting
-- [ ] Implement network segmentation
-- [ ] Use secrets management for credentials
-- [ ] Set resource limits on containers
-- [ ] Enable container security options
-- [ ] Set up monitoring and alerting
-- [ ] Document incident response procedures
-- [ ] Plan credential rotation schedule
-- [ ] Review and update regularly
-
-## Compliance Considerations
-
-### PCI DSS
-
-If handling payment card data:
-
-- Use TLS 1.2 or higher
-- Implement strong access controls
-- Log all access to network devices
-- Encrypt credentials at rest and in transit
-
-### SOC 2
-
-For SOC 2 compliance:
-
-- Maintain audit logs
-- Implement access controls
-- Monitor for security events
-- Document security procedures
-
-### HIPAA
-
-For healthcare environments:
-
-- Encrypt all data in transit
-- Implement access controls
-- Maintain audit trails
-- Use secure credential management
-
-## Incident Response
-
-### Security Incident Procedure
-
-1. **Detect**: Monitor logs for suspicious activity
-2. **Contain**: Isolate affected systems
-3. **Investigate**: Review logs and audit trail
-4. **Remediate**: Rotate credentials, patch vulnerabilities
-5. **Document**: Record incident details and response
-
-### Emergency Shutdown
-
-=== "Docker Compose"
-
-    ```bash
-    # Stop all NAAS services immediately
-    docker compose down
-
-    # Clear Redis data if compromised
-    docker compose down -v
-    ```
-
-=== "Kubernetes (Helm)"
-
-    ```bash
-    # Stop all NAAS services
-    helm uninstall naas
-
-    # Or delete the namespace entirely (including PVCs)
-    kubectl delete namespace naas
-    ```
-
-## Next steps
-
-- [Troubleshooting Guide](troubleshooting.md) - Common issues
-- [API Usage Examples](api-usage.md) - Learn the API
-- [Quick Start Guide](quickstart.md) - Get started with NAAS
+- [ ] Valid TLS certificate (not self-signed)
+- [ ] Strong Redis password
+- [ ] Rate limiting configured
+- [ ] Resource limits set
+- [ ] Log aggregation configured
+- [ ] Alerts on `auth.failure` and `device.locked_out`
+- [ ] Network access restricted to authorized callers
+- [ ] Container images scanned for vulnerabilities

--- a/packages/naas/changes/+security-page-editorial.doc.md
+++ b/packages/naas/changes/+security-page-editorial.doc.md
@@ -1,0 +1,1 @@
+Rewrite security page: remove generic advice, keep NAAS-specific actionable content


### PR DESCRIPTION
## Summary

Editorial rewrite of the security page. Cuts ~40% of the content that was generic security advice (not NAAS-specific) and tightens what remains.

## Removed

- "Don't hardcode credentials" Python examples (obvious to the audience)
- HashiCorp Vault integration snippet (not NAAS-specific)
- Generic credential rotation procedure
- Compliance section (PCI DSS, SOC 2, HIPAA) — bullet-point summaries of entire frameworks that provide zero actionable guidance
- Generic incident response framework (Detect/Contain/Investigate/Remediate/Document)
- Firewall rules section (ufw/iptables basics)
- Network segmentation ASCII diagram
- Duplicate read-only filesystem subsection
- "Monitor Authentication Failures" subsection (was just a link to content 10 lines above)

## Kept and improved

- TLS configuration and rotation (NAAS-specific)
- Authentication model explanation (Basic Auth pass-through + JWT RBAC)
- Redis security
- Rate limiting reference
- Container security defaults
- Audit events (consolidated from 5 tables into 1 reference table)
- Recommended alerts
- Reverse proxy (shortened to essential directives)
- Emergency shutdown
- Pre-production checklist (trimmed from 14 items to 8 actionable ones)