### PR TITLE
docs: fix MD060 table-column-style violations

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -5,7 +5,7 @@ NAAS supports multiple deployment methods. Choose based on your environment and 
 ## Deployment Methods
 
 | Method | Best For | Prerequisites |
-|--------|----------|---------------|
+| ------ | -------- | ------------- |
 | **[Kubernetes (Helm)](../kubernetes.md)** | Production, team environments, scalability | Kubernetes 1.27+, Helm 3 |
 | **[Docker Compose](docker-compose.md)** | Development, small/single-node deployments | Docker, Docker Compose |
 | **Manual** | Custom environments, development without Docker | Python 3.11+, Redis 6+, uv |

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -137,7 +137,7 @@ helm uninstall naas
 ### Values Reference
 
 | Value | Default | Description |
-|-------|---------|-------------|
+| ----- | ------- | ----------- |
 | `image.repository` | `ghcr.io/lykinsbd/naas` | Container image |
 | `image.tag` | Chart `appVersion` | Image tag |
 | `namespace` | `naas` | Target namespace |
@@ -240,7 +240,7 @@ scrape_configs:
 ```
 
 | Metric | Type | Description |
-|--------|------|-------------|
+| ------ | ---- | ----------- |
 | `naas_http_requests_total` | Counter | HTTP requests by endpoint, method, status |
 | `naas_http_request_duration_seconds` | Histogram | Request latency by endpoint |
 | `naas_queue_depth` | Gauge | Jobs waiting in queue |
@@ -251,7 +251,7 @@ scrape_configs:
 Workers reuse SSH connections across sequential jobs to the same device. Configure via `config.*` values:
 
 | Value | Default | Description |
-|-------|---------|-------------|
+| ----- | ------- | ----------- |
 | `config.CONNECTION_POOL_ENABLED` | `true` | Enable pooling |
 | `config.CONNECTION_POOL_MAX_SIZE` | `10` | Max connections per worker process |
 | `config.CONNECTION_POOL_IDLE_TIMEOUT` | `300` | Evict idle connections (seconds) |

--- a/docs/release-notes/v2.1.md
+++ b/docs/release-notes/v2.1.md
@@ -69,7 +69,7 @@ See [Error Codes](../error-codes.md).
 Per-caller and per-caller-per-device sliding window rate limits protect against abuse and accidental flooding:
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| -------- | ------- | ----------- |
 | `RATE_LIMIT_ENABLED` | `true` | Enable/disable rate limiting |
 | `RATE_LIMIT_PER_CALLER` | `1000` | Max requests per caller per window |
 | `RATE_LIMIT_PER_CALLER_DEVICE` | `20` | Max requests per caller per device per window |

--- a/docs/security.md
+++ b/docs/security.md
@@ -69,7 +69,7 @@ NAAS supports two authentication methods:
 ### RBAC
 
 | Role | Can do |
-|------|--------|
+| ---- | ------ |
 | `admin` | Everything, including API key management |
 | `operator` | Submit jobs, view results |
 | `viewer` | View job status and results only |
@@ -118,7 +118,7 @@ For production, use a managed Redis (ElastiCache, Redis Cloud, etc.) with encryp
 Built-in per-caller sliding window rate limiter on all submission endpoints.
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+| -------- | ------- | ----------- |
 | `RATE_LIMIT_ENABLED` | `true` | Enable/disable |
 | `RATE_LIMIT_PER_CALLER` | `1000` | Max requests per caller per window |
 | `RATE_LIMIT_PER_CALLER_DEVICE` | `20` | Max requests per caller per device per window |
@@ -196,7 +196,7 @@ NAAS emits structured JSON audit events via the `NAAS` logger. Each event has an
 ### Event Reference
 
 | Event | Key Fields | Meaning |
-|-------|-----------|---------|
+| ----- | --------- | ------- |
 | `auth.success` | `method`, `identity` | Successful authentication |
 | `auth.failure` | `method`, `reason` | Failed authentication attempt |
 | `auth.context_denied` | `identity`, `context`, `allowed_contexts` | Context authorization failure |
@@ -233,7 +233,7 @@ Ship to your SIEM via any log shipper (Fluentd, Vector, Filebeat). Filter on `ev
 ### Recommended Alerts
 
 | Event | Condition | Indicates |
-|-------|-----------|-----------|
+| ----- | --------- | --------- |
 | `auth.failure` | >10 in 5 minutes | Brute force attempt |
 | `auth.rbac_denied` | Any occurrence | Privilege escalation attempt |
 | `apikey.created` | Any occurrence | New API key — verify expected |

--- a/packages/naas/changes/461.doc.md
+++ b/packages/naas/changes/461.doc.md
@@ -1,0 +1,1 @@
+Fix MD060 table-column-style violations in deployment, kubernetes, security, and v2.1 release-notes pages.


### PR DESCRIPTION
Closes #461

## Problem

PR #460 (`release/2.1` → `main` for v2.1.0) is blocked by 52 `MD060/table-column-style` violations across 4 docs files. The rule was not enforced when these docs were originally merged (PRs #452–#457 on 2026-05-06) but is now active because `DavidAnson/markdownlint-cli2-action@v23` floats and has since picked up a markdownlint version that enforces `MD060` by default.

## Fix

Reformatted table separator rows from `|---|---|` to `| --- | --- |` (MD060 compact style) in:

- `docs/deployment/index.md` (1 table)
- `docs/kubernetes.md` (3 tables)
- `docs/release-notes/v2.1.md` (1 table)
- `docs/security.md` (4 tables)

Only separator rows changed. No content edits, no rewording.

## Verification

Ran the same lint command CI runs (`markdownlint-cli2 v0.22.1` / `markdownlint v0.40.0`) locally:

```
Linting: 45 file(s)
Summary: 0 error(s)
```

`ruff check` and `ruff format --check` also clean (no Python touched, but ran for safety).

## Follow-up

Recommend a separate issue to pin `markdownlint-cli2-action` to a specific minor version so future floating-version rule changes don't silently block PRs.