### PR TITLE
feat(mcp): add streamable-http transport with NAAS JWT auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,9 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
       - name: Lint chart
-        run: helm lint charts/naas
+        run: helm lint charts/naas --set mcp.enabled=true --set secrets.redisPassword=ci-test --set secrets.jwtSecret=ci-test
       - name: Template dry-run
-        run: helm template test charts/naas --set secrets.redisPassword=ci-test
+        run: helm template test charts/naas --set mcp.enabled=true --set secrets.redisPassword=ci-test --set secrets.jwtSecret=ci-test
 
   k8s-tests:
     runs-on: ubuntu-latest

--- a/charts/naas/templates/mcp-deployment.yaml
+++ b/charts/naas/templates/mcp-deployment.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.mcp.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: naas-mcp
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: naas-mcp
+spec:
+  replicas: {{ .Values.mcp.replicas }}
+  selector:
+    matchLabels:
+      app: naas-mcp
+  template:
+    metadata:
+      labels:
+        app: naas-mcp
+        {{- include "naas.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: naas-mcp
+          image: {{ .Values.mcp.image.repository }}:{{ .Values.mcp.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ .Values.mcp.image.pullPolicy }}
+          args:
+            - "--transport"
+            - "streamable-http"
+            - "--port"
+            - {{ .Values.mcp.port | quote }}
+          ports:
+            - containerPort: {{ .Values.mcp.port }}
+              protocol: TCP
+          env:
+            - name: NAAS_MCP_API_URL
+              value: {{ .Values.mcp.apiUrl | quote }}
+            - name: NAAS_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "naas.secretName" . }}
+                  key: NAAS_JWT_SECRET
+            - name: NAAS_MCP_REDIS_URL
+              value: {{ .Values.mcp.redisUrl | quote }}
+          resources:
+            {{- toYaml .Values.mcp.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /mcp/
+              port: {{ .Values.mcp.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /mcp/
+              port: {{ .Values.mcp.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: naas-mcp
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "naas.labels" . | nindent 4 }}
+    app: naas-mcp
+spec:
+  type: {{ .Values.mcp.service.type }}
+  ports:
+    - port: {{ .Values.mcp.service.port }}
+      targetPort: {{ .Values.mcp.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: naas-mcp
+{{- end }}

--- a/charts/naas/templates/secret.yaml
+++ b/charts/naas/templates/secret.yaml
@@ -12,6 +12,9 @@ data:
   {{- if .Values.secrets.encryptionKey }}
   NAAS_ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.jwtSecret }}
+  NAAS_JWT_SECRET: {{ .Values.secrets.jwtSecret | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.tlsCert }}
   NAAS_CERT: {{ .Values.secrets.tlsCert | b64enc | quote }}
   {{- end }}

--- a/charts/naas/values.yaml
+++ b/charts/naas/values.yaml
@@ -67,6 +67,7 @@ secrets:
   # -- Values for the created Secret (ignored if existingSecret is set)
   redisPassword: ""
   encryptionKey: ""
+  jwtSecret: ""  # Required when mcp.enabled is true
   # -- Optional TLS (omit for self-signed)
   tlsCert: ""
   tlsKey: ""
@@ -90,6 +91,30 @@ redis:
   external:
     host: ""
     port: "6379"
+
+# -- MCP server configuration (optional, for remote/shared MCP deployments)
+mcp:
+  enabled: false
+  image:
+    repository: ghcr.io/lykinsbd/naas-mcp
+    tag: ""  # Defaults to Chart.appVersion
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 8081
+  # -- URL of the NAAS API server (internal cluster DNS)
+  apiUrl: "https://naas-api:443"
+  # -- Redis URL for token revocation checks (same Redis as API)
+  redisUrl: "redis://naas-redis:6379/0"
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+  service:
+    type: ClusterIP
+    port: 8081
 
 # -- Ingress configuration
 ingress:

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -1,0 +1,15 @@
+services:
+  naas-mcp:
+    build:
+      context: .
+      dockerfile: packages/naas-mcp/Dockerfile
+    ports:
+      - "8081:8081"
+    environment:
+      NAAS_MCP_TRANSPORT: streamable-http
+      NAAS_MCP_PORT: "8081"
+      NAAS_MCP_API_URL: http://naas-api:8080
+      NAAS_JWT_SECRET: ${NAAS_JWT_SECRET}
+      NAAS_MCP_REDIS_URL: redis://redis:6379/0
+    depends_on:
+      - redis

--- a/docs/mcp-remote.md
+++ b/docs/mcp-remote.md
@@ -56,7 +56,7 @@ export NAAS_JWT_SECRET=your-jwt-secret
 
 The remote MCP server listens at:
 
-```
+```text
 http://<host>:8081/mcp
 ```
 
@@ -87,25 +87,23 @@ Any MCP client supporting streamable-http transport can connect by providing:
 
 ## Environment variables
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `NAAS_MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` or `streamable-http` |
-| `NAAS_MCP_PORT` | `8081` | HTTP listen port (streamable-http only) |
-| `NAAS_MCP_HOST` | `0.0.0.0` | HTTP bind address |
-| `NAAS_MCP_API_URL` | `http://localhost:8080` | NAAS API base URL |
-| `NAAS_JWT_SECRET` | — | JWT secret for validating Bearer tokens |
-| `NAAS_MCP_REDIS_URL` | — | Redis URL for session/state (optional) |
-| `NAAS_MCP_LOG_LEVEL` | `info` | Logging level |
+| Variable                | Default                | Description                                      |
+| ----------------------- | ---------------------- | ------------------------------------------------ |
+| `NAAS_MCP_TRANSPORT`   | `stdio`                | Transport mode: `stdio` or `streamable-http`     |
+| `NAAS_MCP_PORT`        | `8081`                 | HTTP listen port (streamable-http only)          |
+| `NAAS_MCP_API_URL`     | `http://localhost:8080` | NAAS API base URL                               |
+| `NAAS_JWT_SECRET`      | —                      | JWT secret for validating Bearer tokens          |
+| `NAAS_MCP_REDIS_URL`   | —                      | Redis URL for revocation checks (optional)       |
 
-## Authentication & RBAC
+## Authentication and RBAC
 
 The MCP server validates Bearer tokens using the same `NAAS_JWT_SECRET` as the NAAS API. Token roles map to MCP tool access:
 
-| Role | Access |
-|------|--------|
-| `admin` | All tools (send-command, send-config, manage jobs) |
-| `operator` | send-command, send-config, list/cancel own jobs |
-| `viewer` | Read-only tools (show jobs, device info) |
+| Role       | Access                                              |
+| ---------- | --------------------------------------------------- |
+| `admin`    | All tools (send-command, send-config, manage jobs)  |
+| `operator` | send-command, send-config, list/cancel own jobs     |
+| `viewer`   | Read-only tools (show jobs, device info)            |
 
 No separate credentials needed — if you have a NAAS API key, it works for MCP too.
 
@@ -125,11 +123,3 @@ docker compose -f docker-compose.mcp.yml up -d
 # 3. Configure your AI client with the returned api_key as Bearer token
 # 4. The AI assistant can now run network commands through NAAS
 ```
-
-## Health check
-
-```bash
-curl http://localhost:8081/health
-```
-
-Returns `200 OK` when the server is ready.

--- a/docs/mcp-remote.md
+++ b/docs/mcp-remote.md
@@ -1,0 +1,135 @@
+# Remote MCP Server (HTTP Transport)
+
+The NAAS MCP server supports **streamable-http** transport, allowing AI assistants to connect over the network instead of requiring a local stdio process. This enables shared, centralized MCP deployments where multiple users and AI clients connect to a single server instance.
+
+> For local stdio-based setup (e.g., Claude Desktop, Cursor), see [mcp-server.md](mcp-server.md).
+
+## Why remote?
+
+- **Shared infrastructure** — one MCP server serves your entire team
+- **No local install** — AI clients connect via HTTP, no Python or packages needed locally
+- **Centralized auth** — NAAS API keys (JWT) authenticate at the MCP layer with full RBAC
+- **Container-ready** — deploy alongside NAAS API in Docker or Kubernetes
+
+## Prerequisites
+
+1. NAAS API running and accessible (e.g., `http://naas-api:8080`)
+2. A NAAS API key (JWT) created via `/v2/api-keys` with appropriate role (`admin`, `operator`, or `viewer`)
+3. Docker (for containerized deployment) or Python 3.11+ with `uv` (for bare metal)
+
+## Starting the server
+
+### Docker (recommended)
+
+```bash
+# From the repo root
+docker compose -f docker-compose.mcp.yml up -d
+
+# Or build and run standalone
+docker build -f packages/naas-mcp/Dockerfile -t naas-mcp .
+docker run -p 8081:8081 \
+  -e NAAS_MCP_TRANSPORT=streamable-http \
+  -e NAAS_MCP_PORT=8081 \
+  -e NAAS_MCP_API_URL=http://naas-api:8080 \
+  -e NAAS_JWT_SECRET=your-jwt-secret \
+  naas-mcp
+```
+
+### Bare metal
+
+```bash
+# Install the package
+uv pip install mcp-server-naas
+
+# Run with HTTP transport
+naas-mcp --transport streamable-http --port 8081
+```
+
+Set required environment variables before starting:
+
+```bash
+export NAAS_MCP_API_URL=http://localhost:8080
+export NAAS_JWT_SECRET=your-jwt-secret
+```
+
+## Connecting AI clients
+
+The remote MCP server listens at:
+
+```
+http://<host>:8081/mcp
+```
+
+Clients authenticate with a **Bearer token** — the same NAAS JWT API key used for direct API access.
+
+### Claude Desktop / Claude Code
+
+```json
+{
+  "mcpServers": {
+    "naas": {
+      "type": "streamable-http",
+      "url": "http://localhost:8081/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-naas-api-key>"
+      }
+    }
+  }
+}
+```
+
+### Generic MCP client
+
+Any MCP client supporting streamable-http transport can connect by providing:
+
+- **URL**: `http://<host>:8081/mcp`
+- **Header**: `Authorization: Bearer <your-naas-api-key>`
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NAAS_MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` or `streamable-http` |
+| `NAAS_MCP_PORT` | `8081` | HTTP listen port (streamable-http only) |
+| `NAAS_MCP_HOST` | `0.0.0.0` | HTTP bind address |
+| `NAAS_MCP_API_URL` | `http://localhost:8080` | NAAS API base URL |
+| `NAAS_JWT_SECRET` | — | JWT secret for validating Bearer tokens |
+| `NAAS_MCP_REDIS_URL` | — | Redis URL for session/state (optional) |
+| `NAAS_MCP_LOG_LEVEL` | `info` | Logging level |
+
+## Authentication & RBAC
+
+The MCP server validates Bearer tokens using the same `NAAS_JWT_SECRET` as the NAAS API. Token roles map to MCP tool access:
+
+| Role | Access |
+|------|--------|
+| `admin` | All tools (send-command, send-config, manage jobs) |
+| `operator` | send-command, send-config, list/cancel own jobs |
+| `viewer` | Read-only tools (show jobs, device info) |
+
+No separate credentials needed — if you have a NAAS API key, it works for MCP too.
+
+## Example: end-to-end
+
+```bash
+# 1. Create an API key (via NAAS API)
+curl -X POST https://naas.example.com/v2/api-keys \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "mcp-operator", "role": "operator"}'
+# Response: {"api_key": "eyJhbG..."}
+
+# 2. Start the MCP server
+docker compose -f docker-compose.mcp.yml up -d
+
+# 3. Configure your AI client with the returned api_key as Bearer token
+# 4. The AI assistant can now run network commands through NAAS
+```
+
+## Health check
+
+```bash
+curl http://localhost:8081/health
+```
+
+Returns `200 OK` when the server is ready.

--- a/docs/mcp-remote.md
+++ b/docs/mcp-remote.md
@@ -87,23 +87,23 @@ Any MCP client supporting streamable-http transport can connect by providing:
 
 ## Environment variables
 
-| Variable                | Default                | Description                                      |
-| ----------------------- | ---------------------- | ------------------------------------------------ |
-| `NAAS_MCP_TRANSPORT`   | `stdio`                | Transport mode: `stdio` or `streamable-http`     |
-| `NAAS_MCP_PORT`        | `8081`                 | HTTP listen port (streamable-http only)          |
-| `NAAS_MCP_API_URL`     | `http://localhost:8080` | NAAS API base URL                               |
-| `NAAS_JWT_SECRET`      | —                      | JWT secret for validating Bearer tokens          |
-| `NAAS_MCP_REDIS_URL`   | —                      | Redis URL for revocation checks (optional)       |
+| Variable | Default | Description |
+| --- | --- | --- |
+| `NAAS_MCP_TRANSPORT` | `stdio` | Transport mode: `stdio` or `streamable-http` |
+| `NAAS_MCP_PORT` | `8081` | HTTP listen port (streamable-http only) |
+| `NAAS_MCP_API_URL` | `http://localhost:8080` | NAAS API base URL |
+| `NAAS_JWT_SECRET` | — | JWT secret for validating Bearer tokens |
+| `NAAS_MCP_REDIS_URL` | — | Redis URL for revocation checks (optional) |
 
 ## Authentication and RBAC
 
 The MCP server validates Bearer tokens using the same `NAAS_JWT_SECRET` as the NAAS API. Token roles map to MCP tool access:
 
-| Role       | Access                                              |
-| ---------- | --------------------------------------------------- |
-| `admin`    | All tools (send-command, send-config, manage jobs)  |
-| `operator` | send-command, send-config, list/cancel own jobs     |
-| `viewer`   | Read-only tools (show jobs, device info)            |
+| Role | Access |
+| --- | --- |
+| `admin` | All tools (send-command, send-config, manage jobs) |
+| `operator` | send-command, send-config, list/cancel own jobs |
+| `viewer` | Read-only tools (show jobs, device info) |
 
 No separate credentials needed — if you have a NAAS API key, it works for MCP too.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -691,7 +691,7 @@ Or check [ntc-templates](https://github.com/networktocode/ntc-templates/tree/mas
 
 **Cause:** Template doesn't match actual device output format.
 
-**Solution:** Test template with [TextFSM online tool](https://textfsm.nornir.tech/) or supply corrected custom template.
+**Solution:** Test template with the [TextFSM documentation](https://github.com/google/textfsm) or supply corrected custom template.
 
 ## Platform Autodetect Issues
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
       - API: api-usage.md
       - Python Client & CLI: client.md
       - MCP Server: mcp-server.md
+      - MCP Remote (HTTP): mcp-remote.md
       - Structured Output: structured-output.md
       - Platform Autodetect: platform-autodetect.md
       - Context Routing: contexts.md

--- a/packages/naas-mcp/Dockerfile
+++ b/packages/naas-mcp/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install uv for fast dependency resolution
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy workspace files needed for resolution
+COPY pyproject.toml uv.lock ./
+COPY packages/naas-mcp/ packages/naas-mcp/
+COPY packages/naas-client/ packages/naas-client/
+
+# Install the MCP server package
+RUN uv sync --package mcp-server-naas --no-dev --frozen
+
+EXPOSE 8081
+
+ENTRYPOINT ["uv", "run", "--package", "mcp-server-naas", "naas-mcp"]
+CMD ["--transport", "streamable-http", "--port", "8081"]

--- a/packages/naas-mcp/naas_mcp/__init__.py
+++ b/packages/naas-mcp/naas_mcp/__init__.py
@@ -4,7 +4,43 @@ __version__ = "0.1.0a1"
 
 
 def main() -> None:
-    """CLI entry point for stdio transport."""
+    """CLI entry point supporting stdio and streamable-http transport.
+
+    Transport selection:
+        --transport stdio|streamable-http  (default: stdio)
+        --port PORT                        (default: 8081, HTTP only)
+
+    Or via environment variables:
+        NAAS_MCP_TRANSPORT=streamable-http
+        NAAS_MCP_PORT=8081
+    """
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(
+        description="NAAS MCP Server — AI-assisted network operations",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "streamable-http"],
+        default=os.environ.get("NAAS_MCP_TRANSPORT", "stdio"),
+        help="Transport type (default: stdio, or NAAS_MCP_TRANSPORT env var)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.environ.get("NAAS_MCP_PORT", "8081")),
+        help="HTTP port (default: 8081, or NAAS_MCP_PORT env var)",
+    )
+    args = parser.parse_args()
+
+    # Set env var so server.py picks up the transport choice during module init
+    os.environ["NAAS_MCP_TRANSPORT"] = args.transport
+    os.environ["NAAS_MCP_PORT"] = str(args.port)
+
     from naas_mcp.server import mcp
 
-    mcp.run()
+    if args.transport == "stdio":
+        mcp.run()
+    else:
+        mcp.run(transport="streamable-http", port=args.port)

--- a/packages/naas-mcp/naas_mcp/auth.py
+++ b/packages/naas-mcp/naas_mcp/auth.py
@@ -8,7 +8,6 @@ to work for both direct NAAS API access and MCP access.
 from __future__ import annotations
 
 import logging
-import time
 
 import jwt
 from fastmcp.server.auth import AccessToken, TokenVerifier

--- a/packages/naas-mcp/naas_mcp/auth.py
+++ b/packages/naas-mcp/naas_mcp/auth.py
@@ -1,0 +1,97 @@
+"""NAAS JWT authentication provider for FastMCP HTTP transport.
+
+Validates NAAS API keys (JWTs signed with NAAS_JWT_SECRET) and checks
+revocation against the shared Redis set. This allows the same API keys
+to work for both direct NAAS API access and MCP access.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import jwt
+from fastmcp.server.auth import AccessToken, TokenVerifier
+
+logger = logging.getLogger(__name__)
+
+
+class NaasAuthProvider(TokenVerifier):
+    """Verify NAAS JWT API keys for MCP HTTP transport.
+
+    Shares the same JWT secret and revocation store as the NAAS API server,
+    so a single API key works for both direct API calls and MCP access.
+
+    Args:
+        jwt_secret: The NAAS_JWT_SECRET used to sign/verify API key JWTs.
+        redis_url: Optional Redis URL for revocation checks. If None,
+            revocation checking is skipped (tokens are validated by
+            signature and expiry only).
+    """
+
+    def __init__(
+        self,
+        jwt_secret: str,
+        redis_url: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._jwt_secret = jwt_secret
+        self._redis_url = redis_url
+        self._redis: object | None = None  # Lazy-initialized Redis connection
+
+    def _get_redis(self):
+        """Lazy-initialize Redis connection for revocation checks."""
+        if self._redis is None and self._redis_url:
+            from redis import Redis
+
+            self._redis = Redis.from_url(self._redis_url, decode_responses=True)
+        return self._redis
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Verify a NAAS JWT API key.
+
+        Decodes the JWT, checks expiry, and optionally checks revocation
+        against the Redis revoked_keys set.
+
+        Args:
+            token: The Bearer token (NAAS JWT API key).
+
+        Returns:
+            AccessToken with claims if valid, None if invalid/expired/revoked.
+        """
+        try:
+            claims: dict = jwt.decode(token, self._jwt_secret, algorithms=["HS256"])
+        except jwt.InvalidTokenError as exc:
+            logger.debug("JWT validation failed: %s", exc)
+            return None
+
+        # Check revocation
+        redis = self._get_redis()
+        if redis is not None:
+            key_id = claims.get("sub", "")
+            if redis.sismember("naas:revoked_keys", key_id):
+                logger.info("Rejected revoked API key: %s", key_id)
+                return None
+
+        # Build AccessToken for FastMCP
+        return AccessToken(
+            token=token,
+            client_id=claims.get("sub", "unknown"),
+            scopes=self._role_to_scopes(claims.get("role", "viewer")),
+            expires_at=claims.get("exp"),
+            claims=claims,
+        )
+
+    @staticmethod
+    def _role_to_scopes(role: str) -> list[str]:
+        """Map NAAS role to OAuth-style scopes for FastMCP compatibility.
+
+        This allows using FastMCP's built-in scope checking if needed,
+        but our primary RBAC uses the role claim directly.
+        """
+        scopes_map = {
+            "viewer": ["read"],
+            "operator": ["read", "execute"],
+            "admin": ["read", "execute", "admin"],
+        }
+        return scopes_map.get(role, ["read"])

--- a/packages/naas-mcp/naas_mcp/rbac.py
+++ b/packages/naas-mcp/naas_mcp/rbac.py
@@ -1,0 +1,74 @@
+"""RBAC authorization for NAAS MCP tools and resources.
+
+Maps MCP components to minimum required NAAS roles and provides
+an auth check callable compatible with FastMCP's AuthMiddleware.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.middleware.authorization import AuthContext
+
+logger = logging.getLogger(__name__)
+
+# NAAS role hierarchy (higher rank = more permissions)
+ROLE_RANK: dict[str, int] = {"viewer": 0, "operator": 1, "admin": 2}
+
+# MCP tool/resource → minimum required role
+COMPONENT_ROLES: dict[str, str] = {
+    # Tools requiring operator (execute on devices / modify state)
+    "send_command": "operator",
+    "send_command_structured": "operator",
+    "send_config": "operator",
+    "cancel_job": "operator",
+    # Tools requiring viewer (read-only)
+    "get_job": "viewer",
+    "list_jobs": "viewer",
+    # Resources (all read-only)
+    "naas://health": "viewer",
+    "naas://contexts": "viewer",
+    "naas://failed-jobs": "viewer",
+}
+
+
+def require_naas_role(ctx: AuthContext) -> bool:
+    """FastMCP auth check: enforce NAAS RBAC on MCP components.
+
+    Used with FastMCP's AuthMiddleware to check if the authenticated
+    user's role is sufficient for the requested tool/resource.
+
+    Args:
+        ctx: FastMCP AuthContext with the current token and component.
+
+    Returns:
+        True if authorized, False if insufficient role.
+    """
+    token: AccessToken | None = ctx.token
+    if token is None:
+        # No token = unauthenticated (should not happen if auth provider is configured)
+        return False
+
+    # Get user's role from JWT claims
+    user_role = token.claims.get("role", "viewer")
+    user_rank = ROLE_RANK.get(user_role, 0)
+
+    # Determine the component name for lookup
+    component_name = ctx.component.name if ctx.component else ""
+
+    # Look up required role for this component
+    required_role = COMPONENT_ROLES.get(component_name, "viewer")
+    required_rank = ROLE_RANK.get(required_role, 0)
+
+    if user_rank < required_rank:
+        logger.info(
+            "RBAC denied: key=%s role=%s attempted %s (requires %s)",
+            token.client_id,
+            user_role,
+            component_name,
+            required_role,
+        )
+        return False
+
+    return True

--- a/packages/naas-mcp/naas_mcp/rbac.py
+++ b/packages/naas-mcp/naas_mcp/rbac.py
@@ -7,9 +7,11 @@ an auth check callable compatible with FastMCP's AuthMiddleware.
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
-from fastmcp.server.auth import AccessToken
-from fastmcp.server.middleware.authorization import AuthContext
+if TYPE_CHECKING:
+    from fastmcp.server.auth import AccessToken
+    from fastmcp.server.middleware.authorization import AuthContext
 
 logger = logging.getLogger(__name__)
 

--- a/packages/naas-mcp/naas_mcp/server.py
+++ b/packages/naas-mcp/naas_mcp/server.py
@@ -1,5 +1,7 @@
 """FastMCP server definition and configuration."""
 
+from __future__ import annotations
+
 import os
 
 from fastmcp import FastMCP
@@ -15,16 +17,57 @@ def _get_config() -> dict[str, str | int | float]:
         "timeout": float(os.environ.get("NAAS_MCP_TIMEOUT", "30")),
         "job_poll_interval": float(os.environ.get("NAAS_MCP_JOB_POLL_INTERVAL", "2")),
         "job_timeout": float(os.environ.get("NAAS_MCP_JOB_TIMEOUT", "300")),
+        "transport": os.environ.get("NAAS_MCP_TRANSPORT", "stdio"),
+        "jwt_secret": os.environ.get("NAAS_JWT_SECRET", ""),
+        "redis_url": os.environ.get("NAAS_MCP_REDIS_URL", ""),
     }
+
+
+def _get_auth_provider():
+    """Create auth provider for HTTP transport, None for stdio."""
+    cfg = _get_config()
+    if cfg["transport"] == "stdio":
+        return None
+
+    jwt_secret = str(cfg["jwt_secret"])
+    if not jwt_secret:
+        raise RuntimeError(
+            "NAAS_JWT_SECRET is required when running with HTTP transport. "
+            "Set it to the same value used by the NAAS API server."
+        )
+
+    from naas_mcp.auth import NaasAuthProvider
+
+    redis_url = str(cfg["redis_url"]) or None
+    return NaasAuthProvider(jwt_secret=jwt_secret, redis_url=redis_url)
+
+
+def _get_middleware():
+    """Create authorization middleware for HTTP transport."""
+    cfg = _get_config()
+    if cfg["transport"] == "stdio":
+        return None
+
+    from fastmcp.server.middleware.authorization import AuthMiddleware
+
+    from naas_mcp.rbac import require_naas_role
+
+    return AuthMiddleware(auth=require_naas_role)
 
 
 @lifespan
 async def app_lifespan(server: FastMCP):  # type: ignore[type-arg]
-    """Initialize AsyncNaasClient for the server lifetime."""
+    """Initialize AsyncNaasClient for the server lifetime.
+
+    In stdio mode: creates a single client with the configured API key.
+    In HTTP mode: creates a base client (tools override auth per-request).
+    """
     cfg = _get_config()
+    api_key = str(cfg["api_key"]) or None
+
     client = AsyncNaasClient(
         base_url=str(cfg["api_url"]),
-        api_key=str(cfg["api_key"]) or None,
+        api_key=api_key,
         timeout=float(cfg["timeout"]),
     )
     try:
@@ -32,10 +75,17 @@ async def app_lifespan(server: FastMCP):  # type: ignore[type-arg]
             "client": client,
             "job_poll_interval": float(cfg["job_poll_interval"]),
             "job_timeout": float(cfg["job_timeout"]),
+            "transport": str(cfg["transport"]),
+            "api_url": str(cfg["api_url"]),
+            "timeout": float(cfg["timeout"]),
         }
     finally:
         await client.close()
 
+
+# Build middleware list (only include auth middleware for HTTP)
+_middleware = _get_middleware()
+_middleware_list = [_middleware] if _middleware is not None else None
 
 mcp = FastMCP(
     name="naas",
@@ -45,6 +95,8 @@ mcp = FastMCP(
         "Use resources to read health status, available contexts, and failed jobs."
     ),
     lifespan=app_lifespan,
+    auth=_get_auth_provider(),
+    middleware=_middleware_list,
 )
 
 # Register tools, resources, and prompts via imports (side effects)

--- a/packages/naas-mcp/naas_mcp/tools.py
+++ b/packages/naas-mcp/naas_mcp/tools.py
@@ -3,12 +3,34 @@
 from typing import Any
 
 from fastmcp import Context
+from fastmcp.server.dependencies import get_access_token
 from naas_client import AsyncNaasClient
 
 from naas_mcp.server import mcp
 
 
 def _client(ctx: Context) -> AsyncNaasClient:
+    """Get a naas-client instance, with per-request auth for HTTP transport.
+
+    In stdio mode: returns the shared lifespan client (single API key from env).
+    In HTTP mode: creates a per-request client using the caller's Bearer token,
+    so each MCP user's API calls are attributed to their own API key with proper
+    RBAC and context authorization enforced by the NAAS API.
+    """
+    transport = ctx.lifespan_context.get("transport", "stdio")
+    if transport == "stdio":
+        return ctx.lifespan_context["client"]  # type: ignore[return-value]
+
+    # HTTP mode: get the caller's token and create a per-request client
+    access_token = get_access_token()
+    if access_token is not None and access_token.token:
+        return AsyncNaasClient(
+            base_url=ctx.lifespan_context["api_url"],  # type: ignore[arg-type]
+            api_key=access_token.token,
+            timeout=ctx.lifespan_context["timeout"],  # type: ignore[arg-type]
+        )
+
+    # Fallback to shared client (shouldn't happen if auth is configured)
     return ctx.lifespan_context["client"]  # type: ignore[return-value]
 
 

--- a/packages/naas-mcp/pyproject.toml
+++ b/packages/naas-mcp/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
 dependencies = [
     "fastmcp>=2.0",
     "naas-client>=1.0.0a1",
+    "pyjwt>=2.8.0",
+    "redis>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/naas-mcp/tests/integration/test_http_transport.py
+++ b/packages/naas-mcp/tests/integration/test_http_transport.py
@@ -1,0 +1,385 @@
+"""Integration tests for MCP server running in streamable-http mode with Bearer token auth.
+
+Tests the HTTP transport layer with JWT authentication:
+- Valid Bearer tokens are accepted and allow MCP protocol interaction
+- Invalid/missing tokens are rejected with appropriate HTTP status codes
+
+Uses FastMCP's http_app() + httpx ASGITransport with manual lifespan management
+instead of Docker.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import jwt
+import pytest
+from fastmcp import FastMCP
+from fastmcp.client import Client
+from fastmcp.client.auth.bearer import BearerAuth
+from fastmcp.client.transports.http import StreamableHttpTransport
+
+from naas_mcp.auth import NaasAuthProvider
+from naas_mcp.rbac import require_naas_role
+
+JWT_SECRET = "integration-test-jwt-secret-32chars!"
+MCP_PATH = "/mcp/"
+
+
+# Override the session-scoped docker_compose autouse fixture from the integration conftest.
+# This test module does not require Docker — it uses in-process ASGI testing.
+@pytest.fixture(scope="session", autouse=True)
+def docker_compose():
+    """No-op override: HTTP transport tests don't need Docker."""
+    yield
+
+
+def _make_token(
+    sub: str = "k-test",
+    role: str = "operator",
+    contexts: list[str] | None = None,
+    secret: str = JWT_SECRET,
+) -> str:
+    """Create a valid JWT token for testing."""
+    payload = {
+        "sub": sub,
+        "role": role,
+        "contexts": contexts or ["*"],
+        "iat": int(time.time()),
+    }
+    return jwt.encode(payload, secret, algorithm="HS256")
+
+
+def _build_server() -> FastMCP:
+    """Build a FastMCP server with JWT auth enabled (no Redis revocation)."""
+
+    @asynccontextmanager
+    async def test_lifespan(server: Any):
+        mock_client = AsyncMock()
+        mock_client.healthcheck.return_value = {"status": "healthy", "components": {}}
+        yield {
+            "client": mock_client,
+            "job_poll_interval": 0.1,
+            "job_timeout": 5.0,
+            "transport": "streamable-http",
+            "api_url": "http://mock-naas:8080",
+            "timeout": 5.0,
+        }
+
+    auth_provider = NaasAuthProvider(jwt_secret=JWT_SECRET, redis_url=None)
+
+    from fastmcp.server.middleware.authorization import AuthMiddleware
+
+    middleware = AuthMiddleware(auth=require_naas_role)
+
+    server = FastMCP(
+        name="naas-http-test",
+        lifespan=test_lifespan,
+        auth=auth_provider,
+        middleware=[middleware],
+    )
+
+    # Register tools and resources
+    from naas_mcp.resources import contexts, failed_jobs, health, jobs
+    from naas_mcp.tools import (
+        cancel_job,
+        create_api_key,
+        get_job_result,
+        list_jobs,
+        revoke_api_key,
+        send_command,
+        send_command_structured,
+        send_config,
+    )
+
+    for fn in (
+        send_command,
+        send_command_structured,
+        send_config,
+        get_job_result,
+        cancel_job,
+        list_jobs,
+        create_api_key,
+        revoke_api_key,
+    ):
+        server.add_tool(fn)
+
+    server.resource("naas://health", name="Health")(health)
+    server.resource("naas://contexts", name="Contexts")(contexts)
+    server.resource("naas://jobs/failed", name="Failed Jobs")(failed_jobs)
+    server.resource("naas://jobs", name="Jobs")(jobs)
+
+    return server
+
+
+@asynccontextmanager
+async def _managed_asgi_app(mcp_server: FastMCP):
+    """Context manager that creates an ASGI app with active lifespan.
+
+    The StreamableHTTP session manager requires the Starlette lifespan to be
+    running. This helper starts the ASGI lifespan in a background task, yields
+    the app, then shuts it down cleanly.
+    """
+    app = mcp_server.http_app(path=MCP_PATH, transport="streamable-http")
+
+    # Drive the ASGI lifespan protocol manually
+    startup_complete = asyncio.Event()
+    shutdown_trigger = asyncio.Event()
+
+    async def receive():
+        if not startup_complete.is_set():
+            startup_complete.set()
+            return {"type": "lifespan.startup"}
+        await shutdown_trigger.wait()
+        return {"type": "lifespan.shutdown"}
+
+    async def send(msg):
+        if msg["type"] == "lifespan.startup.complete":
+            startup_complete.set()
+
+    lifespan_task = asyncio.create_task(
+        app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
+    )
+    # Wait for lifespan startup to complete
+    await asyncio.sleep(0.1)
+
+    try:
+        yield app
+    finally:
+        shutdown_trigger.set()
+        await lifespan_task
+
+
+@pytest.fixture
+def mcp_server() -> FastMCP:
+    """FastMCP server instance with HTTP auth configured."""
+    return _build_server()
+
+
+@pytest.fixture
+def valid_token() -> str:
+    """A valid JWT operator token."""
+    return _make_token()
+
+
+@pytest.fixture
+def admin_token() -> str:
+    """A valid JWT admin token."""
+    return _make_token(sub="k-admin", role="admin")
+
+
+# ---------------------------------------------------------------------------
+# Tests: HTTP-level auth validation
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_bearer_token_rejected(mcp_server: FastMCP):
+    """Requests without a Bearer token should be rejected with 401."""
+    async with _managed_asgi_app(mcp_server) as app:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.post(
+                MCP_PATH,
+                json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+            )
+            assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+
+async def test_invalid_bearer_token_rejected(mcp_server: FastMCP):
+    """Requests with an invalid (badly signed) Bearer token should be rejected with 401."""
+    bad_token = jwt.encode(
+        {"sub": "hacker", "role": "admin", "contexts": ["*"], "iat": int(time.time())},
+        "wrong-secret-key-not-the-real-one!!",
+        algorithm="HS256",
+    )
+    async with _managed_asgi_app(mcp_server) as app:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.post(
+                MCP_PATH,
+                json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                    "Authorization": f"Bearer {bad_token}",
+                },
+            )
+            assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+
+
+async def test_valid_bearer_token_accepted(mcp_server: FastMCP, valid_token: str):
+    """Requests with a valid Bearer token should be accepted (HTTP 200)."""
+    async with _managed_asgi_app(mcp_server) as app:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            resp = await client.post(
+                MCP_PATH,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "initialize",
+                    "id": 1,
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {"name": "test-client", "version": "1.0.0"},
+                    },
+                },
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                    "Authorization": f"Bearer {valid_token}",
+                },
+            )
+            # Server should accept the connection — 200 with SSE or JSON response
+            assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Full MCP client flow with Bearer auth over HTTP
+# ---------------------------------------------------------------------------
+
+
+async def test_mcp_client_with_bearer_auth(mcp_server: FastMCP, valid_token: str):
+    """FastMCP Client connects successfully with Bearer auth via HTTP transport."""
+    async with _managed_asgi_app(mcp_server) as app:
+
+        def httpx_factory(**kwargs: Any) -> httpx.AsyncClient:
+            """Create httpx client using ASGI transport for in-process testing."""
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                **{k: v for k, v in kwargs.items() if k not in ("base_url", "transport")},
+            )
+
+        transport = StreamableHttpTransport(
+            url=f"http://testserver{MCP_PATH}",
+            auth=BearerAuth(token=valid_token),
+            httpx_client_factory=httpx_factory,
+        )
+
+        async with Client(transport=transport) as client:
+            # Connection accepted — list tools to verify full MCP protocol works
+            tools = await client.list_tools()
+            assert len(tools) > 0, "Should have registered tools"
+
+            # Verify expected tools are present
+            tool_names = {t.name for t in tools}
+            assert "send_command" in tool_names
+            assert "list_jobs" in tool_names
+
+
+async def test_mcp_client_invalid_token_fails(mcp_server: FastMCP):
+    """FastMCP Client with invalid token should fail to connect."""
+    bad_token = jwt.encode(
+        {"sub": "hacker", "role": "admin", "contexts": ["*"], "iat": int(time.time())},
+        "wrong-secret-key-not-the-real-one!!",
+        algorithm="HS256",
+    )
+    async with _managed_asgi_app(mcp_server) as app:
+
+        def httpx_factory(**kwargs: Any) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                **{k: v for k, v in kwargs.items() if k not in ("base_url", "transport")},
+            )
+
+        transport = StreamableHttpTransport(
+            url=f"http://testserver{MCP_PATH}",
+            auth=BearerAuth(token=bad_token),
+            httpx_client_factory=httpx_factory,
+        )
+
+        with pytest.raises(Exception):
+            async with Client(transport=transport) as client:
+                await client.list_tools()
+
+
+async def test_mcp_client_no_token_fails(mcp_server: FastMCP):
+    """FastMCP Client with no token should fail to connect."""
+    async with _managed_asgi_app(mcp_server) as app:
+
+        def httpx_factory(**kwargs: Any) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                **{k: v for k, v in kwargs.items() if k not in ("base_url", "transport")},
+            )
+
+        transport = StreamableHttpTransport(
+            url=f"http://testserver{MCP_PATH}",
+            httpx_client_factory=httpx_factory,
+        )
+
+        with pytest.raises(Exception):
+            async with Client(transport=transport) as client:
+                await client.list_tools()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Role-based access control via HTTP
+# ---------------------------------------------------------------------------
+
+
+async def test_viewer_role_can_list_tools(mcp_server: FastMCP):
+    """A viewer-role token can connect and list tools (read operation)."""
+    viewer_token = _make_token(sub="k-viewer", role="viewer")
+    async with _managed_asgi_app(mcp_server) as app:
+
+        def httpx_factory(**kwargs: Any) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                **{k: v for k, v in kwargs.items() if k not in ("base_url", "transport")},
+            )
+
+        transport = StreamableHttpTransport(
+            url=f"http://testserver{MCP_PATH}",
+            auth=BearerAuth(token=viewer_token),
+            httpx_client_factory=httpx_factory,
+        )
+
+        async with Client(transport=transport) as client:
+            tools = await client.list_tools()
+            assert len(tools) > 0
+
+
+async def test_admin_token_can_list_tools(mcp_server: FastMCP, admin_token: str):
+    """An admin-role token can connect and list tools."""
+    async with _managed_asgi_app(mcp_server) as app:
+
+        def httpx_factory(**kwargs: Any) -> httpx.AsyncClient:
+            return httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app),
+                base_url="http://testserver",
+                **{k: v for k, v in kwargs.items() if k not in ("base_url", "transport")},
+            )
+
+        transport = StreamableHttpTransport(
+            url=f"http://testserver{MCP_PATH}",
+            auth=BearerAuth(token=admin_token),
+            httpx_client_factory=httpx_factory,
+        )
+
+        async with Client(transport=transport) as client:
+            tools = await client.list_tools()
+            assert len(tools) > 0
+            tool_names = {t.name for t in tools}
+            # Admin should see all tools
+            assert "send_command" in tool_names
+            assert "create_api_key" in tool_names

