### PR TITLE
chore(deps): batch security bumps for urllib3, idna, authlib, python-multipart

### DIFF
--- a/packages/naas/changes/+bump-authlib-cve-2025-59420.security.md
+++ b/packages/naas/changes/+bump-authlib-cve-2025-59420.security.md
@@ -1,0 +1,1 @@
+Bump authlib from 1.6.11 to 1.6.12 to address GHSA-9ggr-2464-2j32: open redirect on InvalidScopeError in OpenIDImplicitGrant and OpenIDHybridGrant.

--- a/packages/naas/changes/+bump-idna-cve.security.md
+++ b/packages/naas/changes/+bump-idna-cve.security.md
@@ -1,0 +1,1 @@
+Bump idna from 3.11 to 3.15 to address GHSA-jjg7-2v4v-x38h: specially-crafted inputs to idna.encode() could bypass the CVE-2024-3651 fix.

--- a/packages/naas/changes/+bump-python-multipart-cve.security.md
+++ b/packages/naas/changes/+bump-python-multipart-cve.security.md
@@ -1,0 +1,1 @@
+Bump python-multipart from 0.0.26 to 0.0.27 to address GHSA-9mvj-f7w8-pvh2: denial of service via unbounded multipart part headers.

--- a/packages/naas/changes/+bump-urllib3-cve-2025-50182.security.md
+++ b/packages/naas/changes/+bump-urllib3-cve-2025-50182.security.md
@@ -1,0 +1,1 @@
+Bump urllib3 from 2.6.3 to 2.7.0 to address two high-severity CVEs (GHSA-mf9v-mfxr-j63j and GHSA-pq67-6m6q-mj2v): decompression-bomb safeguard bypasses in the streaming API and sensitive headers being forwarded across origins in proxied low-level redirects.

--- a/uv.lock
+++ b/uv.lock
@@ -119,14 +119,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.11"
+version = "1.6.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/30/6691fdc63b35f54a5a65e04fa1e59d827f4d4e8f4a39678ba7d3088ce0c8/authlib-1.6.12.tar.gz", hash = "sha256:0656d8482f28fc8221929d5f35b2bde5d13e10555ebc06b4561b0d622e83b1bd", size = 165368, upload-time = "2026-05-04T08:11:31.826Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/51/9b0b5cd4cf683a02db937a6f9bbebcdc9c56558a7bb3763ce7d3512103c3/authlib-1.6.12-py2.py3-none-any.whl", hash = "sha256:e9229ad7fde610b139dd12f5edbe97eab9ee78bfb85691247e767727850b99ab", size = 244473, upload-time = "2026-05-04T08:11:30.354Z" },
 ]
 
 [[package]]
@@ -1344,11 +1344,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
@@ -3059,11 +3059,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -3821,11 +3821,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #489. Closes the four stuck Dependabot security PRs (#491, #485, #476, #473) by consolidating their bumps into one auditable change.

## Why a batch PR

The four Dependabot security PRs got tangled in the wake of the base-ref retargeting and default-branch switch from #489:

- Dependabot couldn't reconcile its own tracking of the PRs after the simultaneous changes
- Manual force-rebases of the branches produced PRs with phantom `QUEUED` rollup checks that never finished even though every underlying job succeeded
- `@dependabot recreate` and `@dependabot rebase` both reported the PRs were no longer reconcilable
- One PR (#491 urllib3) Dependabot was able to recreate cleanly; one (#484 pymdown-extensions, manually merged) made it through; the other four were stuck

Consolidating here is faster than untangling each individually, and produces one auditable diff for v2.2.0.

## Bumps applied

| Package | Before | After | Advisory |
|---|---|---|---|
| urllib3 | 2.6.3 | 2.7.0 | [GHSA-mf9v-mfxr-j63j](https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j) (high), [GHSA-pq67-6m6q-mj2v](https://github.com/urllib3/urllib3/security/advisories/GHSA-pq67-6m6q-mj2v) (high) |
| python-multipart | 0.0.26 | 0.0.27 | [GHSA-9mvj-f7w8-pvh2](https://github.com/Kludex/python-multipart/security/advisories/GHSA-9mvj-f7w8-pvh2) (high) |
| authlib | 1.6.11 | 1.6.12 | [GHSA-9ggr-2464-2j32](https://github.com/authlib/authlib/security/advisories/GHSA-9ggr-2464-2j32) (medium) |
| idna | 3.11 | 3.15 | [GHSA-jjg7-2v4v-x38h](https://github.com/kjd/idna/security/advisories/GHSA-jjg7-2v4v-x38h) (medium) |

All four are transitive dependencies — none are declared in any pyproject.toml. The bumps are pure `uv.lock` updates.

## How

```bash
uv lock --upgrade-package urllib3==2.7.0
uv lock --upgrade-package idna==3.15
uv lock --upgrade-package authlib==1.6.12
uv lock --upgrade-package python-multipart==0.0.27
```

Resulting diff in `uv.lock`: 12 insertions, 12 deletions. Only the four target packages changed (their version line and corresponding sdist/wheel hashes).

## Verification

```
$ for pkg in urllib3 idna authlib python-multipart; do
    grep -A 1 "^name = \"$pkg\"\$" uv.lock | grep '^version'
  done
version = "2.7.0"
version = "3.15"
version = "1.6.12"
version = "0.0.27"
```

`git diff --stat uv.lock` confirms only `uv.lock` changed.

## Fragments

Four security-typed fragments created, one per advisory, so the v2.2.0 changelog attribution is accurate.

## Followup

After this lands plus all the other develop work, cut v2.2.0 with the new release pipeline + 5 security fixes (4 here + pymdown-extensions already merged via #484) + the 10 internal/doc improvements.