### PR TITLE
feat(tasks): add inv release-bump for the release ceremony (sub-PR A of #480)

### DIFF
--- a/packages/naas/changes/+release-bump-task.internal.md
+++ b/packages/naas/changes/+release-bump-task.internal.md
@@ -1,0 +1,1 @@
+Add inv release-bump VERSION invoke task that performs the entire release ceremony in one command: bump pyproject.toml + uv lock + (final only) towncrier build + k8s manifest pinning + commit + annotated tag + atomic push. See ADR 0011 for design.

--- a/packages/naas/tasks.py
+++ b/packages/naas/tasks.py
@@ -1,6 +1,31 @@
 """Development tasks for NAAS project."""
 
+import re
+import sys
+from pathlib import Path
+
 from invoke import task
+
+# ---------------------------------------------------------------------------
+# Repo-relative paths used by release tasks. tasks.py runs from packages/naas/
+# but most release-relevant files live at the repo root, so define both.
+# ---------------------------------------------------------------------------
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PYPROJECT_PATH = REPO_ROOT / "packages" / "naas" / "pyproject.toml"
+CHANGES_DIR = REPO_ROOT / "packages" / "naas" / "changes"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+K8S_API_DEPLOYMENT = REPO_ROOT / "k8s" / "api" / "deployment.yaml"
+K8S_WORKER_DEPLOYMENT = REPO_ROOT / "k8s" / "worker" / "deployment.yaml"
+
+# Match release branches: release/1.0, release/1.3, release/2.1 (X.Y only).
+# The historical release/finalize-X.Y.Z branches are not covered here on
+# purpose — those are leftover automation branches and the new model
+# does not use them.
+RELEASE_BRANCH_RE = re.compile(r"^release/(\d+)\.(\d+)$")
+
+# Permissive PEP 440 subset: X.Y.Z, X.Y.ZbN, X.Y.ZrcN. Alphas not allowed
+# at release time (alphas live only on develop).
+RELEASE_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:(b|rc)(\d+))?$")
 
 
 @task
@@ -136,3 +161,268 @@ def changelog_create(c, pr, type, content=""):
         c.run(f"towncrier create {pr}.{type}.md --content '{content}'")
     else:
         c.run(f"towncrier create {pr}.{type}.md --edit")