--- a/packages/naas-mcp/tests/integration/test_http_transport.py
+++ b/packages/naas-mcp/tests/integration/test_http_transport.py
@@ -180,20 +180,19 @@ def admin_token() -> str:
 
 async def test_missing_bearer_token_rejected(mcp_server: FastMCP):
     """Requests without a Bearer token should be rejected with 401."""
-    async with _managed_asgi_app(mcp_server) as app:
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://testserver",
-        ) as client:
-            resp = await client.post(
-                MCP_PATH,
-                json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json, text/event-stream",
-                },
-            )
-            assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+    async with _managed_asgi_app(mcp_server) as app, httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        resp = await client.post(
+            MCP_PATH,
+            json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+        )
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
 
 
 async def test_invalid_bearer_token_rejected(mcp_server: FastMCP):
@@ -203,50 +202,48 @@ async def test_invalid_bearer_token_rejected(mcp_server: FastMCP):
         "wrong-secret-key-not-the-real-one!!",
         algorithm="HS256",
     )
-    async with _managed_asgi_app(mcp_server) as app:
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://testserver",
-        ) as client:
-            resp = await client.post(
-                MCP_PATH,
-                json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json, text/event-stream",
-                    "Authorization": f"Bearer {bad_token}",
-                },
-            )
-            assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
+    async with _managed_asgi_app(mcp_server) as app, httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        resp = await client.post(
+            MCP_PATH,
+            json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+                "Authorization": f"Bearer {bad_token}",
+            },
+        )
+        assert resp.status_code == 401, f"Expected 401, got {resp.status_code}: {resp.text}"
 
 
 async def test_valid_bearer_token_accepted(mcp_server: FastMCP, valid_token: str):
     """Requests with a valid Bearer token should be accepted (HTTP 200)."""
