### PR TITLE
chore: bump develop to v2.2.0a1

### DIFF
--- a/packages/naas/changes/+bump-develop-v2.2.0a1.internal.md
+++ b/packages/naas/changes/+bump-develop-v2.2.0a1.internal.md
@@ -1,0 +1,1 @@
+Bump develop to v2.2.0a1 after v2.1.0 release.

--- a/packages/naas/pyproject.toml
+++ b/packages/naas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "2.1.0"
+version = "2.2.0a1"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "../../README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2103,7 +2103,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "2.1.0"
+version = "2.2.0a1"
 source = { editable = "packages/naas" }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
Replaces #465 (closed due to conflict).

Bumps develop's version from `2.1.0` (set during the v2.1.0 sync in #466) to `2.2.0a1` for the start of the v2.2 development cycle.

## Changes

- `packages/naas/pyproject.toml`: `2.1.0` → `2.2.0a1`
- `uv.lock`: regenerated via `uv lock`
- Internal changelog fragment to satisfy `check-changelog`

Standard post-release bump per [docs/development.md §6–7](https://github.com/lykinsbd/naas/blob/main/docs/development.md#6-automated-final-release-after-pr-merge).