### PR TITLE
ci: pin markdownlint-cli2-action to v23.2.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,12 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Run markdownlint
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        # Pinned to a specific minor version (rather than the @v23 major-floating
+        # convention used elsewhere) because this action's behavior is gated by
+        # the bundled markdownlint engine, which introduces new lint rules in
+        # minor releases. v23.1.0 enabled MD060 by default and broke the v2.1.0
+        # release PR. See #472, #461, #462.
+        uses: DavidAnson/markdownlint-cli2-action@v23.2.0
         with:
           globs: |
             README.md

--- a/packages/naas/changes/472.internal.md
+++ b/packages/naas/changes/472.internal.md
@@ -1,0 +1,1 @@
+Pin DavidAnson/markdownlint-cli2-action to v23.2.0 to prevent silent rule changes from breaking CI. The action's bundled markdownlint engine can introduce new lint rules in minor releases, as happened with MD060 in v23.1.0 which broke the v2.1.0 release PR.


### PR DESCRIPTION
Closes #472

## Problem

CI uses `DavidAnson/markdownlint-cli2-action@v23` (floating major). The action's behavior is gated by a bundled markdownlint engine version, and minor releases of the action can bump that engine to new versions that introduce new lint rules.

This caused the v2.1.0 release to be blocked: action v23.1.0 (released 2026-04-29) bumped to markdownlint v0.40.0 which enabled `MD060/table-column-style` by default, producing 52 violations on already-merged docs (PRs #452–#457). See #461, #462.

## Fix

Pin to `@v23.2.0` (latest, as of 2026-05-18).

```diff
-        uses: DavidAnson/markdownlint-cli2-action@v23
+        uses: DavidAnson/markdownlint-cli2-action@v23.2.0
```

v23.2.0 only changed `package-lock.json` from v23.1.0 — same bundled engine (`markdownlint-cli2 v0.22.1 / markdownlint v0.40.0`). Pinning here just locks in the current state so future minor releases of the action can't silently bump the engine.

Comment added in the workflow file explaining the divergence from the major-only pinning convention used elsewhere.

## Style note

This is the only action in the repo pinned tighter than `@vMAJOR`, but the deviation is justified: this action's whole purpose is running a bundled tool whose behavior changes constitute behavior changes for us. Other actions in the repo (`actions/checkout`, `docker/build-push-action`, etc.) don't have the same engine-bundling characteristic.

## Maintenance

Future updates require a manual version bump rather than auto-floating. Worth considering a Dependabot rule for GitHub Actions to surface new versions if the team wants automatic PRs for these bumps.