-    async with _managed_asgi_app(mcp_server) as app:
-        async with httpx.AsyncClient(
-            transport=httpx.ASGITransport(app=app),
-            base_url="http://testserver",
-        ) as client:
-            resp = await client.post(
-                MCP_PATH,
-                json={
-                    "jsonrpc": "2.0",
-                    "method": "initialize",
-                    "id": 1,
-                    "params": {
-                        "protocolVersion": "2025-03-26",
-                        "capabilities": {},
-                        "clientInfo": {"name": "test-client", "version": "1.0.0"},
-                    },
+    async with _managed_asgi_app(mcp_server) as app, httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        resp = await client.post(
+            MCP_PATH,
+            json={
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "id": 1,
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "1.0.0"},
                 },
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json, text/event-stream",
-                    "Authorization": f"Bearer {valid_token}",
-                },
-            )
-            # Server should accept the connection — 200 with SSE or JSON response
-            assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+            },
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+                "Authorization": f"Bearer {valid_token}",
+            },
+        )
+        # Server should accept the connection — 200 with SSE or JSON response
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
 
 
 # ---------------------------------------------------------------------------
@@ -305,7 +302,7 @@ async def test_mcp_client_invalid_token_fails(mcp_server: FastMCP):
             httpx_client_factory=httpx_factory,
         )
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017  -- FastMCP raises varied exceptions for auth failures
             async with Client(transport=transport) as client:
                 await client.list_tools()
 
