### PR TITLE
fix(tasks): use absolute paths in release-bump k8s manifest pinning

### DIFF
--- a/packages/naas/changes/494.bugfix.md
+++ b/packages/naas/changes/494.bugfix.md
@@ -1,0 +1,1 @@
+Fix release-bump invoke task k8s manifest pinning step failing when invoked from packages/naas/ (the documented invocation pattern). The step used a relative path that resolved incorrectly when cwd wasn't the repo root; now uses absolute paths.

--- a/packages/naas/tasks.py
+++ b/packages/naas/tasks.py
@@ -370,12 +370,11 @@ def release_bump(c, version, dry_run=False, no_push=False, message=""):
     # ----- 6. Final-release specific steps -----
     if is_final:
         for manifest in (K8S_API_DEPLOYMENT, K8S_WORKER_DEPLOYMENT):
+            # Use the absolute path so the command works regardless of cwd
+            # (the documented invocation runs invoke from packages/naas/).
             run(
                 "k8s",
-                (
-                    f"sed -i 's|ghcr.io/lykinsbd/naas:.*|ghcr.io/lykinsbd/naas:{version}|g' "
-                    f"{manifest.relative_to(REPO_ROOT)}"
-                ),
+                (f"sed -i 's|ghcr.io/lykinsbd/naas:.*|ghcr.io/lykinsbd/naas:{version}|g' {manifest}"),
             )
         # towncrier needs to run from the directory holding pyproject.toml
         # with its [tool.towncrier] config (packages/naas/).

--- a/packages/naas/tests/unit/test_tasks_release_bump.py
+++ b/packages/naas/tests/unit/test_tasks_release_bump.py
@@ -17,8 +17,11 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from tasks import (
+    K8S_API_DEPLOYMENT,
+    K8S_WORKER_DEPLOYMENT,
     RELEASE_BRANCH_RE,
     RELEASE_VERSION_RE,
+    REPO_ROOT,
     _is_final_release,
     _validate_target_version,
 )
@@ -160,3 +163,29 @@ class TestValidateTargetVersion:
     def test_finalize_branch_rejected(self):
         with pytest.raises(SystemExit, match="not a release branch"):
             _validate_target_version("1.3.0", "1.3.1", "release/finalize-2.1.0")
+
+
+class TestK8sManifestPaths:
+    """K8s manifest path constants must be absolute.
+
+    The release-bump task runs `sed -i ... <path>` on these manifests via
+    invoke's `c.run`, which executes in the current working directory.
+    The documented invocation is `cd packages/naas && uv run invoke
+    release-bump VERSION`, so a relative path would resolve against
+    packages/naas/ and fail. See #494.
+    """
+
+    def test_k8s_api_deployment_is_absolute(self):
+        assert K8S_API_DEPLOYMENT.is_absolute(), (
+            "K8S_API_DEPLOYMENT must be absolute so the sed step works regardless of cwd. See #494."
+        )
+
+    def test_k8s_worker_deployment_is_absolute(self):
+        assert K8S_WORKER_DEPLOYMENT.is_absolute(), (
+            "K8S_WORKER_DEPLOYMENT must be absolute so the sed step works regardless of cwd. See #494."
+        )
+
+    def test_k8s_paths_anchored_at_repo_root(self):
+        """Sanity: the manifests live where we expect under the repo root."""
+        assert K8S_API_DEPLOYMENT == REPO_ROOT / "k8s" / "api" / "deployment.yaml"
+        assert K8S_WORKER_DEPLOYMENT == REPO_ROOT / "k8s" / "worker" / "deployment.yaml"


### PR DESCRIPTION
## Summary

Fixes the bug discovered while cutting v2.2.0 final (the first end-to-end test of the new release pipeline): the k8s image-pin step in `inv release-bump` failed because it used a relative path that doesn't resolve correctly when invoke is run from the documented location (`packages/naas/`).

```
[k8s] sed -i 's|ghcr.io/lykinsbd/naas:.*|ghcr.io/lykinsbd/naas:2.2.0|g' k8s/api/deployment.yaml
sed: can't read k8s/api/deployment.yaml: No such file or directory
```

## Fix

Drop `.relative_to(REPO_ROOT)` and use the absolute `pathlib.Path` directly. `sed` accepts absolute paths fine, and this matches what the rest of the task already does (git uses `git -C $REPO_ROOT`, towncrier uses `--dir packages/naas` with config-relative resolution, uv finds the workspace root automatically).

## Tests

Added `TestK8sManifestPaths` with three tests:

- `test_k8s_api_deployment_is_absolute` — asserts `K8S_API_DEPLOYMENT` is absolute
- `test_k8s_worker_deployment_is_absolute` — same for worker
- `test_k8s_paths_anchored_at_repo_root` — sanity-checks the path layout

These don't directly exercise the constructed sed command (the task body isn't unit-testable as written), but they enforce the property that makes the fix work — a future refactor that drops absolute paths will fail these tests.

```
49 passed (46 original + 3 new) in tests/unit/test_tasks_release_bump.py
```

## Changelog

Added `494.bugfix.md` fragment.

## Notes

- All other paths in the task are already cwd-safe (verified during investigation, see #494)
- `v2.2.0b1` was unaffected because the k8s step only runs for **final** releases
- Once this merges, I'll cherry-pick to `release/2.2` and resume the v2.2.0 final cut

Closes #494