### PR TITLE
docs: update architecture page to reflect v2.x state

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,98 +2,121 @@
 
 ## Overview
 
-NAAS is a thin async wrapper around [Netmiko](https://github.com/ktbyers/netmiko). The API accepts requests, enqueues jobs, and returns immediately. Workers pick up jobs from the queue and execute them against network devices.
+NAAS is an async wrapper around [Netmiko](https://github.com/ktbyers/netmiko). The API accepts requests, enqueues jobs, and returns immediately. Workers pick up jobs from the queue and execute them against network devices over SSH.
 
 ```mermaid
 sequenceDiagram
     participant Client
     participant API as NAAS API
-    participant Queue as Redis Queue
+    participant Queue as Redis
     participant Worker as RQ Worker
     participant Device as Network Device
 
     Client->>API: POST /v2/send-command
-    API->>Queue: enqueue job (job_id = X-Request-ID)
+    API->>API: Auth (Basic/JWT), RBAC, rate limit
+    API->>Queue: enqueue job (context queue)
     API-->>Client: 202 Accepted { job_id }
 
-    Worker->>Queue: fetch next job
-    Worker->>Device: SSH via Netmiko
+    Worker->>Queue: fetch from context queue
+    Worker->>Device: SSH via Netmiko (pooled connection)
     Device-->>Worker: command output
     Worker->>Queue: store result
 
     Client->>API: GET /v2/send-command/{job_id}
-    API->>Queue: fetch job result
     API-->>Client: 200 { status: finished, results: {...} }
 ```
+
+Clients can also subscribe to `GET /v2/send-command/{job_id}/stream` for real-time SSE updates instead of polling.
 
 ## Components
 
 ```mermaid
 graph TD
-    Client["Client<br/>(curl / Python / etc.)"]
+    Client["Client<br/>(Python SDK / CLI / curl / MCP)"]
     API["NAAS API<br/>(Flask + Gunicorn)"]
-    Redis["Redis<br/>(job queue + results)"]
+    Redis["Redis<br/>(queues, results, state)"]
     Worker["RQ Worker<br/>(one or more)"]
-    Device["Network Devices<br/>(Cisco, Arista, Juniper, ...)"]
-    Metrics["Prometheus<br/>(metrics scraping)"]
+    Device["Network Devices"]
+    Metrics["Prometheus"]
+    OTel["OTel Collector<br/>(optional)"]
 
     Client -->|HTTPS| API
     API -->|enqueue / fetch| Redis
     Worker -->|dequeue / store| Redis
     Worker -->|SSH via Netmiko| Device
-    Worker -->|connection pool| Device
     Metrics -->|scrape /metrics| API
-    API -->|audit events| Redis
+    Metrics -->|scrape /metrics| Worker
+    API -.->|traces| OTel
+    Worker -.->|traces| OTel
 ```
 
 ### NAAS API
 
-The Flask application handles authentication, request validation, job enqueueing, and result retrieval. It is stateless — all state lives in Redis. Multiple API instances can run behind a load balancer.
+Flask application handling:
 
-**New in v1.3:**
+- Authentication (HTTP Basic Auth or JWT Bearer tokens)
+- RBAC enforcement (admin/operator/viewer)
+- Rate limiting (per-caller and per-caller-per-device)
+- Request validation and job deduplication
+- Context-based queue routing
+- Job enqueueing and result retrieval
+- SSE streaming for real-time job updates
+- Prometheus metrics at `/metrics`
+- Structured audit event emission
 
-- Exposes Prometheus metrics at `/metrics`
-- Emits structured audit events for compliance
-- Supports job cancellation via DELETE endpoint
+Stateless — all state lives in Redis. Run multiple instances behind a load balancer.
 
 ### Redis
 
-Redis serves multiple roles:
+Redis is the central coordination point. It stores:
 
-- **Job queue** — RQ uses Redis sorted sets to hold pending jobs
-- **Result store** — completed job output is stored in Redis with a configurable TTL
-- **Circuit breaker state** — per-device failure counts shared across workers
-- **Connection pool metadata** — tracks pooled SSH connections per worker
+- **Job queues** — One RQ queue per context (`naas-default`, `naas-corp`, `naas-oob-dc1`, etc.)
+- **Job results** — Completed output with configurable TTL
+- **Circuit breaker state** — Per-device failure counts, shared across workers
+- **Connection pool metadata** — Tracks pooled SSH connections per worker
+- **Rate limit counters** — Sliding window sorted sets per caller
+- **API keys** — JWT key metadata and revocation set
+- **Encrypted credentials** — Device credentials encrypted at rest (when stored for pooled connections)
+- **Idempotency keys** — Deduplication state for repeated submissions
 
-### RQ Worker
+For production, use a managed Redis with replication and persistence. The bundled Redis is single-replica with no persistence.
 
-Workers are separate processes that dequeue jobs and execute them. Each worker handles one job at a time. Scale horizontally by running more worker containers.
+### RQ Workers
 
-**New in v1.3:**
+Workers are separate processes that dequeue jobs and execute them. Each worker process handles one job at a time.
 
-- Maintains persistent SSH connection pool (configurable)
-- Shares circuit breaker state across all workers
-- Emits structured audit events
+- Serve one or more contexts (configured via `WORKER_CONTEXTS`)
+- Maintain persistent SSH connection pool (reuse connections across sequential jobs to the same device)
+- Share circuit breaker state across all workers via Redis
+- Emit Prometheus metrics and structured audit events
+- Propagate OpenTelemetry trace context from the API through the queue
 
-Workers also hold circuit breaker state in Redis, so all workers share the same per-device failure counts.
+Scale horizontally: total job concurrency = number of worker processes across all pods.
 
 ### Network Devices
 
-NAAS connects to devices over SSH using Netmiko. The API credentials (HTTP Basic Auth) are passed directly to the device — NAAS does not maintain its own credential store.
+NAAS connects to devices over SSH using Netmiko. Credentials from the HTTP request (Basic Auth) are passed directly to the device — NAAS does not maintain a separate credential store.
+
+### MCP Server (Optional)
+
+The `mcp-server-naas` package exposes NAAS operations to AI assistants via the Model Context Protocol. It's a thin client that calls the REST API — no direct Redis or device access.
 
 ## Request Lifecycle
 
-1. **Client** sends `POST /v2/send-command` with device host, platform, and commands
-2. **API** validates the request (host format, platform, auth), checks for duplicate job IDs and device lockout, then enqueues the job
-3. **API** returns `202 Accepted` with the `job_id` (= `X-Request-ID`)
-4. **Worker** picks up the job, checks the circuit breaker, connects to the device via SSH, runs the commands, and stores the result
-5. **Client** polls `GET /v2/send-command/{job_id}` until `status` is `finished` or `failed`
+1. **Client** sends `POST /v2/send-command` with host, platform, commands, and optional context
+2. **API** authenticates (Basic Auth or JWT), checks RBAC role, enforces rate limits
+3. **API** validates the request, checks idempotency key and device lockout
+4. **API** enqueues the job to the context-specific queue (e.g. `naas-oob-dc1`)
+5. **API** returns `202 Accepted` with `job_id`
+6. **Worker** serving that context picks up the job, checks the circuit breaker
+7. **Worker** connects to the device (reusing a pooled connection if available), runs commands, stores the result
+8. **Client** retrieves results via `GET /v2/send-command/{job_id}` or SSE stream
 
 ## Why Async?
 
-SSH connections to network devices can take seconds to minutes depending on device responsiveness, command complexity, and network latency. A synchronous API would hold HTTP connections open for the duration, limiting throughput and causing timeouts.
+SSH connections to network devices take seconds to minutes depending on device responsiveness and command complexity. A synchronous API would hold HTTP connections open for the duration, limiting throughput and causing timeouts.
 
-The async model lets the API return immediately and lets clients poll at their own pace. It also enables horizontal scaling — add more workers to increase throughput without changing the API layer.
+The async model lets the API return immediately. Clients poll or subscribe to SSE at their own pace. It also enables horizontal scaling — add workers to increase throughput without changing the API layer.
 
 ## Scaling
 
@@ -103,9 +126,9 @@ graph LR
     API1["API instance 1"]
     API2["API instance 2"]
     Redis["Redis"]
-    W1["Worker 1"]
-    W2["Worker 2"]
-    W3["Worker 3"]
+    W1["Worker (corp)"]
+    W2["Worker (oob)"]
+    W3["Worker (default)"]
 
     LB --> API1
     LB --> API2
@@ -116,9 +139,9 @@ graph LR
     W3 --> Redis
 ```
 
-- **API** scales horizontally — stateless, any instance can handle any request
-- **Workers** scale horizontally — add replicas to increase concurrent job capacity
-- **Redis** is the single coordination point — use Redis Sentinel or Cluster for HA
+- **API** — Stateless, scales horizontally. Any instance handles any request.
+- **Workers** — Scale per context. Each worker serves one or more contexts. Add replicas to increase concurrency for a given context.
+- **Redis** — Single coordination point. Use Redis Sentinel or Cluster for HA.
 
 === "Docker Compose"
 

--- a/packages/naas/changes/+architecture-update.doc.md
+++ b/packages/naas/changes/+architecture-update.doc.md
@@ -1,0 +1,1 @@
+Update architecture page to reflect v2.x features: RBAC, context routing, rate limiting, SSE, OTel, MCP server


### PR DESCRIPTION
The architecture page still had "New in v1.3" callouts and was missing most v2.x components.

## Changes

- Removed stale "New in v1.3" markers (those features are 3 releases old)
- Added to API responsibilities: RBAC, rate limiting, context routing, SSE streaming, job deduplication
- Added SSE as alternative to polling in sequence diagram and request lifecycle
- Updated Redis roles: now includes rate limit counters, API keys, encrypted credentials, idempotency keys
- Added MCP server as optional component
- Added OTel collector to component diagram
- Updated scaling diagram to show context-specific workers
- Expanded request lifecycle to include auth → RBAC → rate limit → context routing steps
- Updated worker description: context serving, OTel trace propagation, metrics