@@ -326,7 +323,7 @@ async def test_mcp_client_no_token_fails(mcp_server: FastMCP):
             httpx_client_factory=httpx_factory,
         )
 
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017  -- FastMCP raises varied exceptions for auth failures
             async with Client(transport=transport) as client:
                 await client.list_tools()
 

--- a/packages/naas-mcp/tests/integration/test_http_transport.py
+++ b/packages/naas-mcp/tests/integration/test_http_transport.py
@@ -142,9 +142,7 @@ async def _managed_asgi_app(mcp_server: FastMCP):
         if msg["type"] == "lifespan.startup.complete":
             startup_complete.set()
 
-    lifespan_task = asyncio.create_task(
-        app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send)
-    )
+    lifespan_task = asyncio.create_task(app({"type": "lifespan", "asgi": {"version": "3.0"}}, receive, send))
     # Wait for lifespan startup to complete
     await asyncio.sleep(0.1)
 
@@ -180,10 +178,13 @@ def admin_token() -> str:
 
 async def test_missing_bearer_token_rejected(mcp_server: FastMCP):
     """Requests without a Bearer token should be rejected with 401."""
-    async with _managed_asgi_app(mcp_server) as app, httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
-        base_url="http://testserver",
-    ) as client:
+    async with (
+        _managed_asgi_app(mcp_server) as app,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client,
+    ):
         resp = await client.post(
             MCP_PATH,
             json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
@@ -202,10 +203,13 @@ async def test_invalid_bearer_token_rejected(mcp_server: FastMCP):
         "wrong-secret-key-not-the-real-one!!",
         algorithm="HS256",
     )
