### PR TITLE
ci: fix release workflow not stopping when tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ jobs:
   check-version:
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ steps.version.outputs.should_release }}
+      # Only release when the version qualifies AND the tag does not already exist.
+      # tag_check.exists is empty when the tag-check step is skipped (because should_release was false from the version step),
+      # so the != 'true' comparison correctly yields true in that case and we fall back to version.should_release.
+      should_release: ${{ steps.version.outputs.should_release == 'true' && steps.tag_check.outputs.exists != 'true' }}
       version: ${{ steps.version.outputs.version }}
       is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
@@ -70,11 +73,10 @@ jobs:
             echo "✅ Tag v${{ steps.version.outputs.version }} does not exist"
           fi
 
-      - name: Stop if tag exists
+      - name: Skip if tag exists
         if: steps.version.outputs.should_release == 'true' && steps.tag_check.outputs.exists == 'true'
         run: |
-          echo "Tag already exists, skipping release"
-          exit 0
+          echo "::notice::Tag v${{ steps.version.outputs.version }} already exists — release job will be skipped via job output."
 
   release:
     needs: check-version

--- a/packages/naas/changes/468.internal.md
+++ b/packages/naas/changes/468.internal.md
@@ -1,0 +1,1 @@
+Fix release workflow not stopping when the tag already exists. The 'Stop if tag exists' step was a no-op because exit 0 succeeds the step without affecting downstream jobs. Now the should_release job output correctly evaluates to false when the tag exists, preventing duplicate-tag failures and stale changelog rebuilds.


### PR DESCRIPTION
Closes #468

## Problem

The `Release` workflow in `release.yml` had a `Stop if tag exists` step that was a no-op: `exit 0` succeeds the step but doesn't affect downstream jobs. The `release` job was gated only on `version.should_release`, not on the tag-exists check, so it ran anyway when the tag was already published.

This caused two real problems:

1. `fatal: tag 'vX.Y.Z' already exists` when it tried to re-tag
2. The changelog rebuild step (which runs first) pushed a `docs: update changelog for vX.Y.Z` commit to the release branch before the tag step failed

This is what happened during the v2.1.0 release: restoring `release/2.1` after auto-deletion triggered a spurious workflow run that re-built the rc2 changelog and pushed it to the branch (run [26053629842](https://github.com/lykinsbd/naas/actions/runs/26053629842)).

## Fix

Compute the `should_release` job output as a logical AND:

```yaml
should_release: ${{ steps.version.outputs.should_release == 'true' && steps.tag_check.outputs.exists != 'true' }}
```

Cases handled:

| version qualifies? | tag exists? | should_release |
|---|---|---|
| ✅ | ❌ | true (release runs) |
| ✅ | ✅ | false (release skipped) |
| ❌ (alpha, wrong branch, etc.) | n/a | false (release skipped) |

The third case works because when version fails, tag_check is skipped (`if:` false on that step), so `exists` is empty. Empty `!= 'true'` is true, but it doesn't matter — the first AND term short-circuits to false.

Renamed the now-informational step to `Skip if tag exists` and changed the message to a workflow notice for better log visibility.

## Verification

- YAML syntax valid (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- Reasoned through all three cases above
- Cannot end-to-end test without contriving a duplicate-tag scenario, but logic is straightforward