### PR TITLE
chore: clean up orphan 494.bugfix.md fragment after v2.2.0 sync

### DIFF
--- a/packages/naas/changes/+cleanup-orphan-494-fragment.internal.md
+++ b/packages/naas/changes/+cleanup-orphan-494-fragment.internal.md
@@ -1,0 +1,1 @@
+Clean up orphan changelog fragment 494.bugfix.md left on develop after the v2.2.0 release sync. The fragment was correctly consumed by the v2.2.0 release commit on release/2.2, but a 3-way merge (main → develop) brought it back because it existed independently on both branches. This commit removes the orphan; #503 tracks the underlying workflow gap.

--- a/packages/naas/changes/494.bugfix.md
+++ b/packages/naas/changes/494.bugfix.md
@@ -1,1 +1,0 @@
-Fix release-bump invoke task k8s manifest pinning step failing when invoked from packages/naas/ (the documented invocation pattern). The step used a relative path that resolved incorrectly when cwd wasn't the repo root; now uses absolute paths.


### PR DESCRIPTION
## Summary

Removes the orphan `494.bugfix.md` changelog fragment that ended up on develop after the v2.2.0 sync.

## Why is it orphaned?

The fragment was correctly consumed by the v2.2.0 release commit on `release/2.2` — its content appears in CHANGELOG.md's v2.2.0 section. But the `main → develop` sync merge-commit brought the file back to develop because:

- main side of the merge: file deleted in the release commit
- develop side: file still present (added by PR #495 merging to develop after release/2.2 was branched, never re-deleted there)
- 3-way merge with the common ancestor (which had no file): git defaults to keep

If we don't clean up, the next release would include a duplicate entry for the #494 fix in its CHANGELOG.md.

## Why isn't 497.bugfix.md being deleted too?

It is NOT an orphan. The fragment was cherry-picked to release/2.2 in commit `643ff66` (the fix for #497), which happened **AFTER** the release commit `3131528`. So it was never consumed by towncrier. It correctly remains as a pending fragment for the next release.

You can verify:

```bash
git log release/2.2 --oneline -- packages/naas/changes/494.bugfix.md
# 3131528 chore(release): release 2.2.0   ← consumed here
# cabd2f4 fix(tasks): use absolute paths…  ← added here

git log release/2.2 --oneline -- packages/naas/changes/497.bugfix.md
# 643ff66 fix(ci): handle release-branch PRs… ← added here, AFTER the release commit
```

## Followup

#503 tracks the underlying workflow gap (orphan fragments after sync). This PR is just the manual cleanup for v2.2.0.

Refs #503