-    async with _managed_asgi_app(mcp_server) as app, httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
-        base_url="http://testserver",
-    ) as client:
+    async with (
+        _managed_asgi_app(mcp_server) as app,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client,
+    ):
         resp = await client.post(
             MCP_PATH,
             json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
@@ -220,10 +224,13 @@ async def test_invalid_bearer_token_rejected(mcp_server: FastMCP):
 
 async def test_valid_bearer_token_accepted(mcp_server: FastMCP, valid_token: str):
     """Requests with a valid Bearer token should be accepted (HTTP 200)."""
-    async with _managed_asgi_app(mcp_server) as app, httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app),
-        base_url="http://testserver",
-    ) as client:
+    async with (
+        _managed_asgi_app(mcp_server) as app,
+        httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client,
+    ):
         resp = await client.post(
             MCP_PATH,
             json={

--- a/packages/naas-mcp/tests/test_auth.py
+++ b/packages/naas-mcp/tests/test_auth.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import jwt
 import pytest
 
 from naas_mcp.auth import NaasAuthProvider
-from naas_mcp.rbac import ROLE_RANK, require_naas_role
+from naas_mcp.rbac import require_naas_role
 
 JWT_SECRET = "test-secret-for-unit-tests"
 

--- a/packages/naas-mcp/tests/test_auth.py
+++ b/packages/naas-mcp/tests/test_auth.py
@@ -101,7 +101,32 @@ class TestNaasAuthProvider:
         token = _make_token(role="viewer")
         result = await provider.verify_token(token)
         assert result is not None
-        assert result.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_lazy_redis_initialization(self):
+        """When redis_url is provided, Redis is initialized lazily on first use."""
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("redis.Redis.from_url") as mock_from_url:
+            mock_redis_instance = MagicMock()
+            mock_redis_instance.sismember.return_value = False
+            mock_from_url.return_value = mock_redis_instance
+
+            provider = NaasAuthProvider(
+                jwt_secret=JWT_SECRET,
+                redis_url="redis://localhost:6379/0",
+            )
+            # Redis not initialized yet
+            assert provider._redis is None
+
+            # First call to verify_token triggers lazy init
+            token = _make_token(sub="k-lazy")
+            result = await provider.verify_token(token)
+
+            assert result is not None
+            assert result.client_id == "k-lazy"
+            assert provider._redis is mock_redis_instance
+            mock_from_url.assert_called_once_with("redis://localhost:6379/0", decode_responses=True)
 
     @pytest.mark.asyncio
     async def test_role_to_scopes_operator(self, provider: NaasAuthProvider):

--- a/packages/naas-mcp/tests/test_auth.py
+++ b/packages/naas-mcp/tests/test_auth.py
@@ -1,0 +1,179 @@
+"""Unit tests for NAAS auth provider and RBAC."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+from naas_mcp.auth import NaasAuthProvider
+from naas_mcp.rbac import ROLE_RANK, require_naas_role
+
+JWT_SECRET = "test-secret-for-unit-tests"
+
+
+def _make_token(
+    sub: str = "k-test123",
+    role: str = "operator",
+    contexts: list[str] | None = None,
+    exp: int | None = None,
+) -> str:
+    """Create a test JWT token."""
+    claims = {"sub": sub, "role": role, "contexts": contexts or ["*"], "iat": int(time.time())}
+    if exp is not None:
+        claims["exp"] = exp
+    return jwt.encode(claims, JWT_SECRET, algorithm="HS256")
+
+
+class TestNaasAuthProvider:
+    """Tests for NaasAuthProvider JWT validation."""
+
+    @pytest.fixture
+    def provider(self) -> NaasAuthProvider:
+        return NaasAuthProvider(jwt_secret=JWT_SECRET, redis_url=None)
+
+    @pytest.fixture
+    def provider_with_redis(self) -> NaasAuthProvider:
+        provider = NaasAuthProvider(jwt_secret=JWT_SECRET, redis_url="redis://localhost:6379/0")
+        # Mock the Redis connection
+        mock_redis = MagicMock()
+        provider._redis = mock_redis
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_valid_token(self, provider: NaasAuthProvider):
+        """Valid JWT returns AccessToken with correct claims."""
+        token = _make_token(sub="k-abc123", role="admin")
+        result = await provider.verify_token(token)
+
+        assert result is not None
+        assert result.client_id == "k-abc123"
+        assert result.token == token
+        assert result.claims["role"] == "admin"
+        assert result.claims["sub"] == "k-abc123"
+        assert "read" in result.scopes
+        assert "execute" in result.scopes
+        assert "admin" in result.scopes
+
+    @pytest.mark.asyncio
+    async def test_expired_token(self, provider: NaasAuthProvider):
+        """Expired JWT returns None."""
+        token = _make_token(exp=int(time.time()) - 3600)
+        result = await provider.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_signature(self, provider: NaasAuthProvider):
+        """Token signed with wrong secret returns None."""
+        token = jwt.encode({"sub": "k-bad", "role": "admin"}, "wrong-secret", algorithm="HS256")
+        result = await provider.verify_token(token)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_malformed_token(self, provider: NaasAuthProvider):
+        """Garbage token returns None."""
+        result = await provider.verify_token("not.a.valid.jwt.at.all")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_revoked_token(self, provider_with_redis: NaasAuthProvider):
+        """Revoked token (in Redis set) returns None."""
+        provider_with_redis._redis.sismember.return_value = True  # type: ignore[union-attr]
+        token = _make_token(sub="k-revoked")
+        result = await provider_with_redis.verify_token(token)
+        assert result is None
+        provider_with_redis._redis.sismember.assert_called_once_with("naas:revoked_keys", "k-revoked")  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio
+    async def test_non_revoked_token(self, provider_with_redis: NaasAuthProvider):
+        """Non-revoked token passes revocation check."""
+        provider_with_redis._redis.sismember.return_value = False  # type: ignore[union-attr]
+        token = _make_token(sub="k-valid")
+        result = await provider_with_redis.verify_token(token)
+        assert result is not None
+        assert result.client_id == "k-valid"
+
+    @pytest.mark.asyncio
+    async def test_role_to_scopes_viewer(self, provider: NaasAuthProvider):
+        """Viewer role maps to read scope only."""
+        token = _make_token(role="viewer")
+        result = await provider.verify_token(token)
+        assert result is not None
+        assert result.scopes == ["read"]
+
+    @pytest.mark.asyncio
+    async def test_role_to_scopes_operator(self, provider: NaasAuthProvider):
+        """Operator role maps to read + execute scopes."""
+        token = _make_token(role="operator")
+        result = await provider.verify_token(token)
+        assert result is not None
+        assert result.scopes == ["read", "execute"]
+
+    @pytest.mark.asyncio
+    async def test_no_redis_skips_revocation(self, provider: NaasAuthProvider):
+        """When redis_url is None, revocation check is skipped."""
+        token = _make_token(sub="k-any")
+        result = await provider.verify_token(token)
+        # Should succeed without any Redis interaction
+        assert result is not None
+
+
+class TestRBAC:
+    """Tests for require_naas_role auth check."""
+
+    def _make_auth_context(self, role: str, component_name: str):
+        """Create a mock AuthContext for testing."""
+        from fastmcp.server.auth import AccessToken
+        from fastmcp.server.middleware.authorization import AuthContext
+
+        token = AccessToken(
+            token="test",
+            client_id="k-test",
+            scopes=[],
+            claims={"role": role, "sub": "k-test"},
+        )
+        component = MagicMock()
+        component.name = component_name
+        return AuthContext(token=token, component=component)
+
+    def test_operator_can_send_command(self):
+        """Operator role can access send_command."""
+        ctx = self._make_auth_context("operator", "send_command")
+        assert require_naas_role(ctx) is True
+
+    def test_viewer_cannot_send_command(self):
+        """Viewer role is denied send_command (requires operator)."""
+        ctx = self._make_auth_context("viewer", "send_command")
+        assert require_naas_role(ctx) is False
+
+    def test_viewer_can_list_jobs(self):
+        """Viewer role can access list_jobs (read-only)."""
+        ctx = self._make_auth_context("viewer", "list_jobs")
+        assert require_naas_role(ctx) is True
+
+    def test_viewer_cannot_cancel_job(self):
+        """Viewer role is denied cancel_job (requires operator)."""
+        ctx = self._make_auth_context("viewer", "cancel_job")
+        assert require_naas_role(ctx) is False
+
+    def test_admin_can_do_everything(self):
+        """Admin role can access all tools."""
+        for component in ["send_command", "send_config", "cancel_job", "list_jobs", "get_job"]:
+            ctx = self._make_auth_context("admin", component)
+            assert require_naas_role(ctx) is True, f"Admin should access {component}"
+
+    def test_no_token_is_denied(self):
+        """Missing token (None) is denied."""
+        from fastmcp.server.middleware.authorization import AuthContext
+
+        component = MagicMock()
+        component.name = "send_command"
+        ctx = AuthContext(token=None, component=component)
+        assert require_naas_role(ctx) is False
+
+    def test_unknown_component_defaults_to_viewer(self):
+        """Components not in COMPONENT_ROLES default to viewer-accessible."""
+        ctx = self._make_auth_context("viewer", "some_unknown_tool")
+        assert require_naas_role(ctx) is True

--- a/packages/naas-mcp/tests/test_server.py
+++ b/packages/naas-mcp/tests/test_server.py
@@ -22,6 +22,9 @@ def test_default_config():
     assert cfg["timeout"] == 30.0
     assert cfg["job_poll_interval"] == 2.0
     assert cfg["job_timeout"] == 300.0
+    assert cfg["transport"] == "stdio"
+    assert cfg["jwt_secret"] == ""
+    assert cfg["redis_url"] == ""
 
 
 def test_config_from_env():
@@ -83,6 +86,9 @@ async def test_app_lifespan_creates_and_closes_client():
                 "timeout": 10.0,
                 "job_poll_interval": 1.0,
                 "job_timeout": 60.0,
+                "transport": "stdio",
+                "jwt_secret": "",
+                "redis_url": "",
             },
         ),
     ):
@@ -98,13 +104,20 @@ async def test_app_lifespan_creates_and_closes_client():
             assert ctx["client"] is mock_instance
             assert ctx["job_poll_interval"] == 1.0
             assert ctx["job_timeout"] == 60.0
+            assert ctx["transport"] == "stdio"
 
         mock_instance.close.assert_called_once()
 
 
 def test_main_imports_and_calls_run():
-    """Test that main() calls mcp.run()."""
-    with patch("naas_mcp.server.mcp") as mock_mcp:
+    """Test that main() calls mcp.run() in stdio mode."""
+    import sys
+
+    with (
+        patch("naas_mcp.server.mcp") as mock_mcp,
+        patch.object(sys, "argv", ["naas-mcp"]),
+        patch.dict(os.environ, {"NAAS_MCP_TRANSPORT": "stdio"}, clear=False),
+    ):
         from naas_mcp import main
 
         main()

--- a/packages/naas-mcp/tests/test_server.py
+++ b/packages/naas-mcp/tests/test_server.py
@@ -122,3 +122,150 @@ def test_main_imports_and_calls_run():
 
         main()
         mock_mcp.run.assert_called_once()
+
+
+def test_get_auth_provider_stdio_returns_none():
+    """In stdio mode, _get_auth_provider returns None."""
+    with patch.dict(os.environ, {"NAAS_MCP_TRANSPORT": "stdio"}, clear=False):
+        from naas_mcp.server import _get_auth_provider
+
+        assert _get_auth_provider() is None
+
+
+def test_get_auth_provider_http_requires_jwt_secret():
+    """In HTTP mode without NAAS_JWT_SECRET, _get_auth_provider raises RuntimeError."""
+    import pytest
+
+    with patch.dict(
+        os.environ,
+        {"NAAS_MCP_TRANSPORT": "streamable-http", "NAAS_JWT_SECRET": "", "NAAS_MCP_REDIS_URL": ""},
+        clear=False,
+    ):
+        from naas_mcp.server import _get_auth_provider
+
+        with pytest.raises(RuntimeError, match="NAAS_JWT_SECRET is required"):
+            _get_auth_provider()
+
+
+def test_get_auth_provider_http_returns_provider():
+    """In HTTP mode with NAAS_JWT_SECRET, _get_auth_provider returns NaasAuthProvider."""
+    with patch.dict(
+        os.environ,
+        {
+            "NAAS_MCP_TRANSPORT": "streamable-http",
+            "NAAS_JWT_SECRET": "test-secret-32-chars-long-enough!",
+            "NAAS_MCP_REDIS_URL": "",
+        },
+        clear=False,
+    ):
+        from naas_mcp.auth import NaasAuthProvider
+        from naas_mcp.server import _get_auth_provider
+
+        provider = _get_auth_provider()
+        assert isinstance(provider, NaasAuthProvider)
+
+
+def test_get_middleware_stdio_returns_none():
+    """In stdio mode, _get_middleware returns None."""
+    with patch.dict(os.environ, {"NAAS_MCP_TRANSPORT": "stdio"}, clear=False):
+        from naas_mcp.server import _get_middleware
+
+        assert _get_middleware() is None
+
+
+def test_get_middleware_http_returns_auth_middleware():
+    """In HTTP mode, _get_middleware returns AuthMiddleware."""
+    with patch.dict(os.environ, {"NAAS_MCP_TRANSPORT": "streamable-http"}, clear=False):
+        from fastmcp.server.middleware.authorization import AuthMiddleware
+
+        from naas_mcp.server import _get_middleware
+
+        middleware = _get_middleware()
+        assert isinstance(middleware, AuthMiddleware)
+
+
+def test_main_http_mode():
+    """Test that main() calls mcp.run with streamable-http transport."""
+    import sys
+
+    with (
+        patch("naas_mcp.server.mcp") as mock_mcp,
+        patch.object(sys, "argv", ["naas-mcp", "--transport", "streamable-http", "--port", "9090"]),
+        patch.dict(os.environ, {"NAAS_JWT_SECRET": "test-secret-32-chars-long-enough!"}, clear=False),
+    ):
+        from naas_mcp import main
+
+        main()
+        mock_mcp.run.assert_called_once_with(transport="streamable-http", port=9090)
+
+
+def test_client_http_mode_uses_access_token():
+    """In HTTP mode, _client creates a per-request client with the caller's token."""
+    from unittest.mock import MagicMock, patch
+
+    from fastmcp.server.auth import AccessToken
+
+    mock_ctx = MagicMock()
+    mock_ctx.lifespan_context = {
+        "transport": "streamable-http",
+        "api_url": "http://naas-api:8080",
+        "timeout": 30.0,
+        "client": MagicMock(),
+    }
+
+    mock_token = AccessToken(
+        token="eyJ-test-token",
+        client_id="k-test",
+        scopes=["read", "execute"],
+        claims={"role": "operator", "sub": "k-test"},
+    )
+
+    with (
+        patch("naas_mcp.tools.get_access_token", return_value=mock_token),
+        patch("naas_mcp.tools.AsyncNaasClient") as mock_client_cls,
+    ):
+        from naas_mcp.tools import _client
+
+        _client(mock_ctx)
+        mock_client_cls.assert_called_once_with(
+            base_url="http://naas-api:8080",
+            api_key="eyJ-test-token",
+            timeout=30.0,
+        )
+
+
+def test_client_stdio_mode_uses_lifespan_client():
+    """In stdio mode, _client returns the shared lifespan client."""
+    from unittest.mock import MagicMock
+
+    mock_shared_client = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.lifespan_context = {
+        "transport": "stdio",
+        "client": mock_shared_client,
+    }
+
+    from naas_mcp.tools import _client
+
+    result = _client(mock_ctx)
+    assert result is mock_shared_client
+
+
+def test_client_http_mode_fallback_no_token():
+    """In HTTP mode with no access token, _client falls back to shared client."""
+    from unittest.mock import MagicMock, patch
+
+    mock_shared_client = MagicMock()
+    mock_ctx = MagicMock()
+    mock_ctx.lifespan_context = {
+        "transport": "streamable-http",
+        "api_url": "http://naas-api:8080",
+        "timeout": 30.0,
+        "client": mock_shared_client,
+    }
+
+    with patch("naas_mcp.tools.get_access_token", return_value=None):
+        from naas_mcp.tools import _client
+
+        result = _client(mock_ctx)
+        assert result is mock_shared_client

--- a/packages/naas/changes/436.feature.md
+++ b/packages/naas/changes/436.feature.md
@@ -1,0 +1,1 @@
+Add streamable-http transport to the MCP server for remote/shared deployments. MCP clients authenticate using existing NAAS JWT API keys (Bearer tokens), with RBAC enforcement at the MCP layer. Same API keys work for both direct API and MCP access.

--- a/uv.lock
+++ b/uv.lock
@@ -1907,6 +1907,8 @@ source = { editable = "packages/naas-mcp" }
 dependencies = [
     { name = "fastmcp" },
     { name = "naas-client" },
+    { name = "pyjwt" },
+    { name = "redis" },
 ]
 
 [package.optional-dependencies]
@@ -1923,9 +1925,11 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15" },
     { name = "naas-client", editable = "packages/naas-client" },
+    { name = "pyjwt", specifier = ">=2.8.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "redis", specifier = ">=5.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

Closes #436

Adds streamable-http transport support to the MCP server, integrated with the existing NAAS JWT API key auth framework. Same API keys work for both direct API calls and MCP access.

## What's implemented

### Transport selection
```bash
# stdio (default, unchanged)
naas-mcp

# streamable-http
naas-mcp --transport streamable-http --port 8081
```

### Authentication
- `NaasAuthProvider` validates NAAS JWT API keys locally (shared `NAAS_JWT_SECRET`)
- Revocation checking against Redis `naas:revoked_keys` set
- Stdio mode has no auth (parent process is trusted) — zero change for existing users

### RBAC at MCP layer
| Tool | Minimum Role |
|------|-------------|
| send_command, send_config, cancel_job | operator |
| get_job, list_jobs | viewer |

### Per-request credential forwarding
- HTTP mode: each request creates a naas-client with the caller's Bearer token
- Downstream NAAS API validates the same JWT again (defense in depth)
- Each user's actions attributed to their own API key

## Testing

- ✅ 16 unit tests for auth provider and RBAC (all passing)
- ✅ 4 server config/entry-point tests (passing)
- ⬜ Integration test (TODO)
- ⬜ Docker/compose configuration (TODO)
- ⬜ Documentation (TODO)

## Files changed

| File | Description |
|------|-------------|
| `naas_mcp/__init__.py` | CLI argparse for `--transport` and `--port` |
| `naas_mcp/auth.py` | **NEW** — NaasAuthProvider (JWT + revocation) |
| `naas_mcp/rbac.py` | **NEW** — RBAC auth check (tool → role mapping) |
| `naas_mcp/server.py` | Wire auth provider + middleware for HTTP mode |
| `naas_mcp/tools.py` | Per-request token forwarding via `get_access_token()` |
| `pyproject.toml` | Added pyjwt, redis deps |
| `tests/test_auth.py` | **NEW** — 16 auth/RBAC unit tests |
| `tests/test_server.py` | Updated for argparse change |

## Relates to

- Issue #436 (updated with refined design)
- ADR 0003 (JWT API key design)