### PR TITLE
chore: bump develop to v2.3.0a1

### DIFF
--- a/packages/naas/changes/+bump-develop-v2.3.0a1.internal.md
+++ b/packages/naas/changes/+bump-develop-v2.3.0a1.internal.md
@@ -1,0 +1,1 @@
+Bump develop to v2.3.0a1 after v2.2.0 release.

--- a/packages/naas/pyproject.toml
+++ b/packages/naas/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "naas"
-version = "2.2.0"
+version = "2.3.0a1"
 description = "Netmiko As A Service - REST API wrapper for Netmiko"
 readme = "../../README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2103,7 +2103,7 @@ wheels = [
 
 [[package]]
 name = "naas"
-version = "2.2.0"
+version = "2.3.0a1"
 source = { editable = "packages/naas" }
 dependencies = [
     { name = "aniso8601" },


### PR DESCRIPTION
## Summary

Manual version bump after the v2.2.0 release.

## Why manual?

The auto-generated bump PR (#500) had to be closed because of #501 — sync-release.yml's bump-develop job branched from develop BEFORE the main → develop sync PR merged, so its diff (`2.2.0a1 → 2.3.0a1`) didn't apply to develop's post-sync state (which was `2.2.0`). This PR bumps from develop's correct post-sync state.

## Changes

- `packages/naas/pyproject.toml`: `2.2.0 → 2.3.0a1`
- `uv.lock`: refreshed to reflect new project version
- Internal changelog fragment

## Followup

#501 tracks the bump-develop ordering bug so future X.Y.0 releases don't need this manual step.

Refs #501