### PR TITLE
docs: reorganize navigation structure

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,3 +40,6 @@ Do **not** write an ADR for:
 | [0005](0005-structured-audit-event-logging.md) | Structured audit event logging | Accepted |
 | [0006](0006-credential-encryption-at-rest.md) | Credential encryption at rest | Accepted |
 | [0007](0007-api-versioning-strategy.md) | API versioning strategy | Accepted |
+| [0008](0008-opentelemetry-instrumentation-strategy.md) | OpenTelemetry instrumentation strategy | Accepted |
+| [0009](0009-command-authorization-deferred-to-aaa.md) | Command authorization deferred to AAA | Accepted |
+| [0010](0010-mcp-server-thin-client-over-rest-api.md) | MCP server as thin client over REST API | Accepted |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,19 +62,19 @@ nav:
   - Home: index.md
   - Getting Started:
       - Quick Start: quickstart.md
-      - Installation: installation.md
-      - Architecture: architecture.md
-  - User Guide:
-      - API Usage: api-usage.md
-      - Python Client: client.md
+      - Upgrading to v2.0: upgrading.md
+  - Usage:
+      - API: api-usage.md
+      - Python Client & CLI: client.md
       - MCP Server: mcp-server.md
       - Structured Output: structured-output.md
       - Context Routing: contexts.md
+      - Error Codes: error-codes.md
+  - Operations:
+      - Security: security.md
       - Observability: observability.md
       - Reliability: reliability.md
-      - Security: security.md
       - Troubleshooting: troubleshooting.md
-      - Upgrading to v2.0: upgrading.md
   - Deployment:
       - Overview: deployment/index.md
       - Kubernetes: kubernetes.md
@@ -85,20 +85,9 @@ nav:
       - Development Guide: development.md
       - Testing: testing.md
   - Reference:
-      - API Reference: api-reference.md
-      - Error Codes: error-codes.md
-      - Architecture Decisions:
-          - ADR Index: adr/README.md
-          - "0001: Python Client Integration": adr/0001-python-client-library-integration.md
-          - "0002: Secrets Backend Abstraction": adr/0002-secrets-backend-abstraction.md
-          - "0003: API Key Authentication": adr/0003-api-key-authentication.md
-          - "0004: Role-Based Access Control": adr/0004-role-based-access-control.md
-          - "0005: Structured Audit Logging": adr/0005-structured-audit-event-logging.md
-          - "0006: Credential Encryption at Rest": adr/0006-credential-encryption-at-rest.md
-          - "0007: API Versioning Strategy": adr/0007-api-versioning-strategy.md
-          - "0008: OpenTelemetry Instrumentation": adr/0008-opentelemetry-instrumentation-strategy.md
-          - "0009: Command Authorization Deferred to AAA": adr/0009-command-authorization-deferred-to-aaa.md
-          - "0010: MCP Server Thin Client over REST API": adr/0010-mcp-server-thin-client-over-rest-api.md
+      - Architecture: architecture.md
+      - API Specification: api-reference.md
+      - Architecture Decisions: adr/README.md
       - Changelog: changelog.md
       - Release Notes:
           - v2.1: release-notes/v2.1.md

--- a/packages/naas/changes/+nav-restructure.doc.md
+++ b/packages/naas/changes/+nav-restructure.doc.md
@@ -1,0 +1,1 @@
+Reorganize documentation navigation: split User Guide into Usage and Operations, move Architecture to Reference, collapse ADRs to single index link


### PR DESCRIPTION
## Problem

The sidebar was cluttered and poorly organized:
- Reference section had 19 items (10 individual ADRs + 6 release notes + 3 others)
- Architecture was under "Getting Started" (it's not a getting-started task)
- "User Guide" mixed API usage docs with operational docs (security, observability, troubleshooting) — different audiences
- installation.md was a redundant pointer page taking up nav space

## New Structure

| Section | Audience | Contains |
|---------|----------|----------|
| **Getting Started** | New users | Quick Start, Upgrading |
| **Usage** | API consumers | API, Client/CLI, MCP, Structured Output, Contexts, Error Codes |
| **Operations** | People running NAAS | Security, Observability, Reliability, Troubleshooting |
| **Deployment** | Ops/infra | Overview, K8s, Docker Compose, Env Vars |
| **Development** | Contributors | Contributing, Dev Guide, Testing |
| **Reference** | Everyone (lookup) | Architecture, API Spec, ADRs (single link), Changelog, Release Notes |

## Key Changes

- Split User Guide → Usage + Operations
- Architecture moved to Reference
- installation.md removed from nav (still linked from other pages)
- 10 ADR sidebar entries collapsed to single link (ADR index page lists them all)
- Error Codes moved to Usage (where API consumers will look)
- Upgrading moved to Getting Started
- ADR index updated with missing entries (0008, 0009, 0010)