+
+
+# ---------------------------------------------------------------------------
+# Release helpers (used only by the `release-bump` task below)
+# ---------------------------------------------------------------------------
+
+
+def _git(c, cmd, **kwargs):
+    """Run a git command at the repo root and return the stdout."""
+    return c.run(f"git -C {REPO_ROOT} {cmd}", hide=True, **kwargs)
+
+
+def _current_branch(c):
+    return _git(c, "rev-parse --abbrev-ref HEAD").stdout.strip()
+
+
+def _working_tree_dirty(c):
+    result = _git(c, "status --porcelain")
+    return bool(result.stdout.strip())
+
+
+def _read_pyproject_version():
+    """Return the version string in packages/naas/pyproject.toml."""
+    import tomllib
+
+    with PYPROJECT_PATH.open("rb") as fh:
+        data = tomllib.load(fh)
+    return data["project"]["version"]
+
+
+def _write_pyproject_version(new_version):
+    """Update the version line in packages/naas/pyproject.toml in place.
+
+    Uses a regex anchored to the start of the line and the [project]
+    section to avoid touching unrelated `version = "..."` strings.
+    """
+    text = PYPROJECT_PATH.read_text()
+    new_text = re.sub(
+        r'^version = ".*?"$',
+        f'version = "{new_version}"',
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    if new_text == text:
+        raise RuntimeError(f"Could not find a version line to update in {PYPROJECT_PATH}")
+    PYPROJECT_PATH.write_text(new_text)
+
+
+def _validate_target_version(current, target, branch):
+    """Raise SystemExit with a clear message if target is invalid.
+
+    Checks performed:
+    * target matches the release-version regex (rejects alphas and garbage)
+    * target's major.minor matches the branch's major.minor
+    * target is strictly greater than current per PEP 440
+    """
+    from packaging.version import InvalidVersion, Version
+
+    target_match = RELEASE_VERSION_RE.match(target)
+    if not target_match:
+        raise SystemExit(
+            f"❌ Target version '{target}' is not a valid release version.\n"
+            "   Allowed shapes: X.Y.Z, X.Y.ZbN, X.Y.ZrcN.\n"
+            "   Alphas (X.Y.ZaN) are not released — they live on develop only."
+        )
+
+    branch_match = RELEASE_BRANCH_RE.match(branch)
+    if not branch_match:
+        raise SystemExit(
+            f"❌ Current branch '{branch}' is not a release branch.\n"
+            "   Expected something matching release/X.Y (e.g. release/1.3)."
+        )
+
+    target_major, target_minor = target_match.group(1), target_match.group(2)
+    branch_major, branch_minor = branch_match.group(1), branch_match.group(2)
+    if (target_major, target_minor) != (branch_major, branch_minor):
+        raise SystemExit(
+            f"❌ Target version {target} does not match branch {branch}.\n"
+            f"   Branch tracks release/{branch_major}.{branch_minor}; bump only "
+            f"{branch_major}.{branch_minor}.* versions on this branch."
+        )
+
+    try:
+        current_v = Version(current)
+        target_v = Version(target)
+    except InvalidVersion as exc:
+        raise SystemExit(f"❌ Could not parse versions: {exc}") from exc
+
+    if target_v <= current_v:
+        raise SystemExit(f"❌ Target version {target} must be strictly greater than current {current}.")
+
+
+def _list_fragment_files():
+    """Return a sorted list of fragment file Paths under packages/naas/changes/.
+
+    A fragment is any .md file in the directory other than the towncrier
+    template. Hidden files (starting with `.`) are also ignored.
+    """
+    if not CHANGES_DIR.is_dir():
+        return []
+    return sorted(p for p in CHANGES_DIR.glob("*.md") if p.name != "template.md.j2" and not p.name.startswith("."))
+
+
+def _is_final_release(target):
+    """True for X.Y.Z (no prerelease suffix), False for b/rc."""
+    return RELEASE_VERSION_RE.match(target).group(4) is None
+
+
+def _print_step(label, message):
+    print(f"  [{label}] {message}", file=sys.stderr)
+
+
+@task(
+    help={
+        "version": (
+            "Target version to release (e.g. 1.3.0b1, 1.3.0rc2, 1.3.0, 1.3.1). "
+            "Must match the major.minor of the current release/X.Y branch."
+        ),
+        "dry-run": "Print every action without executing.",
+        "no-push": "Run all local steps (commit, tag) but skip the push.",
+        "message": (
+            "Override the commit message. Default: 'chore(release): release X.Y.Z' "
+            "for finals or 'chore(release): bump version to X.Y.ZbN/rcN' for prereleases."
+        ),
+    }
+)
+def release_bump(c, version, dry_run=False, no_push=False, message=""):
+    """Run the release ceremony for the current release/X.Y branch.
+
+    What this does, in order:
+
+    1. Validate the working tree is clean and we are on a release/X.Y branch.
+    2. Validate the target version is compatible with the current branch
+       and strictly newer than the current pyproject.toml version.
+    3. For final releases (no b/rc suffix): require at least one towncrier
+       fragment to exist in packages/naas/changes/.
+    4. Update packages/naas/pyproject.toml with the new version.
+    5. Run `uv lock` to refresh the lockfile.
+    6. For final releases: pin the k8s manifest image tags to the new version,
+       then run `towncrier build --yes` to append a section to CHANGELOG.md
+       and delete consumed fragments.
+    7. Stage everything that changed, commit with a conventional release
+       message, and create an annotated tag at the new commit.
+    8. Push branch and tag atomically (`git push --atomic`).
+
+    Use --dry-run for a first pass without touching anything.
+    Use --no-push to keep the local commit and tag without pushing,
+    e.g. for inspection before the push.
+    """
+    # ----- Pre-flight checks -----
+    branch = _current_branch(c)
+    if not RELEASE_BRANCH_RE.match(branch):
+        raise SystemExit(f"❌ release-bump can only run on a release/X.Y branch.\n   You are currently on '{branch}'.")
+
+    if _working_tree_dirty(c):
+        raise SystemExit("❌ Working tree is dirty. Commit or stash your changes first.")
+
+    # Confirm we are not behind the remote — if we are, the human's bump
+    # commit might land on top of the wrong base.
+    _git(c, "fetch origin")
+    behind = _git(c, f"rev-list --count HEAD..origin/{branch}").stdout.strip()
+    if behind != "0":
+        raise SystemExit(
+            f"❌ Local branch is behind origin/{branch} by {behind} commit(s).\n"
+            f"   Run `git pull --ff-only origin {branch}` first."
+        )
+
+    current_version = _read_pyproject_version()
+    _validate_target_version(current_version, version, branch)
+
+    is_final = _is_final_release(version)
+    if is_final:
+        fragments = _list_fragment_files()
+        if not fragments:
+            raise SystemExit(
+                "❌ Cannot release a final version with no changelog fragments.\n"
+                f"   Add at least one fragment to {CHANGES_DIR.relative_to(REPO_ROOT)} "
+                "before running this task."
+            )
+
+    # ----- Decide on commit message and tag -----
+    tag = f"v{version}"
+    if not message:
+        if is_final:
+            message = f"chore(release): release {version}"
+        else:
+            message = f"chore(release): bump version to {version}"
+
+    print(f"\n🚀 Releasing {tag} on {branch} (current pyproject.toml version: {current_version})\n")
+
+    # ----- Step executor that respects --dry-run -----
+    def run(label, cmd, **kwargs):
+        _print_step(label, cmd)
+        if dry_run:
+            return None
+        return c.run(cmd, **kwargs)
+
+    # ----- 4. Update pyproject.toml -----
+    _print_step("edit", f"set pyproject.toml version → {version}")
+    if not dry_run:
+        _write_pyproject_version(version)
+
+    # ----- 5. uv lock -----
+    run("lock", "uv lock", pty=False)
+
+    # ----- 6. Final-release specific steps -----
+    if is_final:
+        for manifest in (K8S_API_DEPLOYMENT, K8S_WORKER_DEPLOYMENT):
+            run(
+                "k8s",
+                (
+                    f"sed -i 's|ghcr.io/lykinsbd/naas:.*|ghcr.io/lykinsbd/naas:{version}|g' "
+                    f"{manifest.relative_to(REPO_ROOT)}"
+                ),
+            )
+        # towncrier needs to run from the directory holding pyproject.toml
+        # with its [tool.towncrier] config (packages/naas/).
+        run(
+            "towncrier",
+            f"towncrier build --yes --version {version} --dir packages/naas",
+        )
+
+    # ----- 7. Stage + commit + tag -----
+    paths_to_add = [
+        "packages/naas/pyproject.toml",
+        "uv.lock",
+    ]
+    if is_final:
+        paths_to_add.extend(
+            [
+                "CHANGELOG.md",
+                "k8s/api/deployment.yaml",
+                "k8s/worker/deployment.yaml",
+                "packages/naas/changes/",
+            ]
+        )
+
+    run("add", f"git -C {REPO_ROOT} add -- {' '.join(paths_to_add)}")
+    # Use shell-safe single quotes; release messages never contain single
+    # quotes in our convention, but defend anyway.
+    safe_message = message.replace("'", "'\\''")
+    run("commit", f"git -C {REPO_ROOT} commit -m '{safe_message}'")
+    run(
+        "tag",
+        f"git -C {REPO_ROOT} tag -a -m 'Release {tag}' {tag}",
+    )
+
+    # ----- 8. Push (or not) -----
+    if no_push:
+        print(
+            f"\n✋ --no-push set. Local commit and tag {tag} are ready.\n"
+            f"   Push with:  git push --atomic origin {branch} {tag}\n"
+        )
+        return
+
+    run(
+        "push",
+        f"git -C {REPO_ROOT} push --atomic origin {branch} {tag}",
+    )
+
+    if dry_run:
+        print("\n💡 Dry run complete. No changes were made. Run again without --dry-run to apply.\n")
+    else:
+        print(f"\n✅ Released {tag}. CI will create the GitHub Release.\n")

--- a/packages/naas/tests/unit/test_tasks_release_bump.py
+++ b/packages/naas/tests/unit/test_tasks_release_bump.py
@@ -1,0 +1,162 @@
+"""Unit tests for release-bump helpers in tasks.py.
+
+The task itself does git/file/network side effects so we don't unit-test
+the whole task body — those are exercised via `inv release-bump --dry-run`
+during real release work. This file covers the pure validators that
+catch operator mistakes before any side effects happen.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# tasks.py lives at packages/naas/tasks.py, the same level as the naas/
+# package. Add packages/naas/ to sys.path so the import works in any
+# pytest collection mode.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from tasks import (
+    RELEASE_BRANCH_RE,
+    RELEASE_VERSION_RE,
+    _is_final_release,
+    _validate_target_version,
+)
+
+
+class TestReleaseBranchRegex:
+    """Branch must match release/X.Y exactly — not finalize-X.Y.Z, not X.Y.Z."""
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "release/1.0",
+            "release/1.3",
+            "release/2.1",
+            "release/10.5",
+            "release/100.200",
+        ],
+    )
+    def test_valid_release_branches(self, branch):
+        assert RELEASE_BRANCH_RE.match(branch) is not None
+
+    @pytest.mark.parametrize(
+        "branch",
+        [
+            "release/finalize-2.1.0",  # historical leftover branch shape
+            "release/1.0.0",  # patch level on the branch name not allowed
+            "release/foo",
+            "release/v1.3",
+            "develop",
+            "main",
+            "feature/something",
+            "hotfix/123",
+            "",
+        ],
+    )
+    def test_invalid_branches(self, branch):
+        assert RELEASE_BRANCH_RE.match(branch) is None
+
+
+class TestReleaseVersionRegex:
+    """Version must be X.Y.Z, X.Y.ZbN, or X.Y.ZrcN. Alphas rejected."""
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1.3.0",
+            "1.3.1",
+            "1.3.0b1",
+            "1.3.0b10",
+            "1.3.0rc1",
+            "1.3.0rc99",
+            "10.20.30",
+            "0.0.0",
+        ],
+    )
+    def test_valid_versions(self, version):
+        assert RELEASE_VERSION_RE.match(version) is not None
+
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "1.3.0a1",  # alphas rejected: develop-only
+            "1.3",
+            "v1.3.0",
+            "1.3.0-rc.1",  # SemVer style not supported
+            "1.3.0.post1",
+            "1.3.0.dev1",
+            "garbage",
+            "",
+            "1.3.0b",  # number required after b
+            "1.3.0rc",
+        ],
+    )
+    def test_invalid_versions(self, version):
+        assert RELEASE_VERSION_RE.match(version) is None
+
+
+class TestIsFinalRelease:
+    @pytest.mark.parametrize(
+        "version, expected",
+        [
+            ("1.3.0", True),
+            ("1.3.1", True),
+            ("10.20.30", True),
+            ("1.3.0b1", False),
+            ("1.3.0rc1", False),
+            ("1.3.0rc99", False),
+        ],
+    )
+    def test(self, version, expected):
+        assert _is_final_release(version) is expected
+
+
+class TestValidateTargetVersion:
+    """Branch + current + target compatibility checks."""
+
+    @pytest.mark.parametrize(
+        "current, target",
+        [
+            ("1.3.0a1", "1.3.0b1"),
+            ("1.3.0b1", "1.3.0rc1"),
+            ("1.3.0rc1", "1.3.0rc2"),
+            ("1.3.0rc2", "1.3.0"),
+            ("1.3.0", "1.3.1"),
+            ("1.3.5", "1.3.6"),
+            ("1.3.0", "1.3.10"),  # double-digit patch
+        ],
+    )
+    def test_valid_progressions_on_release_1_3(self, current, target):
+        # Should not raise
+        _validate_target_version(current, target, "release/1.3")
+
+    def test_target_major_minor_must_match_branch(self):
+        with pytest.raises(SystemExit, match="does not match branch"):
+            _validate_target_version("1.3.0a1", "1.4.0b1", "release/1.3")
+
+    def test_target_must_be_strictly_greater(self):
+        with pytest.raises(SystemExit, match="must be strictly greater"):
+            _validate_target_version("1.3.0", "1.3.0", "release/1.3")
+
+    def test_target_must_not_be_lower(self):
+        # Lower version on a 1.3.x branch would be caught either by
+        # major.minor mismatch or strictly-greater.
+        with pytest.raises(SystemExit):
+            _validate_target_version("1.3.5", "1.3.4", "release/1.3")
+
+    def test_alpha_target_rejected(self):
+        with pytest.raises(SystemExit, match="not a valid release version"):
+            _validate_target_version("1.3.0", "1.3.0a1", "release/1.3")
+
+    def test_garbage_target_rejected(self):
+        with pytest.raises(SystemExit, match="not a valid release version"):
+            _validate_target_version("1.3.0", "garbage", "release/1.3")
+
+    def test_non_release_branch_rejected(self):
+        with pytest.raises(SystemExit, match="not a release branch"):
+            _validate_target_version("1.3.0", "1.3.1", "main")
+
+    def test_finalize_branch_rejected(self):
+        with pytest.raises(SystemExit, match="not a release branch"):
+            _validate_target_version("1.3.0", "1.3.1", "release/finalize-2.1.0")


### PR DESCRIPTION
Part of #480 — implements [ADR 0011](https://github.com/lykinsbd/naas/blob/develop/docs/adr/0011-release-process.md).

This is **sub-PR A of three** for the release pipeline migration.

## What this adds

A new `inv release-bump VERSION` invoke task that performs the entire release ceremony in one command on a release/X.Y branch.

## Behavior

```text
$ inv release-bump 1.3.0b1   # on release/1.3
  → bumps pyproject.toml: X.Y.0a1 → 1.3.0b1
  → runs uv lock
  → commits: chore(release): bump version to 1.3.0b1
  → creates annotated tag v1.3.0b1
  → git push --atomic origin release/1.3 v1.3.0b1

$ inv release-bump 1.3.0     # final release
  → bumps pyproject.toml: 1.3.0rc2 → 1.3.0
  → runs uv lock
  → pins k8s/api/deployment.yaml and k8s/worker/deployment.yaml image tags
  → runs towncrier build --yes (appends to CHANGELOG.md, deletes consumed fragments)
  → commits: chore(release): release 1.3.0
  → creates annotated tag v1.3.0
  → git push --atomic origin release/1.3 v1.3.0
```

Two flags for safe operation: `--dry-run` prints every action without executing, `--no-push` keeps the local commit and tag without pushing.

## Validation

The task validates BEFORE any side effect:

| Check | Error message |
|---|---|
| Current branch matches release/X.Y | 'release-bump can only run on a release/X.Y branch' |
| Working tree is clean | 'Working tree is dirty. Commit or stash your changes first.' |
| Local branch in sync with origin | 'Local branch is behind origin/X by N commit(s).' |
| Target version is X.Y.Z, X.Y.ZbN, or X.Y.ZrcN | 'is not a valid release version. Allowed shapes: ...' |
| Target's major.minor matches current branch | 'Target version 1.4.0b1 does not match branch release/1.3.' |
| Target is strictly greater than current | 'Target version 1.3.0 must be strictly greater than current 1.3.0.' |
| (Final only) at least one fragment exists | 'Cannot release a final version with no changelog fragments.' |

Alphas (`1.3.0a1`) are explicitly rejected — those live only on develop.

## Tests

`packages/naas/tests/unit/test_tasks_release_bump.py` covers the validation logic with **46 parametrized test cases**:

- 14 tests on the release-branch regex (including the historical `release/finalize-X.Y.Z` shape, which is correctly rejected)
- 21 tests on the version regex (including alpha rejection and SemVer-style `1.3.0-rc.1` rejection)
- 4 tests on `_is_final_release`
- 11 tests on the validation function combining branch + current + target checks

Side-effecting parts (file writes, git operations, network) are exercised via `--dry-run` against real release branches during sub-PR B and during real releases. Unit-testing the full task body would require heavy mocking and add little value over a dry-run.

```
$ uv run pytest tests/unit/test_tasks_release_bump.py
46 passed in 1.30s
```

## Why this design

The new release model (ADR 0011) makes the human run a single command to do what was previously spread across `release.yml` commit-back logic, `finalize-release.yml` PR-creation, manual bumps, and ad-hoc manifest edits. Centralizing it in one task means:

- No silent state drift between branches (CI no longer commits back)
- Validation catches operator mistakes before any side effect
- The `git push --atomic` ensures commit and tag land together or neither does

## Why not yet wire up the workflows?

This sub-PR introduces the task but doesn't change `release.yml` or delete `finalize-release.yml`. Those changes are in sub-PR B. Reasoning: this PR is testable in isolation (pure new code, no behavioral change to CI), so it can land safely. Sub-PR B then references this task in the rewritten workflows.

## Followup

- ✅ #477 — backfill CHANGELOG.md
- ✅ #478 — transclude CHANGELOG.md into docs
- ✅ #479 — ADR
- ⏭️ #480 sub-PR A (this) — `inv release-bump` invoke task
- ⏭️ #480 sub-PR B — workflow rewrites (release.yml, delete finalize-release.yml, sync-release.yml fixes)
- ⏭️ #480 sub-PR C — docs/development.md rewrite, agent prompt update, CONTRIBUTING.md verification